### PR TITLE
Nonlocal Potential BC with Schottky test fix

### DIFF
--- a/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -47,7 +47,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 
         trans_ss_check = 1
         ss_check_tol = 1E-15
-        ss_tmin = 3e-9 # or 3*${relaxTime}
+        ss_tmin = ${fparse 3 * relaxTime}
 
         petsc_options = '-snes_converged_reason -snes_linesearch_monitor'
         solve_type = NEWTON

--- a/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -47,7 +47,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 
         trans_ss_check = 1
         ss_check_tol = 1E-15
-        ss_tmin = 3*${relaxTime}
+        ss_tmin = 3e-9 # or 3*${relaxTime}
 
         petsc_options = '-snes_converged_reason -snes_linesearch_monitor'
         solve_type = NEWTON

--- a/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -680,7 +680,7 @@ area = 5.02e-7 # Formerly 3.14e-6
         [./potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
-                vals = '${vhigh}')
+                vals = '${vhigh}'
                 value = 'VHigh'
         [../]
         [./potential_ic_func]


### PR DESCRIPTION
In fixing up #16, I ran a check of the heavy tests, and discovered 1d_dc.non_local_potential_bc was broken. The problem seemed to be due to stricter input file check standards (a GetPot Expression for multiplication couldn't get past a type check for a parameter, and a parenthesis was left in as a typo). 

On fixing these the test still failed due to a "Sideset Distribution Factor" error (see below for a snippet from the exodiff output). However, the paraview output lines up very well with the original gold file, so I'm unsure what the problem still is. I figured I could open a PR for the obvious changes that needed to be made, and then we can decide if this is worth a re-gold of the old test or if something else is wrong. 

`Sideset Distribution Factors:
1d_dc.non_local_potential_bc:   --------- Time step 1, 1.0000000e-05 ~ 1.3525119e-08, rel diff:  9.98647e-01 (FAILED)`