### PR TITLE
Add MooseDocs

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,0 +1,20 @@
+Content:
+    Zapdos:
+        root_dir: ${ROOT_DIR}/doc/content
+    moose:
+        root_dir: ${MOOSE_DIR}/framework/doc/content
+        content:
+            - js/*
+            - css/*
+            - contrib/**
+            - media/**
+
+Renderer:
+    type: MooseDocs.base.MaterializeRenderer
+    name: Zapdos
+
+Extensions:
+    MooseDocs.extensions.appsyntax:
+        executable: ${ROOT_DIR}
+        includes:
+            - include

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -8,12 +8,15 @@ Content:
             - css/*
             - contrib/**
             - media/**
+            - templates/stubs/*
 
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
     name: Zapdos
 
 Extensions:
+    MooseDocs.extensions.template:
+        active: True
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
         includes:

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -1,0 +1,3 @@
+!config navigation breadcrumbs=False scrollspy=False
+
+# ZapdosApp

--- a/doc/content/source/actions/AddLotsOfCoeffDiffusion.md
+++ b/doc/content/source/actions/AddLotsOfCoeffDiffusion.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfCoeffDiffusion syntax=/LotsOfCoeffDiffusion/AddLotsOfCoeffDiffusion

--- a/doc/content/source/actions/AddLotsOfEFieldAdvection.md
+++ b/doc/content/source/actions/AddLotsOfEFieldAdvection.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfEFieldAdvection syntax=/LotsOfEFieldAdvection/AddLotsOfEFieldAdvection

--- a/doc/content/source/actions/AddLotsOfPotentialDrivenArtificialDiff.md
+++ b/doc/content/source/actions/AddLotsOfPotentialDrivenArtificialDiff.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfPotentialDrivenArtificialDiff syntax=/LotsOfPotentialDrivenArtificialDiff/AddLotsOfPotentialDrivenArtificialDiff

--- a/doc/content/source/actions/AddLotsOfSources.md
+++ b/doc/content/source/actions/AddLotsOfSources.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfSources syntax=/LotsOfSources/AddLotsOfSources

--- a/doc/content/source/actions/AddLotsOfTimeDerivatives.md
+++ b/doc/content/source/actions/AddLotsOfTimeDerivatives.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfTimeDerivatives syntax=/LotsOfTimeDerivatives/AddLotsOfTimeDerivatives

--- a/doc/content/source/actions/AddLotsOfVariables.md
+++ b/doc/content/source/actions/AddLotsOfVariables.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_action.md.template name=AddLotsOfVariables syntax=/LotsOfVariables/AddLotsOfVariables

--- a/doc/content/source/auxkernels/AbsValueAux.md
+++ b/doc/content/source/auxkernels/AbsValueAux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=AbsValueAux syntax=/AuxKernels/AbsValueAux

--- a/doc/content/source/auxkernels/Current.md
+++ b/doc/content/source/auxkernels/Current.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Current syntax=/AuxKernels/Current

--- a/doc/content/source/auxkernels/DensityMoles.md
+++ b/doc/content/source/auxkernels/DensityMoles.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DensityMoles syntax=/AuxKernels/DensityMoles

--- a/doc/content/source/auxkernels/DiffusiveFlux.md
+++ b/doc/content/source/auxkernels/DiffusiveFlux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DiffusiveFlux syntax=/AuxKernels/DiffusiveFlux

--- a/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
+++ b/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionFluxAux syntax=/AuxKernels/DriftDiffusionFluxAux

--- a/doc/content/source/auxkernels/EFieldAdvAux.md
+++ b/doc/content/source/auxkernels/EFieldAdvAux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldAdvAux syntax=/AuxKernels/EFieldAdvAux

--- a/doc/content/source/auxkernels/Efield.md
+++ b/doc/content/source/auxkernels/Efield.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Efield syntax=/AuxKernels/Efield

--- a/doc/content/source/auxkernels/ElectronTemperature.md
+++ b/doc/content/source/auxkernels/ElectronTemperature.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronTemperature syntax=/AuxKernels/ElectronTemperature

--- a/doc/content/source/auxkernels/Position.md
+++ b/doc/content/source/auxkernels/Position.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Position syntax=/AuxKernels/Position

--- a/doc/content/source/auxkernels/PowerDep.md
+++ b/doc/content/source/auxkernels/PowerDep.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=PowerDep syntax=/AuxKernels/PowerDep

--- a/doc/content/source/auxkernels/ProcRate.md
+++ b/doc/content/source/auxkernels/ProcRate.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProcRate syntax=/AuxKernels/ProcRate

--- a/doc/content/source/auxkernels/ProcRateForRateCoeff.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeff.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProcRateForRateCoeff syntax=/AuxKernels/ProcRateForRateCoeff

--- a/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProcRateForRateCoeffThreeBody syntax=/AuxKernels/ProcRateForRateCoeffThreeBody

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Sigma syntax=/AuxKernels/Sigma

--- a/doc/content/source/auxkernels/TM0CylindricalErAux.md
+++ b/doc/content/source/auxkernels/TM0CylindricalErAux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0CylindricalErAux syntax=/AuxKernels/TM0CylindricalErAux

--- a/doc/content/source/auxkernels/TM0CylindricalEzAux.md
+++ b/doc/content/source/auxkernels/TM0CylindricalEzAux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0CylindricalEzAux syntax=/AuxKernels/TM0CylindricalEzAux

--- a/doc/content/source/auxkernels/TotalFlux.md
+++ b/doc/content/source/auxkernels/TotalFlux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TotalFlux syntax=/AuxKernels/TotalFlux

--- a/doc/content/source/auxkernels/UserFlux.md
+++ b/doc/content/source/auxkernels/UserFlux.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=UserFlux syntax=/AuxKernels/UserFlux

--- a/doc/content/source/bcs/CircuitDirichletPotential.md
+++ b/doc/content/source/bcs/CircuitDirichletPotential.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CircuitDirichletPotential syntax=/BCs/CircuitDirichletPotential

--- a/doc/content/source/bcs/DCIonBC.md
+++ b/doc/content/source/bcs/DCIonBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DCIonBC syntax=/BCs/DCIonBC

--- a/doc/content/source/bcs/DriftDiffusionDoNothingBC.md
+++ b/doc/content/source/bcs/DriftDiffusionDoNothingBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionDoNothingBC syntax=/BCs/DriftDiffusionDoNothingBC

--- a/doc/content/source/bcs/DriftDiffusionUserDoNothingBC.md
+++ b/doc/content/source/bcs/DriftDiffusionUserDoNothingBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionUserDoNothingBC syntax=/BCs/DriftDiffusionUserDoNothingBC

--- a/doc/content/source/bcs/ElectronAdvectionDoNothingBC.md
+++ b/doc/content/source/bcs/ElectronAdvectionDoNothingBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronAdvectionDoNothingBC syntax=/BCs/ElectronAdvectionDoNothingBC

--- a/doc/content/source/bcs/ElectronDiffusionDoNothingBC.md
+++ b/doc/content/source/bcs/ElectronDiffusionDoNothingBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronDiffusionDoNothingBC syntax=/BCs/ElectronDiffusionDoNothingBC

--- a/doc/content/source/bcs/ElectronTemperatureDirichletBC.md
+++ b/doc/content/source/bcs/ElectronTemperatureDirichletBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronTemperatureDirichletBC syntax=/BCs/ElectronTemperatureDirichletBC

--- a/doc/content/source/bcs/FieldEmissionBC.md
+++ b/doc/content/source/bcs/FieldEmissionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=FieldEmissionBC syntax=/BCs/FieldEmissionBC

--- a/doc/content/source/bcs/HagelaarElectronAdvectionBC.md
+++ b/doc/content/source/bcs/HagelaarElectronAdvectionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarElectronAdvectionBC syntax=/BCs/HagelaarElectronAdvectionBC

--- a/doc/content/source/bcs/HagelaarElectronBC.md
+++ b/doc/content/source/bcs/HagelaarElectronBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarElectronBC syntax=/BCs/HagelaarElectronBC

--- a/doc/content/source/bcs/HagelaarEnergyAdvectionBC.md
+++ b/doc/content/source/bcs/HagelaarEnergyAdvectionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarEnergyAdvectionBC syntax=/BCs/HagelaarEnergyAdvectionBC

--- a/doc/content/source/bcs/HagelaarEnergyBC.md
+++ b/doc/content/source/bcs/HagelaarEnergyBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarEnergyBC syntax=/BCs/HagelaarEnergyBC

--- a/doc/content/source/bcs/HagelaarIonAdvectionBC.md
+++ b/doc/content/source/bcs/HagelaarIonAdvectionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarIonAdvectionBC syntax=/BCs/HagelaarIonAdvectionBC

--- a/doc/content/source/bcs/HagelaarIonDiffusionBC.md
+++ b/doc/content/source/bcs/HagelaarIonDiffusionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HagelaarIonDiffusionBC syntax=/BCs/HagelaarIonDiffusionBC

--- a/doc/content/source/bcs/LogDensityDirichletBC.md
+++ b/doc/content/source/bcs/LogDensityDirichletBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=LogDensityDirichletBC syntax=/BCs/LogDensityDirichletBC

--- a/doc/content/source/bcs/LymberopoulosElectronBC.md
+++ b/doc/content/source/bcs/LymberopoulosElectronBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=LymberopoulosElectronBC syntax=/BCs/LymberopoulosElectronBC

--- a/doc/content/source/bcs/LymberopoulosIonBC.md
+++ b/doc/content/source/bcs/LymberopoulosIonBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=LymberopoulosIonBC syntax=/BCs/LymberopoulosIonBC

--- a/doc/content/source/bcs/NeumannCircuitVoltageMoles_KV.md
+++ b/doc/content/source/bcs/NeumannCircuitVoltageMoles_KV.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=NeumannCircuitVoltageMoles_KV syntax=/BCs/NeumannCircuitVoltageMoles_KV

--- a/doc/content/source/bcs/PenaltyCircuitPotential.md
+++ b/doc/content/source/bcs/PenaltyCircuitPotential.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=PenaltyCircuitPotential syntax=/BCs/PenaltyCircuitPotential

--- a/doc/content/source/bcs/PotentialDriftOutflowBC.md
+++ b/doc/content/source/bcs/PotentialDriftOutflowBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=PotentialDriftOutflowBC syntax=/BCs/PotentialDriftOutflowBC

--- a/doc/content/source/bcs/SchottkyEmissionBC.md
+++ b/doc/content/source/bcs/SchottkyEmissionBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=SchottkyEmissionBC syntax=/BCs/SchottkyEmissionBC

--- a/doc/content/source/bcs/SecondaryElectronBC.md
+++ b/doc/content/source/bcs/SecondaryElectronBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=SecondaryElectronBC syntax=/BCs/SecondaryElectronBC

--- a/doc/content/source/bcs/TM0AntennaVertBC.md
+++ b/doc/content/source/bcs/TM0AntennaVertBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0AntennaVertBC syntax=/BCs/TM0AntennaVertBC

--- a/doc/content/source/bcs/TM0PECVertBC.md
+++ b/doc/content/source/bcs/TM0PECVertBC.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0PECVertBC syntax=/BCs/TM0PECVertBC

--- a/doc/content/source/constraints/ArbitrarilyTiedValueConstraint.md
+++ b/doc/content/source/constraints/ArbitrarilyTiedValueConstraint.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ArbitrarilyTiedValueConstraint syntax=/Constraints/ArbitrarilyTiedValueConstraint

--- a/doc/content/source/dgkernels/DGCoeffDiffusion.md
+++ b/doc/content/source/dgkernels/DGCoeffDiffusion.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DGCoeffDiffusion syntax=/DGKernels/DGCoeffDiffusion

--- a/doc/content/source/dgkernels/DGEFieldAdvection.md
+++ b/doc/content/source/dgkernels/DGEFieldAdvection.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DGEFieldAdvection syntax=/DGKernels/DGEFieldAdvection

--- a/doc/content/source/indicators/AnalyticalDiffIndicator.md
+++ b/doc/content/source/indicators/AnalyticalDiffIndicator.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=AnalyticalDiffIndicator syntax=/Adaptivity/Indicators/AnalyticalDiffIndicator

--- a/doc/content/source/interfacekernels/HphiRadialInterface.md
+++ b/doc/content/source/interfacekernels/HphiRadialInterface.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HphiRadialInterface syntax=/InterfaceKernels/HphiRadialInterface

--- a/doc/content/source/interfacekernels/InterfaceAdvection.md
+++ b/doc/content/source/interfacekernels/InterfaceAdvection.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=InterfaceAdvection syntax=/InterfaceKernels/InterfaceAdvection

--- a/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
+++ b/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=InterfaceLogDiffusionElectrons syntax=/InterfaceKernels/InterfaceLogDiffusionElectrons

--- a/doc/content/source/kernels/AxisymmetricCurlZ.md
+++ b/doc/content/source/kernels/AxisymmetricCurlZ.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=AxisymmetricCurlZ syntax=/Kernels/AxisymmetricCurlZ

--- a/doc/content/source/kernels/ChargeSourceMoles_KV.md
+++ b/doc/content/source/kernels/ChargeSourceMoles_KV.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ChargeSourceMoles_KV syntax=/Kernels/ChargeSourceMoles_KV

--- a/doc/content/source/kernels/CoeffDiffusion.md
+++ b/doc/content/source/kernels/CoeffDiffusion.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CoeffDiffusion syntax=/Kernels/CoeffDiffusion

--- a/doc/content/source/kernels/CoeffDiffusionElectrons.md
+++ b/doc/content/source/kernels/CoeffDiffusionElectrons.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CoeffDiffusionElectrons syntax=/Kernels/CoeffDiffusionElectrons

--- a/doc/content/source/kernels/CoeffDiffusionEnergy.md
+++ b/doc/content/source/kernels/CoeffDiffusionEnergy.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CoeffDiffusionEnergy syntax=/Kernels/CoeffDiffusionEnergy

--- a/doc/content/source/kernels/CoeffDiffusionLin.md
+++ b/doc/content/source/kernels/CoeffDiffusionLin.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CoeffDiffusionLin syntax=/Kernels/CoeffDiffusionLin

--- a/doc/content/source/kernels/DriftDiffusion.md
+++ b/doc/content/source/kernels/DriftDiffusion.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusion syntax=/Kernels/DriftDiffusion

--- a/doc/content/source/kernels/DriftDiffusionElectrons.md
+++ b/doc/content/source/kernels/DriftDiffusionElectrons.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionElectrons syntax=/Kernels/DriftDiffusionElectrons

--- a/doc/content/source/kernels/DriftDiffusionEnergy.md
+++ b/doc/content/source/kernels/DriftDiffusionEnergy.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionEnergy syntax=/Kernels/DriftDiffusionEnergy

--- a/doc/content/source/kernels/DriftDiffusionUser.md
+++ b/doc/content/source/kernels/DriftDiffusionUser.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=DriftDiffusionUser syntax=/Kernels/DriftDiffusionUser

--- a/doc/content/source/kernels/EFieldAdvection.md
+++ b/doc/content/source/kernels/EFieldAdvection.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldAdvection syntax=/Kernels/EFieldAdvection

--- a/doc/content/source/kernels/EFieldAdvectionElectrons.md
+++ b/doc/content/source/kernels/EFieldAdvectionElectrons.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldAdvectionElectrons syntax=/Kernels/EFieldAdvectionElectrons

--- a/doc/content/source/kernels/EFieldAdvectionEnergy.md
+++ b/doc/content/source/kernels/EFieldAdvectionEnergy.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldAdvectionEnergy syntax=/Kernels/EFieldAdvectionEnergy

--- a/doc/content/source/kernels/EFieldArtDiff.md
+++ b/doc/content/source/kernels/EFieldArtDiff.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldArtDiff syntax=/Kernels/EFieldArtDiff

--- a/doc/content/source/kernels/EFieldMagnitudeSource.md
+++ b/doc/content/source/kernels/EFieldMagnitudeSource.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=EFieldMagnitudeSource syntax=/Kernels/EFieldMagnitudeSource

--- a/doc/content/source/kernels/ElectronEnergyLossFromElastic.md
+++ b/doc/content/source/kernels/ElectronEnergyLossFromElastic.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronEnergyLossFromElastic syntax=/Kernels/ElectronEnergyLossFromElastic

--- a/doc/content/source/kernels/ElectronEnergyLossFromExcitation.md
+++ b/doc/content/source/kernels/ElectronEnergyLossFromExcitation.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronEnergyLossFromExcitation syntax=/Kernels/ElectronEnergyLossFromExcitation

--- a/doc/content/source/kernels/ElectronEnergyLossFromIonization.md
+++ b/doc/content/source/kernels/ElectronEnergyLossFromIonization.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronEnergyLossFromIonization syntax=/Kernels/ElectronEnergyLossFromIonization

--- a/doc/content/source/kernels/ElectronEnergyTermElasticRate.md
+++ b/doc/content/source/kernels/ElectronEnergyTermElasticRate.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronEnergyTermElasticRate syntax=/Kernels/ElectronEnergyTermElasticRate

--- a/doc/content/source/kernels/ElectronEnergyTermRate.md
+++ b/doc/content/source/kernels/ElectronEnergyTermRate.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronEnergyTermRate syntax=/Kernels/ElectronEnergyTermRate

--- a/doc/content/source/kernels/ElectronTimeDerivative.md
+++ b/doc/content/source/kernels/ElectronTimeDerivative.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronTimeDerivative syntax=/Kernels/ElectronTimeDerivative

--- a/doc/content/source/kernels/ElectronsFromIonization.md
+++ b/doc/content/source/kernels/ElectronsFromIonization.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronsFromIonization syntax=/Kernels/ElectronsFromIonization

--- a/doc/content/source/kernels/ElectronsFromIonizationUser.md
+++ b/doc/content/source/kernels/ElectronsFromIonizationUser.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ElectronsFromIonizationUser syntax=/Kernels/ElectronsFromIonizationUser

--- a/doc/content/source/kernels/ExcitationReaction.md
+++ b/doc/content/source/kernels/ExcitationReaction.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ExcitationReaction syntax=/Kernels/ExcitationReaction

--- a/doc/content/source/kernels/IonsFromIonization.md
+++ b/doc/content/source/kernels/IonsFromIonization.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=IonsFromIonization syntax=/Kernels/IonsFromIonization

--- a/doc/content/source/kernels/JouleHeating.md
+++ b/doc/content/source/kernels/JouleHeating.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=JouleHeating syntax=/Kernels/JouleHeating

--- a/doc/content/source/kernels/LogStabilizationMoles.md
+++ b/doc/content/source/kernels/LogStabilizationMoles.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=LogStabilizationMoles syntax=/Kernels/LogStabilizationMoles

--- a/doc/content/source/kernels/PotentialGradientSource.md
+++ b/doc/content/source/kernels/PotentialGradientSource.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=PotentialGradientSource syntax=/Kernels/PotentialGradientSource

--- a/doc/content/source/kernels/ProductAABBRxn.md
+++ b/doc/content/source/kernels/ProductAABBRxn.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProductAABBRxn syntax=/Kernels/ProductAABBRxn

--- a/doc/content/source/kernels/ProductFirstOrderRxn.md
+++ b/doc/content/source/kernels/ProductFirstOrderRxn.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProductFirstOrderRxn syntax=/Kernels/ProductFirstOrderRxn

--- a/doc/content/source/kernels/ReactantAARxn.md
+++ b/doc/content/source/kernels/ReactantAARxn.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ReactantAARxn syntax=/Kernels/ReactantAARxn

--- a/doc/content/source/kernels/ReactantFirstOrderRxn.md
+++ b/doc/content/source/kernels/ReactantFirstOrderRxn.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ReactantFirstOrderRxn syntax=/Kernels/ReactantFirstOrderRxn

--- a/doc/content/source/kernels/TM0Cylindrical.md
+++ b/doc/content/source/kernels/TM0Cylindrical.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0Cylindrical syntax=/Kernels/TM0Cylindrical

--- a/doc/content/source/kernels/TM0CylindricalEr.md
+++ b/doc/content/source/kernels/TM0CylindricalEr.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0CylindricalEr syntax=/Kernels/TM0CylindricalEr

--- a/doc/content/source/kernels/TM0CylindricalEz.md
+++ b/doc/content/source/kernels/TM0CylindricalEz.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=TM0CylindricalEz syntax=/Kernels/TM0CylindricalEz

--- a/doc/content/source/kernels/UserSource.md
+++ b/doc/content/source/kernels/UserSource.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=UserSource syntax=/Kernels/UserSource

--- a/doc/content/source/materials/Gas.md
+++ b/doc/content/source/materials/Gas.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Gas syntax=/Materials/Gas

--- a/doc/content/source/materials/GasBase.md
+++ b/doc/content/source/materials/GasBase.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=GasBase syntax=/Materials/GasBase

--- a/doc/content/source/materials/GasElectronMoments.md
+++ b/doc/content/source/materials/GasElectronMoments.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=GasElectronMoments syntax=/Materials/GasElectronMoments

--- a/doc/content/source/materials/HeavySpecies.md
+++ b/doc/content/source/materials/HeavySpecies.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HeavySpecies syntax=/Materials/HeavySpecies

--- a/doc/content/source/materials/HeavySpeciesMaterial.md
+++ b/doc/content/source/materials/HeavySpeciesMaterial.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=HeavySpeciesMaterial syntax=/Materials/HeavySpeciesMaterial

--- a/doc/content/source/materials/JacMat.md
+++ b/doc/content/source/materials/JacMat.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=JacMat syntax=/Materials/JacMat

--- a/doc/content/source/materials/SigmaMat.md
+++ b/doc/content/source/materials/SigmaMat.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=SigmaMat syntax=/Materials/SigmaMat

--- a/doc/content/source/materials/Water.md
+++ b/doc/content/source/materials/Water.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=Water syntax=/Materials/Water

--- a/doc/content/source/meshmodifiers/NodeAndSidesetBetweenSubdomains.md
+++ b/doc/content/source/meshmodifiers/NodeAndSidesetBetweenSubdomains.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=NodeAndSidesetBetweenSubdomains syntax=/MeshModifiers/NodeAndSidesetBetweenSubdomains

--- a/doc/content/source/postprocessors/PlasmaFrequencyInverse.md
+++ b/doc/content/source/postprocessors/PlasmaFrequencyInverse.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=PlasmaFrequencyInverse syntax=/Postprocessors/PlasmaFrequencyInverse

--- a/doc/content/source/postprocessors/SideTotFluxIntegral.md
+++ b/doc/content/source/postprocessors/SideTotFluxIntegral.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=SideTotFluxIntegral syntax=/Postprocessors/SideTotFluxIntegral

--- a/doc/content/source/userobjects/BlockAverageValue.md
+++ b/doc/content/source/userobjects/BlockAverageValue.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=BlockAverageValue syntax=/Postprocessors/BlockAverageValue

--- a/doc/content/source/userobjects/CurrentDensityShapeSideUserObject.md
+++ b/doc/content/source/userobjects/CurrentDensityShapeSideUserObject.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=CurrentDensityShapeSideUserObject syntax=/UserObjects/CurrentDensityShapeSideUserObject

--- a/doc/content/source/userobjects/ProvideMobility.md
+++ b/doc/content/source/userobjects/ProvideMobility.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_object.md.template name=ProvideMobility syntax=/UserObjects/ProvideMobility

--- a/doc/content/syntax/LotsOfCoeffDiffusion/index.md
+++ b/doc/content/syntax/LotsOfCoeffDiffusion/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfCoeffDiffusion syntax=/LotsOfCoeffDiffusion

--- a/doc/content/syntax/LotsOfEFieldAdvection/index.md
+++ b/doc/content/syntax/LotsOfEFieldAdvection/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfEFieldAdvection syntax=/LotsOfEFieldAdvection

--- a/doc/content/syntax/LotsOfPotentialDrivenArtificialDiff/index.md
+++ b/doc/content/syntax/LotsOfPotentialDrivenArtificialDiff/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfPotentialDrivenArtificialDiff syntax=/LotsOfPotentialDrivenArtificialDiff

--- a/doc/content/syntax/LotsOfSources/index.md
+++ b/doc/content/syntax/LotsOfSources/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfSources syntax=/LotsOfSources

--- a/doc/content/syntax/LotsOfTimeDerivatives/index.md
+++ b/doc/content/syntax/LotsOfTimeDerivatives/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfTimeDerivatives syntax=/LotsOfTimeDerivatives

--- a/doc/content/syntax/LotsOfVariables/index.md
+++ b/doc/content/syntax/LotsOfVariables/index.md
@@ -1,0 +1,1 @@
+!template load file=stubs/moose_system.md.template name=LotsOfVariables syntax=/LotsOfVariables

--- a/doc/moosedocs.py
+++ b/doc/moosedocs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import sys
+import os
+
+# Locate MOOSE directory
+MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__name__), '..', 'moose')))
+if not os.path.exists(MOOSE_DIR):
+    MOOSE_DIR = os.path.abspath(os.path.join(os.path.dirname(__name__), '..', '..', 'moose'))
+if not os.path.exists(MOOSE_DIR):
+    raise Exception('Failed to locate MOOSE, specify the MOOSE_DIR environment variable.')
+os.environ['MOOSE_DIR'] = MOOSE_DIR
+
+# Append MOOSE python directory
+MOOSE_PYTHON_DIR = os.path.join(MOOSE_DIR, 'python')
+if MOOSE_PYTHON_DIR not in sys.path:
+    sys.path.append(MOOSE_PYTHON_DIR)
+
+from MooseDocs import main
+if __name__ == '__main__':
+    sys.exit(main.run())


### PR DESCRIPTION
This PR adds MooseDocs infrastructure to the `doc` directory, as well as stub pages for the currently existing source code and actions in Zapdos as of today (09/26/2019). 

`index.md` is still in default form, as it would be with a new Stork. Links to source code documentation and general information still needs to be added. I can work on adding some of that now, or make a new PR after this gets merged.

Closes #36 