### PR TITLE
Performance log deprecated parameter fix

### DIFF
--- a/problems/2d.i
+++ b/problems/2d.i
@@ -57,7 +57,7 @@ dom0Scale=1e-3
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/2d_jac_test.i
+++ b/problems/2d_jac_test.i
@@ -55,7 +55,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/2d_temp.i
+++ b/problems/2d_temp.i
@@ -48,7 +48,7 @@ dom0Scale=1e-3
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/Secondary_no_reflection.i
+++ b/problems/Secondary_no_reflection.i
@@ -75,7 +75,7 @@ vhigh = 103E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/problems/TM.i
+++ b/problems/TM.i
@@ -38,7 +38,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/TM_steady.i
+++ b/problems/TM_steady.i
@@ -34,7 +34,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/TM_steady_dieletric.i
+++ b/problems/TM_steady_dieletric.i
@@ -44,7 +44,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
   [./out]
     type = Exodus

--- a/problems/current_carrying_wire.i
+++ b/problems/current_carrying_wire.i
@@ -41,7 +41,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/mean_en.i
+++ b/problems/mean_en.i
@@ -90,7 +90,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/mean_en_multi.i
+++ b/problems/mean_en_multi.i
@@ -71,7 +71,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/problems/mean_en_post_PJFNK.i
+++ b/problems/mean_en_post_PJFNK.i
@@ -91,7 +91,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
   [./out]
     type = Exodus

--- a/problems/mean_en_postprocessor.i
+++ b/problems/mean_en_postprocessor.i
@@ -91,7 +91,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
   [./out]
     type = Exodus

--- a/problems/no_diffusion.i
+++ b/problems/no_diffusion.i
@@ -75,7 +75,7 @@ vhigh = 103E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/problems/rz_x_rotation_axis.i
+++ b/problems/rz_x_rotation_axis.i
@@ -27,7 +27,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/problems/shape_side_uo_physics_test.i
+++ b/problems/shape_side_uo_physics_test.i
@@ -136,7 +136,7 @@ u_left = 0.5
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
     execute_on = 'timestep_end'

--- a/problems/thesis_example.i
+++ b/problems/thesis_example.i
@@ -31,7 +31,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/problems/water_only.i
+++ b/problems/water_only.i
@@ -46,7 +46,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -70,7 +70,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/1d_dc/densities_mean_en.i
+++ b/tests/1d_dc/densities_mean_en.i
@@ -87,7 +87,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/tests/1d_dc/mean_en.i
+++ b/tests/1d_dc/mean_en.i
@@ -94,7 +94,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/tests/1d_dc/mean_en_multi.i
+++ b/tests/1d_dc/mean_en_multi.i
@@ -72,7 +72,7 @@ dom1Scale=1e-7
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   # print_linear_residuals = false
   [./out]
     type = Exodus

--- a/tests/Schottky_emission/Example1/Input.i
+++ b/tests/Schottky_emission/Example1/Input.i
@@ -83,7 +83,7 @@ vhigh = 200E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/Schottky_emission/Example2/Input.i
+++ b/tests/Schottky_emission/Example2/Input.i
@@ -83,7 +83,7 @@ vhigh = 80E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/Schottky_emission/Example3/Input.i
+++ b/tests/Schottky_emission/Example3/Input.i
@@ -83,7 +83,7 @@ relaxTime = 50E-6 #s
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/Schottky_emission/Example4/Input.i
+++ b/tests/Schottky_emission/Example4/Input.i
@@ -70,7 +70,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/Schottky_emission/Example4/Jac.i
+++ b/tests/Schottky_emission/Example4/Jac.i
@@ -63,7 +63,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/Schottky_emission/PaschenLaw/Input.i
+++ b/tests/Schottky_emission/PaschenLaw/Input.i
@@ -82,7 +82,7 @@ vhigh = 0.10 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/TM10_circular_wg/TM_steady.i
+++ b/tests/TM10_circular_wg/TM_steady.i
@@ -35,7 +35,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/tests/TM10_circular_wg/TM_steady_dieletric.i
+++ b/tests/TM10_circular_wg/TM_steady_dieletric.i
@@ -45,7 +45,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
   [./out]
     type = Exodus

--- a/tests/current_carrying_wire/current_carrying_wire.i
+++ b/tests/current_carrying_wire/current_carrying_wire.i
@@ -42,7 +42,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./out]
     type = Exodus

--- a/tests/field_emission/field_emission.i
+++ b/tests/field_emission/field_emission.i
@@ -73,7 +73,7 @@ vhigh=0.15 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/Schottky/Input.i
+++ b/tests/reflections/Schottky/Input.i
@@ -79,7 +79,7 @@ vhigh = 150E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/Schottky_300_V_5_um/Input.i
+++ b/tests/reflections/Schottky_300_V_5_um/Input.i
@@ -82,7 +82,7 @@ vhigh = 400E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/Schottky_400_V_10_um/Input.i
+++ b/tests/reflections/Schottky_400_V_10_um/Input.i
@@ -79,7 +79,7 @@ vhigh = 175E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/base/Input.i
+++ b/tests/reflections/base/Input.i
@@ -76,7 +76,7 @@ vhigh = 175E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/high_initial/Input.i
+++ b/tests/reflections/high_initial/Input.i
@@ -79,7 +79,7 @@ vhigh = 175E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus

--- a/tests/reflections/low_initial/Input.i
+++ b/tests/reflections/low_initial/Input.i
@@ -79,7 +79,7 @@ vhigh = 175E-3 #kV
 []
 
 [Outputs]
-        print_perf_log = true
+        perf_graph = true
         print_linear_residuals = false
         [./out]
                 type = Exodus


### PR DESCRIPTION
refs #22 

Changed print_perf_log to perf_graph in all input files located in `test` and `problems`.