### PR TITLE
Improve code formatting

### DIFF
--- a/include/auxkernels/ProcRateForRateCoeff.h
+++ b/include/auxkernels/ProcRateForRateCoeff.h
@@ -27,8 +27,6 @@ public:
   virtual Real computeValue();
 
 protected:
-
-
   const VariableValue & _v;
   const VariableValue & _w;
   const MaterialProperty<Real> & _reaction_coeff;

--- a/include/auxkernels/ProcRateForRateCoeffThreeBody.h
+++ b/include/auxkernels/ProcRateForRateCoeffThreeBody.h
@@ -27,8 +27,6 @@ public:
   virtual Real computeValue();
 
 protected:
-
-
   const VariableValue & _v;
   const VariableValue & _w;
   const VariableValue & _vv;

--- a/include/kernels/ScaledReaction.h
+++ b/include/kernels/ScaledReaction.h
@@ -29,5 +29,4 @@ protected:
 
 private:
   Real _nu;
-
 };

--- a/include/materials/HeavySpecies.h
+++ b/include/materials/HeavySpecies.h
@@ -34,11 +34,11 @@ protected:
   std::string _potential_units;
   Real _voltage_scaling;
 
-  MaterialProperty<Real> & _massHeavy; // Replaces _massArp
+  MaterialProperty<Real> & _massHeavy;        // Replaces _massArp
   MaterialProperty<Real> & _temperatureHeavy; // Replaces _tempArp
-  MaterialProperty<Real> & _sgnHeavy; // Replaces _sgnArp (unused though)
-  MaterialProperty<Real> & _muHeavy;  // Replaces _muArp
-  MaterialProperty<Real> & _diffHeavy; // Replaces _diffArp
+  MaterialProperty<Real> & _sgnHeavy;         // Replaces _sgnArp (unused though)
+  MaterialProperty<Real> & _muHeavy;          // Replaces _muArp
+  MaterialProperty<Real> & _diffHeavy;        // Replaces _diffArp
 
   const MaterialProperty<Real> & _T_gas;
   const MaterialProperty<Real> & _p_gas;

--- a/include/materials/HeavySpeciesMaterial.h
+++ b/include/materials/HeavySpeciesMaterial.h
@@ -34,11 +34,11 @@ protected:
   std::string _potential_units;
   Real _voltage_scaling;
 
-  MaterialProperty<Real> & _massHeavy; // Replaces _massArp
+  MaterialProperty<Real> & _massHeavy;        // Replaces _massArp
   MaterialProperty<Real> & _temperatureHeavy; // Replaces _tempArp
-  MaterialProperty<Real> & _sgnHeavy; // Replaces _sgnArp (unused though)
-  MaterialProperty<Real> & _muHeavy;  // Replaces _muArp
-  MaterialProperty<Real> & _diffHeavy; // Replaces _diffArp
+  MaterialProperty<Real> & _sgnHeavy;         // Replaces _sgnArp (unused though)
+  MaterialProperty<Real> & _muHeavy;          // Replaces _muArp
+  MaterialProperty<Real> & _diffHeavy;        // Replaces _diffArp
 
   const MaterialProperty<Real> & _T_gas;
   const MaterialProperty<Real> & _p_gas;
@@ -50,9 +50,4 @@ protected:
   // MaterialProperty<Real> & _T_gas;
   // MaterialProperty<Real> & _p_gas;  // Replace with gas fraction?
   // MaterialProperty<Real> & _n_gas;
-
-
-
-
-
 };

--- a/include/postprocessors/PlasmaFrequencyInverse.h
+++ b/include/postprocessors/PlasmaFrequencyInverse.h
@@ -24,7 +24,6 @@ InputParameters validParams<PlasmaFrequencyInverse>();
 class PlasmaFrequencyInverse : public ElementVariablePostprocessor
 {
 public:
-
   /**
    * Class constructor
    * @param parameters The input parameters

--- a/src/auxkernels/AbsValueAux.C
+++ b/src/auxkernels/AbsValueAux.C
@@ -18,8 +18,7 @@ validParams<AbsValueAux>()
 {
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredCoupledVar("u", "Variable we want absolute value of.");
-  params.addClassDescription(
-    "Returns the absolute value of variable");
+  params.addClassDescription("Returns the absolute value of variable");
   return params;
 }
 

--- a/src/auxkernels/Current.C
+++ b/src/auxkernels/Current.C
@@ -24,7 +24,7 @@ validParams<Current>()
       "art_diff", false, "Whether there is a current contribution from artificial diffusion.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Returns the electric current associated with the flux of defined species");
+      "Returns the electric current associated with the flux of defined species");
   return params;
 }
 

--- a/src/auxkernels/DensityMoles.C
+++ b/src/auxkernels/DensityMoles.C
@@ -19,8 +19,7 @@ validParams<DensityMoles>()
   InputParameters params = validParams<Density>();
 
   params.addRequiredParam<bool>("use_moles", "Whether to convert from units of moles to #.");
-  params.addClassDescription(
-    "Returns physical densities in units of #/m^3");
+  params.addClassDescription("Returns physical densities in units of #/m^3");
   return params;
 }
 

--- a/src/auxkernels/DiffusiveFlux.C
+++ b/src/auxkernels/DiffusiveFlux.C
@@ -19,8 +19,7 @@ validParams<DiffusiveFlux>()
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Returns the diffusive flux of defined species");
+  params.addClassDescription("Returns the diffusive flux of defined species");
   return params;
 }
 

--- a/src/auxkernels/DriftDiffusionFluxAux.C
+++ b/src/auxkernels/DriftDiffusionFluxAux.C
@@ -25,8 +25,7 @@ validParams<DriftDiffusionFluxAux>()
                         "negative.");
   params.addRequiredCoupledVar("u", "The drift-diffusing species.");
   params.addParam<int>("component", 0, "The flux component you want to see.");
-  params.addClassDescription(
-    "Returns the drift-diffusion flux of defined species");
+  params.addClassDescription("Returns the drift-diffusion flux of defined species");
   return params;
 }
 

--- a/src/auxkernels/EFieldAdvAux.C
+++ b/src/auxkernels/EFieldAdvAux.C
@@ -21,8 +21,7 @@ validParams<EFieldAdvAux>()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Returns the electric field driven advective flux of defined species");
+  params.addClassDescription("Returns the electric field driven advective flux of defined species");
   return params;
 }
 

--- a/src/auxkernels/Efield.C
+++ b/src/auxkernels/Efield.C
@@ -24,7 +24,7 @@ validParams<Efield>()
   params.addRequiredParam<int>("component",
                                "The component of the electric field to access. Accepts an integer");
   params.addClassDescription(
-    "Returns the defined component of the electric field (0 = x, 1 = y, 2 = z)");
+      "Returns the defined component of the electric field (0 = x, 1 = y, 2 = z)");
   return params;
 }
 

--- a/src/auxkernels/ElectronTemperature.C
+++ b/src/auxkernels/ElectronTemperature.C
@@ -20,8 +20,7 @@ validParams<ElectronTemperature>()
 
   params.addRequiredCoupledVar("electron_density", "The electron density");
   params.addRequiredCoupledVar("mean_en", "The logarathmic representation of the mean energy.");
-  params.addClassDescription(
-    "Returns the electron temperature");
+  params.addClassDescription("Returns the electron temperature");
 
   return params;
 }

--- a/src/auxkernels/Position.C
+++ b/src/auxkernels/Position.C
@@ -19,10 +19,10 @@ validParams<Position>()
   InputParameters params = validParams<AuxKernel>();
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Produces an elemental auxiliary variable useful for plotting against other"
-    "elemental auxiliary variables. Mesh points automatically output by Zapdos only work"
-    "for plotting nodal variables. Since almost all auxiliary variables are elemental, this"
-    "AuxKernel is very important");
+      "Produces an elemental auxiliary variable useful for plotting against other"
+      "elemental auxiliary variables. Mesh points automatically output by Zapdos only work"
+      "for plotting nodal variables. Since almost all auxiliary variables are elemental, this"
+      "AuxKernel is very important");
   return params;
 }
 

--- a/src/auxkernels/PowerDep.C
+++ b/src/auxkernels/PowerDep.C
@@ -25,7 +25,7 @@ validParams<PowerDep>()
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Amount of power deposited into a user specified specie by Joule Heating");
+      "Amount of power deposited into a user specified specie by Joule Heating");
   return params;
 }
 

--- a/src/auxkernels/ProcRate.C
+++ b/src/auxkernels/ProcRate.C
@@ -25,8 +25,8 @@ validParams<ProcRate>()
       "The process that we want to get the townsend coefficient for. Options are iz, ex, and el.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Reaction rate for electron impact collisions in units of #/m^3s. User can pass"
-    "choice of elastic, excitation, or ionization Townsend coefficients");
+      "Reaction rate for electron impact collisions in units of #/m^3s. User can pass"
+      "choice of elastic, excitation, or ionization Townsend coefficients");
   return params;
 }
 

--- a/src/auxkernels/ProcRateForRateCoeff.C
+++ b/src/auxkernels/ProcRateForRateCoeff.C
@@ -22,8 +22,8 @@ validParams<ProcRateForRateCoeff>()
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-    "Reaction rate for two body collisions in units of #/m^3s. User can pass"
-    "choice of elastic, excitation, or ionization reaction rate coefficients");
+      "Reaction rate for two body collisions in units of #/m^3s. User can pass"
+      "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;
 }
@@ -31,9 +31,9 @@ validParams<ProcRateForRateCoeff>()
 ProcRateForRateCoeff::ProcRateForRateCoeff(const InputParameters & parameters)
   : AuxKernel(parameters),
 
-  _v(coupledValue("v")),
-  _w(coupledValue("w")),
-  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
 {
 }
 
@@ -42,5 +42,4 @@ ProcRateForRateCoeff::computeValue()
 {
 
   return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]);
-
 }

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody.C
@@ -23,8 +23,8 @@ validParams<ProcRateForRateCoeffThreeBody>()
   params.addCoupledVar("vv", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-    "Reaction rate for three body collisions in units of #/m^3s. User can pass"
-    "choice of elastic, excitation, or ionization reaction rate coefficients");
+      "Reaction rate for three body collisions in units of #/m^3s. User can pass"
+      "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;
 }
@@ -32,10 +32,10 @@ validParams<ProcRateForRateCoeffThreeBody>()
 ProcRateForRateCoeffThreeBody::ProcRateForRateCoeffThreeBody(const InputParameters & parameters)
   : AuxKernel(parameters),
 
-  _v(coupledValue("v")),
-  _w(coupledValue("w")),
-  _vv(coupledValue("vv")),
-  _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
+    _v(coupledValue("v")),
+    _w(coupledValue("w")),
+    _vv(coupledValue("vv")),
+    _reaction_coeff(getMaterialProperty<Real>("k_" + getParam<std::string>("reaction")))
 {
 }
 
@@ -43,6 +43,6 @@ Real
 ProcRateForRateCoeffThreeBody::computeValue()
 {
 
-  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) * std::exp(_vv[_qp]);
-
+  return 6.02e23 * _reaction_coeff[_qp] * std::exp(_v[_qp]) * std::exp(_w[_qp]) *
+         std::exp(_vv[_qp]);
 }

--- a/src/auxkernels/TotalFlux.C
+++ b/src/auxkernels/TotalFlux.C
@@ -20,8 +20,7 @@ validParams<TotalFlux>()
 
   params.addRequiredCoupledVar("density_log", "The electron density");
   params.addRequiredCoupledVar("potential", "The potential");
-  params.addClassDescription(
-    "Returns the total flux of defined species");
+  params.addClassDescription("Returns the total flux of defined species");
 
   return params;
 }

--- a/src/auxkernels/UserFlux.C
+++ b/src/auxkernels/UserFlux.C
@@ -24,7 +24,7 @@ validParams<UserFlux>()
   params.addRequiredParam<Real>("sign", "The charge sign of the drift-diffusing particle.");
   params.addRequiredParam<Real>("EField", "The electric field moving the charges.");
   params.addClassDescription(
-    "Returns the total flux of defined species that requires constant user defined coefficients");
+      "Returns the total flux of defined species that requires constant user defined coefficients");
   return params;
 }
 

--- a/src/bcs/CircuitDirichletPotential.C
+++ b/src/bcs/CircuitDirichletPotential.C
@@ -36,9 +36,8 @@ validParams<CircuitDirichletPotential>()
                    1.,
                    "For 1D calculations, an area has to be passed. This area also must "
                    "match the units convention of position_units.");
-  p.addClassDescription(
-    "Dirichlet circuit boundary condition for potential"
-    "(The current is given through an UserObject)");
+  p.addClassDescription("Dirichlet circuit boundary condition for potential"
+                        "(The current is given through an UserObject)");
   return p;
 }
 

--- a/src/bcs/DCIonBC.C
+++ b/src/bcs/DCIonBC.C
@@ -22,8 +22,7 @@ validParams<DCIonBC>()
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredCoupledVar("potential", "The electrical potential");
   params.addRequiredParam<Real>("position_units", "Units of position");
-  params.addClassDescription(
-    "Electric field driven outflow boundary condition");
+  params.addClassDescription("Electric field driven outflow boundary condition");
   return params;
 }
 
@@ -55,8 +54,9 @@ DCIonBC::computeQpResidual()
     _a = 0.0;
   }
 
-  return _test[_i][_qp] * _r_units * (_a * _mu[_qp] * _sgn[_qp] * -_grad_potential[_qp] * _r_units *
-                                      std::exp(_u[_qp]) * _normals[_qp]);
+  return _test[_i][_qp] * _r_units *
+         (_a * _mu[_qp] * _sgn[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) *
+          _normals[_qp]);
 }
 
 Real
@@ -71,8 +71,9 @@ DCIonBC::computeQpJacobian()
     _a = 0.0;
   }
 
-  return _test[_i][_qp] * _r_units * (_a * _mu[_qp] * _sgn[_qp] * -_grad_potential[_qp] * _r_units *
-                                      std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp]);
+  return _test[_i][_qp] * _r_units *
+         (_a * _mu[_qp] * _sgn[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) *
+          _phi[_j][_qp] * _normals[_qp]);
 }
 
 Real
@@ -88,8 +89,9 @@ DCIonBC::computeQpOffDiagJacobian(unsigned int jvar)
     {
       _a = 0.0;
     }
-    return _test[_i][_qp] * _r_units * (_a * _mu[_qp] * _sgn[_qp] * -_grad_phi[_j][_qp] * _r_units *
-                                        std::exp(_u[_qp]) * _normals[_qp]);
+    return _test[_i][_qp] * _r_units *
+           (_a * _mu[_qp] * _sgn[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_u[_qp]) *
+            _normals[_qp]);
   }
   else
   {

--- a/src/bcs/DriftDiffusionDoNothingBC.C
+++ b/src/bcs/DriftDiffusionDoNothingBC.C
@@ -30,8 +30,8 @@ validParams<DriftDiffusionDoNothingBC>()
   params.addParam<Real>("diff", "The diffusivity.");
   params.addParam<Real>("sign", "The sign of the charged particle.");
   params.addParam<bool>("use_material_props", true, "Whether to use a material for properties.");
-  params.addClassDescription(
-    "Boundary condition where the flux at the boundary is equal to the bulk dift-diffusion equation");
+  params.addClassDescription("Boundary condition where the flux at the boundary is equal to the "
+                             "bulk dift-diffusion equation");
   return params;
 }
 

--- a/src/bcs/DriftDiffusionUserDoNothingBC.C
+++ b/src/bcs/DriftDiffusionUserDoNothingBC.C
@@ -20,9 +20,9 @@ validParams<DriftDiffusionUserDoNothingBC>()
   params.addRequiredParam<Real>("mu", "The mobility.");
   params.addRequiredParam<Real>("diff", "The diffusivity.");
   params.addRequiredParam<Real>("sign", "The charge sign of the drift-diffusing particle.");
-  params.addClassDescription(
-    "Boundary condition where the flux at the boundary is equal to the bulk dift-diffusion equation"
-    "with constant user defined coefficients");
+  params.addClassDescription("Boundary condition where the flux at the boundary is equal to the "
+                             "bulk dift-diffusion equation"
+                             "with constant user defined coefficients");
   return params;
 }
 

--- a/src/bcs/ElectronAdvectionDoNothingBC.C
+++ b/src/bcs/ElectronAdvectionDoNothingBC.C
@@ -21,8 +21,8 @@ validParams<ElectronAdvectionDoNothingBC>()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("mean_en", "The log of the mean energy.");
   params.addRequiredParam<Real>("position_units", "The units of position.");
-  params.addClassDescription(
-    "Boundary condition where the election advection flux at the boundary is equal to the bulk election advection equation");
+  params.addClassDescription("Boundary condition where the election advection flux at the boundary "
+                             "is equal to the bulk election advection equation");
   return params;
 }
 

--- a/src/bcs/ElectronDiffusionDoNothingBC.C
+++ b/src/bcs/ElectronDiffusionDoNothingBC.C
@@ -20,8 +20,8 @@ validParams<ElectronDiffusionDoNothingBC>()
   params.addRequiredCoupledVar("mean_en",
                                "The log of the product of mean energy times electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position");
-  params.addClassDescription(
-    "Boundary condition where the election diffusion flux at the boundary is equal to the bulk election diffusion equation");
+  params.addClassDescription("Boundary condition where the election diffusion flux at the boundary "
+                             "is equal to the bulk election diffusion equation");
   return params;
 }
 
@@ -58,8 +58,9 @@ ElectronDiffusionDoNothingBC::computeQpJacobian()
   _d_diffem_d_u =
       _d_diffem_d_actual_mean_en[_qp] * std::exp(_mean_en[_qp] - _u[_qp]) * -_phi[_j][_qp];
 
-  return -_diffem[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                          std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+  return -_diffem[_qp] *
+             (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+              std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
              _normals[_qp] * _test[_i][_qp] * _r_units -
          _d_diffem_d_u * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units * _normals[_qp] *
              _test[_i][_qp] * _r_units;

--- a/src/bcs/ElectronTemperatureDirichletBC.C
+++ b/src/bcs/ElectronTemperatureDirichletBC.C
@@ -20,8 +20,7 @@ validParams<ElectronTemperatureDirichletBC>()
   params.addRequiredParam<Real>("value", "Value of the BC");
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addParam<Real>("penalty_value", 1.0, "The penalty value for the Dirichlet BC.");
-  params.addClassDescription(
-    "Electron temperature boundary condition");
+  params.addClassDescription("Electron temperature boundary condition");
   return params;
 }
 

--- a/src/bcs/FieldEmissionBC.C
+++ b/src/bcs/FieldEmissionBC.C
@@ -203,8 +203,9 @@ FieldEmissionBC::computeQpOffDiagJacobian(unsigned int jvar)
 
       jFE = (FE_a / (_work_function[_qp])) * pow(F, 2) *
             std::exp(-v * FE_b * pow(_work_function[_qp], 1.5) / F);
-      _d_jFE_d_potential = jFE * (2 - (FE_b * FE_c) / (6 * sqrt(_work_function[_qp])) +
-                                  (FE_b * pow(_work_function[_qp], 1.5) / F)) *
+      _d_jFE_d_potential = jFE *
+                           (2 - (FE_b * FE_c) / (6 * sqrt(_work_function[_qp])) +
+                            (FE_b * pow(_work_function[_qp], 1.5) / F)) *
                            (_grad_phi[_j][_qp] * _normals[_qp]) /
                            (_grad_potential[_qp] * _normals[_qp]);
 

--- a/src/bcs/HagelaarElectronAdvectionBC.C
+++ b/src/bcs/HagelaarElectronAdvectionBC.C
@@ -21,9 +21,8 @@ validParams<HagelaarElectronAdvectionBC>()
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic advective electron boundary condition"
-    "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
+  params.addClassDescription("Kinetic advective electron boundary condition"
+                             "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
   return params;
 }
 

--- a/src/bcs/HagelaarElectronBC.C
+++ b/src/bcs/HagelaarElectronBC.C
@@ -21,9 +21,8 @@ validParams<HagelaarElectronBC>()
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic electron boundary condition"
-    "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
+  params.addClassDescription("Kinetic electron boundary condition"
+                             "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
   return params;
 }
 

--- a/src/bcs/HagelaarEnergyAdvectionBC.C
+++ b/src/bcs/HagelaarEnergyAdvectionBC.C
@@ -25,9 +25,8 @@ validParams<HagelaarEnergyAdvectionBC>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredCoupledVar("ip", "The ion density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic advective electron energy boundary condition"
-    "(Based on DOI:https://doi.org/10.1063/1.2715745)");
+  params.addClassDescription("Kinetic advective electron energy boundary condition"
+                             "(Based on DOI:https://doi.org/10.1063/1.2715745)");
   return params;
 }
 
@@ -204,9 +203,10 @@ HagelaarEnergyAdvectionBC::computeQpOffDiagJacobian(unsigned int jvar)
                      _d_mumean_en_d_actual_mean_en[_qp] * _actual_mean_en * -_phi[_j][_qp] *
                      (2. * _a - 1.) -
                  5. * _d_v_thermal_d_em) +
-            (_r - 1.) * (6. * -_grad_potential[_qp] * _r_units * _normals[_qp] * _mumean_en[_qp] *
-                             (2. * _a - 1.) -
-                         5. * _v_thermal) *
+            (_r - 1.) *
+                (6. * -_grad_potential[_qp] * _r_units * _normals[_qp] * _mumean_en[_qp] *
+                     (2. * _a - 1.) -
+                 5. * _v_thermal) *
                 -_se_energy[_qp] * _d_n_gamma_d_em);
   }
 

--- a/src/bcs/HagelaarIonAdvectionBC.C
+++ b/src/bcs/HagelaarIonAdvectionBC.C
@@ -23,9 +23,8 @@ validParams<HagelaarIonAdvectionBC>()
   params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic advective ion boundary condition"
-    "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
+  params.addClassDescription("Kinetic advective ion boundary condition"
+                             "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
   return params;
 }
 

--- a/src/bcs/HagelaarIonDiffusionBC.C
+++ b/src/bcs/HagelaarIonDiffusionBC.C
@@ -24,9 +24,8 @@ validParams<HagelaarIonDiffusionBC>()
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addParam<Real>(
       "user_velocity", -1., "Optional parameter if user wants to specify the thermal velocity");
-  params.addClassDescription(
-    "Kinetic diffusive ion boundary condition"
-    "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
+  params.addClassDescription("Kinetic diffusive ion boundary condition"
+                             "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
 
   return params;
 }

--- a/src/bcs/LogDensityDirichletBC.C
+++ b/src/bcs/LogDensityDirichletBC.C
@@ -18,15 +18,13 @@ validParams<LogDensityDirichletBC>()
 {
   InputParameters params = validParams<NodalBC>();
   params.addRequiredParam<Real>("value", "Value of the BC");
-  params.addClassDescription(
-    "Density Dirichlet boundary condition"
-    "(Densities must be in log form and in moles/m^3)");
+  params.addClassDescription("Density Dirichlet boundary condition"
+                             "(Densities must be in log form and in moles/m^3)");
   return params;
 }
 
 LogDensityDirichletBC::LogDensityDirichletBC(const InputParameters & parameters)
-  : NodalBC(parameters),
-    _value(getParam<Real>("value"))
+  : NodalBC(parameters), _value(getParam<Real>("value"))
 {
 }
 

--- a/src/bcs/LymberopoulosElectronBC.C
+++ b/src/bcs/LymberopoulosElectronBC.C
@@ -79,8 +79,9 @@ LymberopoulosElectronBC::computeQpJacobian()
          (_sign * _ks * std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp] * _normals[_qp]);
 }
 
+// need to fix
 Real
-LymberopoulosElectronBC::computeQpOffDiagJacobian(unsigned int jvar) // need to fix
+LymberopoulosElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id)
   {

--- a/src/bcs/LymberopoulosElectronBC.C
+++ b/src/bcs/LymberopoulosElectronBC.C
@@ -22,9 +22,8 @@ validParams<LymberopoulosElectronBC>()
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("ion", "The ion density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Simpified kinetic electron boundary condition"
-    "(Based on DOI: https://doi.org/10.1063/1.352926)");
+  params.addClassDescription("Simpified kinetic electron boundary condition"
+                             "(Based on DOI: https://doi.org/10.1063/1.352926)");
   return params;
 }
 
@@ -42,8 +41,8 @@ LymberopoulosElectronBC::LymberopoulosElectronBC(const InputParameters & paramet
     _grad_Arp(coupledGradient("ion")),
     _Arp_id(coupled("ion")),
 
-    _muion(getMaterialProperty<Real>("mu" + (*getVar("ion",0)).name())),
-    _diffion(getMaterialProperty<Real>("diff" + (*getVar("ion",0)).name())),
+    _muion(getMaterialProperty<Real>("mu" + (*getVar("ion", 0)).name())),
+    _diffion(getMaterialProperty<Real>("diff" + (*getVar("ion", 0)).name())),
 
     _sign(1)
 {
@@ -53,50 +52,61 @@ Real
 LymberopoulosElectronBC::computeQpResidual()
 {
 
-  RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]));
+  RealVectorValue _ion_flux =
+      (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]));
 
-  //RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]) -
+  // RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units *
+  // std::exp(_Arp[_qp]) -
   //            _diffion[_qp] * std::exp(_Arp[_qp]) * _grad_Arp[_qp] * _r_units);
 
-  return _test[_i][_qp] * _r_units * ( _sign * _ks * std::exp(_u[_qp]) * _normals[_qp] * _normals[_qp]  - _gamma * _ion_flux * _normals[_qp] );
+  return _test[_i][_qp] * _r_units *
+         (_sign * _ks * std::exp(_u[_qp]) * _normals[_qp] * _normals[_qp] -
+          _gamma * _ion_flux * _normals[_qp]);
 }
 
 Real
 LymberopoulosElectronBC::computeQpJacobian()
 {
 
-  RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]));
+  RealVectorValue _ion_flux =
+      (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]));
 
-  //RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]) -
+  // RealVectorValue _ion_flux = (_muion[_qp] * -_grad_potential[_qp] * _r_units *
+  // std::exp(_Arp[_qp]) -
   //            _diffion[_qp] * std::exp(_Arp[_qp]) * _grad_Arp[_qp] * _r_units);
 
-  return _test[_i][_qp] * _r_units * ( _sign * _ks * std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp] * _normals[_qp] );
+  return _test[_i][_qp] * _r_units *
+         (_sign * _ks * std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp] * _normals[_qp]);
 }
 
 Real
-LymberopoulosElectronBC::computeQpOffDiagJacobian(unsigned int jvar) //need to fix
+LymberopoulosElectronBC::computeQpOffDiagJacobian(unsigned int jvar) // need to fix
 {
   if (jvar == _potential_id)
   {
 
-    RealVectorValue _d_ion_flux_d_V = (_muion[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_Arp[_qp]));
+    RealVectorValue _d_ion_flux_d_V =
+        (_muion[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_Arp[_qp]));
 
-    //RealVectorValue _d_ion_flux_d_V = (_muion[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_Arp[_qp]) -
+    // RealVectorValue _d_ion_flux_d_V = (_muion[_qp] * -_grad_phi[_j][_qp] * _r_units *
+    // std::exp(_Arp[_qp]) -
     //            _diffion[_qp] * std::exp(_Arp[_qp]) * _grad_Arp[_qp] * _r_units);
 
-    return _test[_i][_qp] * _r_units * ( (- _gamma * _d_ion_flux_d_V  *  _normals[_qp]) );
+    return _test[_i][_qp] * _r_units * ((-_gamma * _d_ion_flux_d_V * _normals[_qp]));
   }
 
   else if (jvar == _Arp_id)
   {
 
-    RealVectorValue _d_ion_flux_d_ion = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]) * _phi[_j][_qp]);
+    RealVectorValue _d_ion_flux_d_ion =
+        (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]) * _phi[_j][_qp]);
 
-    //RealVectorValue _d_ion_flux_d_ion = (_muion[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_Arp[_qp]) * _phi[_j][_qp] -
+    // RealVectorValue _d_ion_flux_d_ion = (_muion[_qp] * -_grad_potential[_qp] * _r_units *
+    // std::exp(_Arp[_qp]) * _phi[_j][_qp] -
     //                      _diffion[_qp] * (std::exp(_Arp[_qp]) * _grad_phi[_j][_qp] * _r_units +
     //                      std::exp(_Arp[_qp]) * _phi[_j][_qp] * _grad_Arp[_qp] * _r_units));
 
-    return _test[_i][_qp] * _r_units * ( (- _gamma * _d_ion_flux_d_ion  *  _normals[_qp]) );
+    return _test[_i][_qp] * _r_units * ((-_gamma * _d_ion_flux_d_ion * _normals[_qp]));
   }
 
   else

--- a/src/bcs/LymberopoulosIonBC.C
+++ b/src/bcs/LymberopoulosIonBC.C
@@ -22,9 +22,8 @@ validParams<LymberopoulosIonBC>()
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Simpified kinetic ion boundary condition"
-    "(Based on DOI: https://doi.org/10.1063/1.352926)");
+  params.addClassDescription("Simpified kinetic ion boundary condition"
+                             "(Based on DOI: https://doi.org/10.1063/1.352926)");
   return params;
 }
 
@@ -45,18 +44,16 @@ Real
 LymberopoulosIonBC::computeQpResidual()
 {
 
-  return _test[_i][_qp] * _r_units *
-          _mu[_qp] * -_grad_potential[_qp] * _r_units *
-          std::exp(_u[_qp]) * _normals[_qp];
+  return _test[_i][_qp] * _r_units * _mu[_qp] * -_grad_potential[_qp] * _r_units *
+         std::exp(_u[_qp]) * _normals[_qp];
 }
 
 Real
 LymberopoulosIonBC::computeQpJacobian()
 {
 
-  return _test[_i][_qp] * _r_units *
-          _mu[_qp] * -_grad_potential[_qp] * _r_units *
-          std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp];
+  return _test[_i][_qp] * _r_units * _mu[_qp] * -_grad_potential[_qp] * _r_units *
+         std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp];
 }
 
 Real
@@ -65,9 +62,8 @@ LymberopoulosIonBC::computeQpOffDiagJacobian(unsigned int jvar)
   if (jvar == _potential_id)
   {
 
-    return _test[_i][_qp] * _r_units *
-            _mu[_qp] * _grad_phi[_j][_qp] * _r_units *
-            std::exp(_u[_qp]) * _normals[_qp];
+    return _test[_i][_qp] * _r_units * _mu[_qp] * _grad_phi[_j][_qp] * _r_units *
+           std::exp(_u[_qp]) * _normals[_qp];
   }
 
   else

--- a/src/bcs/MatchedValueLogBC.C
+++ b/src/bcs/MatchedValueLogBC.C
@@ -18,8 +18,8 @@ validParams<MatchedValueLogBC>()
   params.addRequiredParam<Real>("H", "The ratio of liquid phase density to gas phase density");
   params.addRequiredCoupledVar("v", "The variable whose value we are to match.");
   params.addClassDescription(
-    "Henry’s Law like thermodynamic boundary condition for specifying a specie"
-    "concentration ratio at the gas-liquid interface");
+      "Henry’s Law like thermodynamic boundary condition for specifying a specie"
+      "concentration ratio at the gas-liquid interface");
   return params;
 }
 

--- a/src/bcs/NeumannCircuitVoltageNew.C
+++ b/src/bcs/NeumannCircuitVoltageNew.C
@@ -35,8 +35,8 @@ validParams<NeumannCircuitVoltageNew>()
   p.addRequiredParam<Real>("position_units", "Units of position.");
   p.addRequiredParam<Real>("resistance", "The ballast resistance in Ohms.");
   p.addClassDescription(
-    "Circuit boundary condition for potential"
-    "(Similar to 'NeumannCircuitVoltageNew' BC but current is given through an UserObject)");
+      "Circuit boundary condition for potential"
+      "(Similar to 'NeumannCircuitVoltageNew' BC but current is given through an UserObject)");
   return p;
 }
 

--- a/src/bcs/PenaltyCircuitPotential.C
+++ b/src/bcs/PenaltyCircuitPotential.C
@@ -39,8 +39,7 @@ validParams<PenaltyCircuitPotential>()
   p.addRequiredParam<std::string>("potential_units", "The potential units.");
   p.addRequiredParam<Real>("position_units", "Units of position.");
   p.addRequiredParam<Real>("resistance", "The ballast resistance in Ohms.");
-  p.addClassDescription(
-    "Circuit boundary condition for potential multiplied by a penalty term");
+  p.addClassDescription("Circuit boundary condition for potential multiplied by a penalty term");
   return p;
 }
 

--- a/src/bcs/PotentialDriftOutflowBC.C
+++ b/src/bcs/PotentialDriftOutflowBC.C
@@ -21,7 +21,7 @@ validParams<PotentialDriftOutflowBC>()
   params.addRequiredCoupledVar(
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar(
-    "potential", "The gradient of the potential will be used to compute the advection velocity.");
+      "potential", "The gradient of the potential will be used to compute the advection velocity.");
 
   params.addParam<MooseEnum>("charge_sign", charge_sign, "The sign of the charged particle.");
   return params;

--- a/src/bcs/SakiyamaElectronDiffusionBC.C
+++ b/src/bcs/SakiyamaElectronDiffusionBC.C
@@ -17,12 +17,11 @@ InputParameters
 validParams<SakiyamaElectronDiffusionBC>()
 {
   InputParameters params = validParams<IntegratedBC>();
-  //params.addRequiredParam<Real>("r", "The reflection coefficient");
+  // params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic electron boundary condition"
-    "(Based on DOI: https://doi.org/10.1116/1.579300)");
+  params.addClassDescription("Kinetic electron boundary condition"
+                             "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
 }
 
@@ -52,8 +51,7 @@ SakiyamaElectronDiffusionBC::computeQpResidual()
   _v_thermal =
       std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_mean_en[_qp] - _u[_qp]) / (M_PI * _massem[_qp]));
 
-  return _test[_i][_qp] * _r_units *
-         (0.25 * _v_thermal * std::exp(_u[_qp]));
+  return _test[_i][_qp] * _r_units * (0.25 * _v_thermal * std::exp(_u[_qp]));
 }
 
 Real
@@ -85,8 +83,7 @@ SakiyamaElectronDiffusionBC::computeQpOffDiagJacobian(unsigned int jvar)
                              _phi[_j][_qp];
     _actual_mean_en = std::exp(_mean_en[_qp] - _u[_qp]);
 
-    return _test[_i][_qp] * _r_units *
-           (0.25 * _d_v_thermal_d_mean_en * std::exp(_u[_qp]));
+    return _test[_i][_qp] * _r_units * (0.25 * _d_v_thermal_d_mean_en * std::exp(_u[_qp]));
   }
 
   else

--- a/src/bcs/SakiyamaEnergyDiffusionBC.C
+++ b/src/bcs/SakiyamaEnergyDiffusionBC.C
@@ -22,9 +22,8 @@ validParams<SakiyamaEnergyDiffusionBC>()
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic advective electron energy boundary condition"
-    "(Based on DOI: https://doi.org/10.1116/1.579300)");
+  params.addClassDescription("Kinetic advective electron energy boundary condition"
+                             "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
 }
 
@@ -54,8 +53,7 @@ SakiyamaEnergyDiffusionBC::computeQpResidual()
   _v_thermal =
       std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) / (M_PI * _massem[_qp]));
 
-      return _test[_i][_qp] * _r_units *
-          ((5.0/3.0) * 0.25 * _v_thermal * std::exp(_u[_qp]));
+  return _test[_i][_qp] * _r_units * ((5.0 / 3.0) * 0.25 * _v_thermal * std::exp(_u[_qp]));
 }
 
 Real
@@ -69,8 +67,8 @@ SakiyamaEnergyDiffusionBC::computeQpJacobian()
                      (M_PI * _massem[_qp]) * _phi[_j][_qp];
 
   return _test[_i][_qp] * _r_units *
-      ((5.0/3.0) * 0.25 * _d_v_thermal_d_u * std::exp(_u[_qp]) +
-       (5.0/3.0) * 0.25 * _v_thermal * std::exp(_u[_qp]) * _phi[_j][_qp]);
+         ((5.0 / 3.0) * 0.25 * _d_v_thermal_d_u * std::exp(_u[_qp]) +
+          (5.0 / 3.0) * 0.25 * _v_thermal * std::exp(_u[_qp]) * _phi[_j][_qp]);
 }
 
 Real
@@ -83,10 +81,9 @@ SakiyamaEnergyDiffusionBC::computeQpOffDiagJacobian(unsigned int jvar)
     _v_thermal =
         std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) / (M_PI * _massem[_qp]));
     _d_v_thermal_d_em = 0.5 / _v_thermal * 8 * _e[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) /
-                       (M_PI * _massem[_qp]) * -_phi[_j][_qp];
+                        (M_PI * _massem[_qp]) * -_phi[_j][_qp];
 
-    return _test[_i][_qp] * _r_units *
-           ((5.0/3.0) * 0.25 * _d_v_thermal_d_em * std::exp(_u[_qp]));
+    return _test[_i][_qp] * _r_units * ((5.0 / 3.0) * 0.25 * _d_v_thermal_d_em * std::exp(_u[_qp]));
   }
 
   else

--- a/src/bcs/SakiyamaEnergySecondaryElectronBC.C
+++ b/src/bcs/SakiyamaEnergySecondaryElectronBC.C
@@ -21,19 +21,22 @@ validParams<SakiyamaEnergySecondaryElectronBC>()
 {
   InputParameters params = validParams<IntegratedBC>();
   params.addRequiredParam<Real>("se_coeff", "The secondary electron coefficient");
-  params.addRequiredParam<bool>("Tse_equal_Te", "The secondary electron temperature equal the electron temperature in eV");
-  params.addParam<Real>("user_se_energy", 1.0, "The user's value of the secondary electron temperature in eV");
+  params.addRequiredParam<bool>(
+      "Tse_equal_Te", "The secondary electron temperature equal the electron temperature in eV");
+  params.addParam<Real>(
+      "user_se_energy", 1.0, "The user's value of the secondary electron temperature in eV");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredCoupledVar("ip", "The ion density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Kinetic secondary electron for mean electron energy boundary condition"
-    "(Based on DOI: https://doi.org/10.1116/1.579300)");
+      "Kinetic secondary electron for mean electron energy boundary condition"
+      "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
 }
 
-SakiyamaEnergySecondaryElectronBC::SakiyamaEnergySecondaryElectronBC(const InputParameters & parameters)
+SakiyamaEnergySecondaryElectronBC::SakiyamaEnergySecondaryElectronBC(
+    const InputParameters & parameters)
   : IntegratedBC(parameters),
 
     _r_units(1. / getParam<Real>("position_units")),
@@ -87,8 +90,8 @@ SakiyamaEnergySecondaryElectronBC::computeQpResidual()
 
   _ion_flux = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]);
 
-  return  -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0/3.0) * _se_energy
-          * _ion_flux * _normals[_qp];
+  return -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0 / 3.0) * _se_energy * _ion_flux *
+         _normals[_qp];
 }
 
 Real
@@ -114,8 +117,8 @@ SakiyamaEnergySecondaryElectronBC::computeQpJacobian()
 
   _ion_flux = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]);
 
-  return  -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0/3.0) * _d_se_energy_d_u
-          * _ion_flux * _normals[_qp];
+  return -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0 / 3.0) * _d_se_energy_d_u * _ion_flux *
+         _normals[_qp];
 }
 
 Real
@@ -141,10 +144,11 @@ SakiyamaEnergySecondaryElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
       _se_energy = _user_se_energy;
     }
 
-    _d_ion_flux_d_potential = _a * _sgnip[_qp] * _muip[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_u[_qp]);
+    _d_ion_flux_d_potential =
+        _a * _sgnip[_qp] * _muip[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_u[_qp]);
 
-    return  -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0/3.0) * _se_energy
-            * _d_ion_flux_d_potential * _normals[_qp];
+    return -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0 / 3.0) * _se_energy *
+           _d_ion_flux_d_potential * _normals[_qp];
   }
 
   else if (jvar == _em_id)
@@ -167,10 +171,11 @@ SakiyamaEnergySecondaryElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
       _d_se_energy_d_em = 0;
     }
 
-    _ion_flux = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]);
+    _ion_flux =
+        _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]);
 
-    return  -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0/3.0) * _d_se_energy_d_em
-            * _ion_flux * _normals[_qp];
+    return -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0 / 3.0) * _d_se_energy_d_em *
+           _ion_flux * _normals[_qp];
   }
 
   else if (jvar == _ip_id)
@@ -193,10 +198,11 @@ SakiyamaEnergySecondaryElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
       _se_energy = _user_se_energy;
     }
 
-    _d_ion_flux_d_ip = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) * _phi[_j][_qp];
+    _d_ion_flux_d_ip = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units *
+                       std::exp(_u[_qp]) * _phi[_j][_qp];
 
-    return  -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0/3.0) * _se_energy
-            * _d_ion_flux_d_ip * _normals[_qp];
+    return -_test[_i][_qp] * _r_units * _a * _se_coeff * (5.0 / 3.0) * _se_energy *
+           _d_ion_flux_d_ip * _normals[_qp];
   }
 
   else

--- a/src/bcs/SakiyamaIonAdvectionBC.C
+++ b/src/bcs/SakiyamaIonAdvectionBC.C
@@ -20,12 +20,11 @@ InputParameters
 validParams<SakiyamaIonAdvectionBC>()
 {
   InputParameters params = validParams<IntegratedBC>();
-  //params.addRequiredParam<Real>("r", "The reflection coefficient");
+  // params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Kinetic advective ion boundary condition"
-    "(Based on DOI: https://doi.org/10.1116/1.579300)");
+  params.addClassDescription("Kinetic advective ion boundary condition"
+                             "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
 }
 
@@ -58,8 +57,8 @@ SakiyamaIonAdvectionBC::computeQpResidual()
   }
 
   return _test[_i][_qp] * _r_units *
-         (_a * _sgn[_qp] * _mu[_qp] * -_grad_potential[_qp] * _r_units *
-          std::exp(_u[_qp]) * _normals[_qp]);
+         (_a * _sgn[_qp] * _mu[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) *
+          _normals[_qp]);
 }
 
 Real
@@ -75,8 +74,8 @@ SakiyamaIonAdvectionBC::computeQpJacobian()
   }
 
   return _test[_i][_qp] * _r_units *
-         (_a * _sgn[_qp] * _mu[_qp] * -_grad_potential[_qp] * _r_units *
-          std::exp(_u[_qp]) * _phi[_j][_qp] * _normals[_qp]);
+         (_a * _sgn[_qp] * _mu[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) *
+          _phi[_j][_qp] * _normals[_qp]);
 }
 
 Real
@@ -94,8 +93,8 @@ SakiyamaIonAdvectionBC::computeQpOffDiagJacobian(unsigned int jvar)
     }
 
     return _test[_i][_qp] * _r_units *
-           (_a * _sgn[_qp] * _mu[_qp] * -_grad_phi[_j][_qp] * _r_units *
-            std::exp(_u[_qp]) * _normals[_qp]);
+           (_a * _sgn[_qp] * _mu[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_u[_qp]) *
+            _normals[_qp]);
   }
 
   else

--- a/src/bcs/SakiyamaSecondaryElectronBC.C
+++ b/src/bcs/SakiyamaSecondaryElectronBC.C
@@ -20,18 +20,20 @@ InputParameters
 validParams<SakiyamaSecondaryElectronBC>()
 {
   InputParameters params = validParams<IntegratedBC>();
-  //params.addRequiredParam<Real>("r", "The reflection coefficient");
+  // params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
   params.addRequiredCoupledVar("ip", "The ion density.");
   params.addCoupledVar("neutral_gas", "Name of the neutrial gas");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addParam<bool>("variable_temp", false,
-       "Does the temperature of the species change based on Wannier's formulation");
-  params.addParam<Real>("users_gamma", "A secondary electron emission coeff. only used for this BC.");
-  params.addClassDescription(
-    "Kinetic secondary electron boundary condition"
-    "(Based on DOI: https://doi.org/10.1116/1.579300)");
+  params.addParam<bool>(
+      "variable_temp",
+      false,
+      "Does the temperature of the species change based on Wannier's formulation");
+  params.addParam<Real>("users_gamma",
+                        "A secondary electron emission coeff. only used for this BC.");
+  params.addClassDescription("Kinetic secondary electron boundary condition"
+                             "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
 }
 
@@ -73,7 +75,7 @@ SakiyamaSecondaryElectronBC::SakiyamaSecondaryElectronBC(const InputParameters &
     _user_se_coeff(getParam<Real>("users_gamma")),
 
     _kb(getMaterialProperty<Real>("k_boltz")),
-    _massNeutral(getMaterialProperty<Real>("mass" + (*getVar("neutral_gas",0)).name())),
+    _massNeutral(getMaterialProperty<Real>("mass" + (*getVar("neutral_gas", 0)).name())),
     _massip(getMaterialProperty<Real>("mass" + _ip_var.name())),
     _T(getMaterialProperty<Real>("T" + _ip_var.name())),
     _variable_temp(getParam<bool>("variable_temp")),
@@ -97,21 +99,21 @@ SakiyamaSecondaryElectronBC::computeQpResidual()
 
   if (_variable_temp)
   {
-    _temp = _T[_qp] + (_massip[_qp] + _massNeutral[_qp]) / (5.0*_massip[_qp] + 3.0*_massNeutral[_qp]) *
-                             (_massNeutral[_qp] * std::pow((_muip[_qp] * (_grad_potential[_qp] * _r_units).norm()),2) / _kb[_qp]);
+    _temp = _T[_qp] +
+            (_massip[_qp] + _massNeutral[_qp]) / (5.0 * _massip[_qp] + 3.0 * _massNeutral[_qp]) *
+                (_massNeutral[_qp] *
+                 std::pow((_muip[_qp] * (_grad_potential[_qp] * _r_units).norm()), 2) / _kb[_qp]);
   }
   else
   {
-    _temp = _T[_qp];  // Needs to be changed.
+    _temp = _T[_qp]; // Needs to be changed.
   }
 
   _v_thermal = std::sqrt(8 * _kb[_qp] * _temp / (M_PI * _massip[_qp]));
 
   _ion_flux = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]);
 
-
-  return  -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _ion_flux *
-             _normals[_qp];
+  return -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _ion_flux * _normals[_qp];
 }
 
 Real
@@ -145,22 +147,28 @@ SakiyamaSecondaryElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
 
     if (_variable_temp)
     {
-      Real _d_grad_potential_d_potential_mag = _grad_potential[_qp] * _r_units * _grad_phi[_j][_qp] * _r_units / (_grad_phi[_j][_qp] * _r_units).norm();
+      Real _d_grad_potential_d_potential_mag = _grad_potential[_qp] * _r_units *
+                                               _grad_phi[_j][_qp] * _r_units /
+                                               (_grad_phi[_j][_qp] * _r_units).norm();
 
-      _d_temp_d_potential = (_massip[_qp] + _massNeutral[_qp]) / (5.0*_massip[_qp] + 3.0*_massNeutral[_qp]) *
-                               (_massNeutral[_qp] * std::pow((_muip[_qp] * _d_grad_potential_d_potential_mag),2) / _kb[_qp]);
+      _d_temp_d_potential =
+          (_massip[_qp] + _massNeutral[_qp]) / (5.0 * _massip[_qp] + 3.0 * _massNeutral[_qp]) *
+          (_massNeutral[_qp] * std::pow((_muip[_qp] * _d_grad_potential_d_potential_mag), 2) /
+           _kb[_qp]);
     }
     else
     {
       _d_temp_d_potential = 0;
     }
 
+    _d_v_thermal_d_potential =
+        std::sqrt(8 * _kb[_qp] * _d_temp_d_potential / (M_PI * _massip[_qp]));
 
-    _d_v_thermal_d_potential = std::sqrt(8 * _kb[_qp] * _d_temp_d_potential / (M_PI * _massip[_qp]));
+    _d_ion_flux_d_potential =
+        _sgnip[_qp] * _muip[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_ip[_qp]);
 
-    _d_ion_flux_d_potential = _sgnip[_qp] * _muip[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_ip[_qp]);
-
-    return -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _d_ion_flux_d_potential * _normals[_qp];
+    return -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _d_ion_flux_d_potential *
+           _normals[_qp];
   }
 
   else if (jvar == _mean_en_id)
@@ -190,20 +198,22 @@ SakiyamaSecondaryElectronBC::computeQpOffDiagJacobian(unsigned int jvar)
 
     if (_variable_temp)
     {
-      _temp = _T[_qp] + (_massip[_qp] + _massNeutral[_qp]) / (5.0*_massip[_qp] + 3.0*_massNeutral[_qp]) *
-                               (_massNeutral[_qp] * std::pow((_muip[_qp] * (_grad_potential[_qp] * _r_units).norm()),2) / _kb[_qp]);
+      _temp = _T[_qp] +
+              (_massip[_qp] + _massNeutral[_qp]) / (5.0 * _massip[_qp] + 3.0 * _massNeutral[_qp]) *
+                  (_massNeutral[_qp] *
+                   std::pow((_muip[_qp] * (_grad_potential[_qp] * _r_units).norm()), 2) / _kb[_qp]);
     }
     else
     {
-      _temp = _T[_qp];  // Needs to be changed.
+      _temp = _T[_qp]; // Needs to be changed.
     }
 
     _v_thermal = std::sqrt(8 * _kb[_qp] * _temp / (M_PI * _massip[_qp]));
 
-    _d_ion_flux_d_ip = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) * _phi[_j][_qp];
+    _d_ion_flux_d_ip = _a * _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units *
+                       std::exp(_u[_qp]) * _phi[_j][_qp];
 
-    return -_test[_i][_qp] * _r_units * _a * _user_se_coeff *
-        _d_ion_flux_d_ip * _normals[_qp];
+    return -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _d_ion_flux_d_ip * _normals[_qp];
   }
 
   else

--- a/src/dgkernels/DGCoeffDiffusion.C
+++ b/src/dgkernels/DGCoeffDiffusion.C
@@ -25,9 +25,8 @@ validParams<DGCoeffDiffusion>()
   // See header file for sigma and epsilon
   params.addRequiredParam<Real>("sigma", "sigma");
   params.addRequiredParam<Real>("epsilon", "epsilon");
-  params.addClassDescription(
-    "The discontinuous Galerkin form of the generic diffusion term"
-    "(Densities must be in log form)");
+  params.addClassDescription("The discontinuous Galerkin form of the generic diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 
@@ -63,9 +62,10 @@ DGCoeffDiffusion::computeQpResidual(Moose::DGResidualType type)
       break;
 
     case Moose::Neighbor:
-      r += 0.5 * (_diff[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _normals[_qp] +
-                  _diff_neighbor[_qp] * std::exp(_u_neighbor[_qp]) * _grad_u_neighbor[_qp] *
-                      _normals[_qp]) *
+      r += 0.5 *
+           (_diff[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _normals[_qp] +
+            _diff_neighbor[_qp] * std::exp(_u_neighbor[_qp]) * _grad_u_neighbor[_qp] *
+                _normals[_qp]) *
            _test_neighbor[_i][_qp];
       r += _epsilon * 0.5 * _grad_test_neighbor[_i][_qp] * _normals[_qp] *
            (std::exp(_u[_qp]) - std::exp(_u_neighbor[_qp]));
@@ -90,8 +90,9 @@ DGCoeffDiffusion::computeQpJacobian(Moose::DGJacobianType type)
   {
 
     case Moose::ElementElement:
-      r -= 0.5 * _diff[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] +
-                               std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp]) *
+      r -= 0.5 * _diff[_qp] *
+           (std::exp(_u[_qp]) * _grad_phi[_j][_qp] +
+            std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp]) *
            _normals[_qp] * _test[_i][_qp];
       r += _epsilon * 0.5 * _grad_test[_i][_qp] * _normals[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp];
       r += _sigma / h_elem * std::exp(_u[_qp]) * _phi[_j][_qp] * _test[_i][_qp];
@@ -108,8 +109,9 @@ DGCoeffDiffusion::computeQpJacobian(Moose::DGJacobianType type)
       break;
 
     case Moose::NeighborElement:
-      r += 0.5 * _diff[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] +
-                               std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp]) *
+      r += 0.5 * _diff[_qp] *
+           (std::exp(_u[_qp]) * _grad_phi[_j][_qp] +
+            std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp]) *
            _normals[_qp] * _test_neighbor[_i][_qp];
       r += _epsilon * 0.5 * _grad_test_neighbor[_i][_qp] * _normals[_qp] * std::exp(_u[_qp]) *
            _phi[_j][_qp];

--- a/src/dgkernels/DGEFieldAdvection.C
+++ b/src/dgkernels/DGEFieldAdvection.C
@@ -22,8 +22,8 @@ validParams<DGEFieldAdvection>()
   InputParameters params = validParams<DGKernel>();
   params.addRequiredCoupledVar("potential", "The potential that drives advection.");
   params.addClassDescription(
-    "The discontinuous Galerkin form of the generic electric field driven advection term"
-    "(Densities must be in log form)");
+      "The discontinuous Galerkin form of the generic electric field driven advection term"
+      "(Densities must be in log form)");
   return params;
 }
 

--- a/src/indicators/AnalyticalDiffIndicator.C
+++ b/src/indicators/AnalyticalDiffIndicator.C
@@ -19,8 +19,8 @@ validParams<AnalyticalDiffIndicator>()
 {
   InputParameters params = validParams<ElementIntegralIndicator>();
   params.addRequiredParam<FunctionName>("function", "The analytic solution to compare against");
-  params.addClassDescription(
-    "Returns the difference between the function of the analytic solution vs the computed solution");
+  params.addClassDescription("Returns the difference between the function of the analytic solution "
+                             "vs the computed solution");
   return params;
 }
 

--- a/src/interfacekernels/InterfaceAdvection.C
+++ b/src/interfacekernels/InterfaceAdvection.C
@@ -32,11 +32,11 @@ validParams<InterfaceAdvection>()
   params.addRequiredParam<Real>("neighbor_position_units",
                                 "The units of position in the neighboring domain.");
   params.addClassDescription(
-    "Used to include the electric field driven advective flux of species"
-    "into or out of a neighboring subdomain. Currently this interface kernel"
-    "is specific to electrons because the transport coefficients are assumed"
-    "to be a function of the mean electron energy. A generic interface"
-    "kernel with constant transport coefficients will have a much simpler Jacobian");
+      "Used to include the electric field driven advective flux of species"
+      "into or out of a neighboring subdomain. Currently this interface kernel"
+      "is specific to electrons because the transport coefficients are assumed"
+      "to be a function of the mean electron energy. A generic interface"
+      "kernel with constant transport coefficients will have a much simpler Jacobian");
   return params;
 }
 

--- a/src/interfacekernels/InterfaceLogDiffusionElectrons.C
+++ b/src/interfacekernels/InterfaceLogDiffusionElectrons.C
@@ -30,8 +30,8 @@ validParams<InterfaceLogDiffusionElectrons>()
   params.addRequiredParam<Real>("neighbor_position_units",
                                 "The units of position in the neighboring domain.");
   params.addClassDescription(
-    "Used to include the diffusive flux of species into or out of a neighboring"
-    "subdomain. Currently specific to electrons.");
+      "Used to include the diffusive flux of species into or out of a neighboring"
+      "subdomain. Currently specific to electrons.");
   return params;
 }
 

--- a/src/kernels/ChargeSourceMoles_KV.C
+++ b/src/kernels/ChargeSourceMoles_KV.C
@@ -23,8 +23,8 @@ validParams<ChargeSourceMoles_KV>()
   params.addRequiredCoupledVar("charged", "The charged species");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addClassDescription(
-    "Used for adding charged sources to Poisson’s equation; This kernel"
-    "assumes that densities are measured in units of mol/volume as opposed to #/volume");
+      "Used for adding charged sources to Poisson’s equation; This kernel"
+      "assumes that densities are measured in units of mol/volume as opposed to #/volume");
   return params;
 }
 

--- a/src/kernels/CoeffDiffusion.C
+++ b/src/kernels/CoeffDiffusion.C
@@ -21,9 +21,8 @@ validParams<CoeffDiffusion>()
 {
   InputParameters params = validParams<Diffusion>();
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Generic diffusion term"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 
@@ -50,7 +49,8 @@ CoeffDiffusion::computeQpResidual()
 Real
 CoeffDiffusion::computeQpJacobian()
 {
-  return -_diffusivity[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                               std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+  return -_diffusivity[_qp] *
+         (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+          std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
          -_grad_test[_i][_qp] * _r_units;
 }

--- a/src/kernels/CoeffDiffusionElectrons.C
+++ b/src/kernels/CoeffDiffusionElectrons.C
@@ -20,9 +20,8 @@ validParams<CoeffDiffusionElectrons>()
   params.addRequiredCoupledVar("mean_en",
                                "The log of the product of mean energy times electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position");
-  params.addClassDescription(
-    "Electron specific diffusion term"
-    "(Electron density must be in log form)");
+  params.addClassDescription("Electron specific diffusion term"
+                             "(Electron density must be in log form)");
   return params;
 }
 
@@ -59,8 +58,9 @@ CoeffDiffusionElectrons::computeQpJacobian()
   _d_diffem_d_u =
       _d_diffem_d_actual_mean_en[_qp] * std::exp(_mean_en[_qp] - _u[_qp]) * -_phi[_j][_qp];
 
-  return -_diffem[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                          std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+  return -_diffem[_qp] *
+             (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+              std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
              -_grad_test[_i][_qp] * _r_units -
          _d_diffem_d_u * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units * -_grad_test[_i][_qp] *
              _r_units;

--- a/src/kernels/CoeffDiffusionEnergy.C
+++ b/src/kernels/CoeffDiffusionEnergy.C
@@ -19,9 +19,8 @@ validParams<CoeffDiffusionEnergy>()
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("em", "The log of the electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Electron energy specific diffusion term"
-    "(Densities must be in log form)");
+  params.addClassDescription("Electron energy specific diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 
@@ -57,8 +56,9 @@ CoeffDiffusionEnergy::computeQpJacobian()
 {
   _d_diffel_d_u = _d_diffel_d_actual_mean_en[_qp] * std::exp(_u[_qp] - _em[_qp]) * _phi[_j][_qp];
 
-  return -_diffel[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                          std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+  return -_diffel[_qp] *
+             (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+              std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
              -_grad_test[_i][_qp] * _r_units -
          _d_diffel_d_u * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units * -_grad_test[_i][_qp] *
              _r_units;

--- a/src/kernels/CoeffDiffusionLin.C
+++ b/src/kernels/CoeffDiffusionLin.C
@@ -21,9 +21,8 @@ validParams<CoeffDiffusionLin>()
 {
   InputParameters params = validParams<Diffusion>();
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Generic linear diffusion term"
-    "(Values are NOT in log form)");
+  params.addClassDescription("Generic linear diffusion term"
+                             "(Values are NOT in log form)");
   return params;
 }
 

--- a/src/kernels/DriftDiffusion.C
+++ b/src/kernels/DriftDiffusion.C
@@ -31,8 +31,8 @@ validParams<DriftDiffusion>()
   params.addParam<Real>("sign", "The sign of the charged particle.");
   params.addParam<bool>("use_material_props", true, "Whether to use a material for properties.");
   params.addClassDescription("Generic drift-diffusion equation that contains both"
-    "electric field driven advection and diffusion term"
-    "(Densities must be in log form)");
+                             "electric field driven advection and diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/DriftDiffusionElectrons.C
+++ b/src/kernels/DriftDiffusionElectrons.C
@@ -23,8 +23,8 @@ validParams<DriftDiffusionElectrons>()
                                "The log of the product of mean energy times electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position");
   params.addClassDescription("Electron specific drift-diffusion equation that contains both"
-    "electric field driven advection and diffusion term"
-    "(Densities must be in log form)");
+                             "electric field driven advection and diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 
@@ -78,8 +78,9 @@ DriftDiffusionElectrons::computeQpJacobian()
           _muem[_qp] * _sign[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp] * -_grad_potential[_qp] *
               _r_units) *
              -_grad_test[_i][_qp] * _r_units -
-         _diffem[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                         std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+         _diffem[_qp] *
+             (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+              std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
              -_grad_test[_i][_qp] * _r_units -
          _d_diffem_d_u * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units * -_grad_test[_i][_qp] *
              _r_units;

--- a/src/kernels/DriftDiffusionEnergy.C
+++ b/src/kernels/DriftDiffusionEnergy.C
@@ -22,8 +22,8 @@ validParams<DriftDiffusionEnergy>()
   params.addRequiredCoupledVar("em", "The log of the electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription("Electron energy specific drift-diffusion equation that contains both"
-    "electric field driven advection and diffusion term"
-    "(Densities must be in log form)");
+                             "electric field driven advection and diffusion term"
+                             "(Densities must be in log form)");
   return params;
 }
 
@@ -77,8 +77,9 @@ DriftDiffusionEnergy::computeQpJacobian()
           _muel[_qp] * _sign[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp] * -_grad_potential[_qp] *
               _r_units) *
              -_grad_test[_i][_qp] * _r_units -
-         _diffel[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
-                         std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
+         _diffel[_qp] *
+             (std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units +
+              std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units) *
              -_grad_test[_i][_qp] * _r_units -
          _d_diffel_d_u * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units * -_grad_test[_i][_qp] *
              _r_units;

--- a/src/kernels/DriftDiffusionUser.C
+++ b/src/kernels/DriftDiffusionUser.C
@@ -20,10 +20,11 @@ validParams<DriftDiffusionUser>()
   params.addRequiredParam<Real>("mu", "The mobility.");
   params.addRequiredParam<Real>("diff", "The diffusivity.");
   params.addRequiredParam<Real>("sign", "The charge sign of the drift-diffusing particle.");
-  params.addClassDescription("Generic drift-diffusion equation that contains both"
-    "electric field driven advection and diffusion term and that requires constant user defined"
-    "mobility and diffusivity"
-    "(Densities must be in log form)");
+  params.addClassDescription(
+      "Generic drift-diffusion equation that contains both"
+      "electric field driven advection and diffusion term and that requires constant user defined"
+      "mobility and diffusivity"
+      "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/EFieldAdvection.C
+++ b/src/kernels/EFieldAdvection.C
@@ -23,9 +23,8 @@ validParams<EFieldAdvection>()
   params.addRequiredCoupledVar(
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Generic electric field driven advection term"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic electric field driven advection term"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/EFieldAdvectionElectrons.C
+++ b/src/kernels/EFieldAdvectionElectrons.C
@@ -21,9 +21,8 @@ validParams<EFieldAdvectionElectrons>()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("mean_en", "The log of the mean energy.");
   params.addRequiredParam<Real>("position_units", "The units of position.");
-  params.addClassDescription(
-    "Electron specific electric field driven advection term"
-    "(Electron density must be in log form)");
+  params.addClassDescription("Electron specific electric field driven advection term"
+                             "(Electron density must be in log form)");
   return params;
 }
 

--- a/src/kernels/EFieldAdvectionEnergy.C
+++ b/src/kernels/EFieldAdvectionEnergy.C
@@ -21,9 +21,8 @@ validParams<EFieldAdvectionEnergy>()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("em", "The log of the electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position");
-  params.addClassDescription(
-    "Electron energy specific electric field driven advection term"
-    "(Densities must be in log form)");
+  params.addClassDescription("Electron energy specific electric field driven advection term"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/EFieldArtDiff.C
+++ b/src/kernels/EFieldArtDiff.C
@@ -24,9 +24,8 @@ validParams<EFieldArtDiff>()
                                "The potential for calculating the advection velocity.");
   params.addParam<Real>("scale", 1., "Amount to scale artificial diffusion.");
   params.addRequiredParam<Real>("position_units", "Units of position");
-  params.addClassDescription(
-    "Generic artificial electric field driven advection term"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic artificial electric field driven advection term"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/EFieldMagnitudeSource.C
+++ b/src/kernels/EFieldMagnitudeSource.C
@@ -19,7 +19,7 @@ validParams<EFieldMagnitudeSource>()
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("potential", "The electric potential.");
   params.addClassDescription(
-    "Electric field magnitude term based on the electrostatic approximation");
+      "Electric field magnitude term based on the electrostatic approximation");
   return params;
 }
 

--- a/src/kernels/ElectronEnergyLossFromElastic.C
+++ b/src/kernels/ElectronEnergyLossFromElastic.C
@@ -21,8 +21,8 @@ validParams<ElectronEnergyLossFromElastic>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Electron energy loss term for elastic collisions using Townsend coefficient"
-    "(Densities must be in log form)");
+      "Electron energy loss term for elastic collisions using Townsend coefficient"
+      "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronEnergyLossFromExcitation.C
+++ b/src/kernels/ElectronEnergyLossFromExcitation.C
@@ -21,9 +21,9 @@ validParams<ElectronEnergyLossFromExcitation>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Electron energy loss term for inelastic excitation collisions"
-    "using Townsend coefficient; Eex is the energy lost in Volts in a single"
-    "excitation collision (Densities must be in log form)");
+      "Electron energy loss term for inelastic excitation collisions"
+      "using Townsend coefficient; Eex is the energy lost in Volts in a single"
+      "excitation collision (Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronEnergyLossFromIonization.C
+++ b/src/kernels/ElectronEnergyLossFromIonization.C
@@ -21,9 +21,9 @@ validParams<ElectronEnergyLossFromIonization>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Electron energy loss term for inelastic ionization collisions"
-    "using Townsend coefficient; Eiz is the energy lost in Volts in a single"
-    "ionization collision (Densities must be in log form)");
+      "Electron energy loss term for inelastic ionization collisions"
+      "using Townsend coefficient; Eiz is the energy lost in Volts in a single"
+      "ionization collision (Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronEnergyTermElasticRate.C
+++ b/src/kernels/ElectronEnergyTermElasticRate.C
@@ -23,8 +23,8 @@ validParams<ElectronEnergyTermElasticRate>()
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredCoupledVar("potential", "The potential.");
   params.addClassDescription(
-    "Electron energy loss term for elastic collisions using reaction rate coefficient"
-    "(Densities must be in log form)");
+      "Electron energy loss term for elastic collisions using reaction rate coefficient"
+      "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronEnergyTermRate.C
+++ b/src/kernels/ElectronEnergyTermRate.C
@@ -24,9 +24,9 @@ validParams<ElectronEnergyTermRate>()
   params.addParam<Real>("threshold_energy", 0.0, "Energy required for reaction to take place.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-    "Electron energy loss term for inelastic collisions"
-    "using reaction rate coefficient; Threshold energy is the energy lost in Volts in a single"
-    "collision (Densities must be in log form)");
+      "Electron energy loss term for inelastic collisions"
+      "using reaction rate coefficient; Threshold energy is the energy lost in Volts in a single"
+      "collision (Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronTimeDerivative.C
+++ b/src/kernels/ElectronTimeDerivative.C
@@ -18,8 +18,7 @@ validParams<ElectronTimeDerivative>()
 {
   InputParameters params = validParams<TimeKernel>();
   params.addParam<bool>("lumping", false, "True for mass matrix lumping, false otherwise");
-  params.addClassDescription(
-    "Generic accumulation term for variables in log form.");
+  params.addClassDescription("Generic accumulation term for variables in log form.");
   return params;
 }
 

--- a/src/kernels/ElectronsFromIonization.C
+++ b/src/kernels/ElectronsFromIonization.C
@@ -32,8 +32,8 @@ validParams<ElectronsFromIonization>()
   params.addParam<Real>("diffem", "The diffusivity.");
   params.addParam<Real>("alpha_iz", "The Townsend ionization coefficient.");
   params.addClassDescription(
-    "Rate of production of electrons from ionization using Townsend coefficient"
-    "(Electron density must be in log form)");
+      "Rate of production of electrons from ionization using Townsend coefficient"
+      "(Electron density must be in log form)");
   return params;
 }
 

--- a/src/kernels/ElectronsFromIonizationUser.C
+++ b/src/kernels/ElectronsFromIonizationUser.C
@@ -20,9 +20,9 @@ validParams<ElectronsFromIonizationUser>()
   params.addRequiredParam<Real>("muem", "The mobility.");
   params.addRequiredParam<Real>("diffem", "The diffusivity.");
   params.addRequiredParam<Real>("alpha_iz", "The Townsend ionization coefficient.");
-  params.addClassDescription(
-    "Rate of production of electrons from ionization that requires constant user defined coefficients"
-    "(Electron density must be in log form)");
+  params.addClassDescription("Rate of production of electrons from ionization that requires "
+                             "constant user defined coefficients"
+                             "(Electron density must be in log form)");
   return params;
 }
 

--- a/src/kernels/ExcitationReaction.C
+++ b/src/kernels/ExcitationReaction.C
@@ -24,11 +24,10 @@ validParams<ExcitationReaction>()
   params.addRequiredCoupledVar("potential", "The potential.");
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addRequiredParam<bool>("reactant",
-                                "Checks if the variable is the reactant.");
+  params.addRequiredParam<bool>("reactant", "Checks if the variable is the reactant.");
   params.addClassDescription(
-    "Rate of production of metastables from excitation using Townsend coefficient"
-    "(Densities must be in log form)");
+      "Rate of production of metastables from excitation using Townsend coefficient"
+      "(Densities must be in log form)");
   return params;
 }
 
@@ -71,11 +70,14 @@ ExcitationReaction::computeQpResidual()
   // ("deexcitation"). Will be generalized into separate class
   // ("ElectronImpactReaction") to accept any townsend coefficient for any
   // generic electron-impact reaction.
-  if (_reactant) {
+  if (_reactant)
+  {
     Real alpha = _alpha_source[_qp] / _n_gas[_qp] * std::exp(_u[_qp]);
     Real iz_term = alpha * electron_flux_mag;
     return _test[_i][_qp] * iz_term;
-  } else {
+  }
+  else
+  {
     Real alpha = _alpha_source[_qp];
     Real iz_term = alpha * electron_flux_mag;
     return -_test[_i][_qp] * iz_term;
@@ -88,10 +90,13 @@ ExcitationReaction::computeQpJacobian()
   Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) -
                             _diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units)
                                .norm();
-  if (_reactant) {
+  if (_reactant)
+  {
     Real d_alpha = _alpha_source[_qp] / _n_gas[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp];
     return d_alpha * electron_flux_mag * -_test[_i][_qp];
-  } else {
+  }
+  else
+  {
     return 0.0;
   }
 }
@@ -101,9 +106,12 @@ ExcitationReaction::computeQpOffDiagJacobian(unsigned int jvar)
 {
   Real mult_factor = -1.0;
   Real alpha = 1.0;
-  if (_reactant) {
+  if (_reactant)
+  {
     alpha = _alpha_source[_qp] / _n_gas[_qp] * std::exp(_u[_qp]);
-  } else {
+  }
+  else
+  {
     alpha = _alpha_source[_qp];
   }
 
@@ -139,7 +147,6 @@ ExcitationReaction::computeQpOffDiagJacobian(unsigned int jvar)
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em /
                                   (electron_flux_mag + std::numeric_limits<double>::epsilon());
 
-
   Real d_iz_term_d_potential = (alpha * d_electron_flux_mag_d_potential);
   Real d_iz_term_d_mean_en =
       (electron_flux_mag * d_iz_d_mean_en + alpha * d_electron_flux_mag_d_mean_en);
@@ -149,13 +156,13 @@ ExcitationReaction::computeQpOffDiagJacobian(unsigned int jvar)
     mult_factor = -1.0 * mult_factor;
 
   if (jvar == _potential_id)
-    return mult_factor*_test[_i][_qp] * d_iz_term_d_potential;
+    return mult_factor * _test[_i][_qp] * d_iz_term_d_potential;
 
   else if (jvar == _mean_en_id)
-    return mult_factor*_test[_i][_qp] * d_iz_term_d_mean_en;
+    return mult_factor * _test[_i][_qp] * d_iz_term_d_mean_en;
 
   else if (jvar == _em_id)
-    return mult_factor*_test[_i][_qp] * d_iz_term_d_em;
+    return mult_factor * _test[_i][_qp] * d_iz_term_d_em;
 
   else
     return 0.0;

--- a/src/kernels/IonsFromIonization.C
+++ b/src/kernels/IonsFromIonization.C
@@ -21,9 +21,8 @@ validParams<IonsFromIonization>()
   params.addRequiredCoupledVar("potential", "The potential.");
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Rate of production of ions from ionization using Townsend coefficient"
-    "(Ion density must be in log form)");
+  params.addClassDescription("Rate of production of ions from ionization using Townsend coefficient"
+                             "(Ion density must be in log form)");
   return params;
 }
 

--- a/src/kernels/JouleHeating.C
+++ b/src/kernels/JouleHeating.C
@@ -23,9 +23,8 @@ validParams<JouleHeating>()
   params.addRequiredCoupledVar("em", "The electron density.");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addClassDescription(
-    "Joule heating term for electrons"
-    "(Densities must be in log form)");
+  params.addClassDescription("Joule heating term for electrons"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/LogStabilizationMoles.C
+++ b/src/kernels/LogStabilizationMoles.C
@@ -20,8 +20,8 @@ validParams<LogStabilizationMoles>()
   params.addRequiredParam<Real>("offset",
                                 "The offset parameter that goes into the exponential function");
   params.addClassDescription(
-    "Kernel stabilizes solution variable u in places where u → 0; b is the offset value"
-    "specified by the user. A typical value for b is 20.");
+      "Kernel stabilizes solution variable u in places where u → 0; b is the offset value"
+      "specified by the user. A typical value for b is 20.");
   return params;
 }
 

--- a/src/kernels/PotentialGradientSource.C
+++ b/src/kernels/PotentialGradientSource.C
@@ -18,8 +18,7 @@ validParams<PotentialGradientSource>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("potential", "The potential.");
-  params.addClassDescription(
-    "Duplicate kernel of 'EFieldMagnitudeSource'");
+  params.addClassDescription("Duplicate kernel of 'EFieldMagnitudeSource'");
   return params;
 }
 

--- a/src/kernels/ProductAABBRxn.C
+++ b/src/kernels/ProductAABBRxn.C
@@ -21,10 +21,9 @@ validParams<ProductAABBRxn>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("v", "The variable that is reacting to create u.");
-  params.addClassDescription(
-    "Generic second order reaction source term in which two molecules of"
-    "v are produced from two molecules of u"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic second order reaction source term in which two molecules of"
+                             "v are produced from two molecules of u"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ProductFirstOrderRxn.C
+++ b/src/kernels/ProductFirstOrderRxn.C
@@ -21,9 +21,8 @@ validParams<ProductFirstOrderRxn>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredCoupledVar("v", "The variable that is reacting to create u.");
-  params.addClassDescription(
-    "Generic first order reaction source term for u (v is the reactant"
-    "and densities must be in log form)");
+  params.addClassDescription("Generic first order reaction source term for u (v is the reactant"
+                             "and densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ReactantAARxn.C
+++ b/src/kernels/ReactantAARxn.C
@@ -20,10 +20,9 @@ InputParameters
 validParams<ReactantAARxn>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addClassDescription(
-    "Generic second order reaction sink term for u in which two"
-    "molecules of u are consumed"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic second order reaction sink term for u in which two"
+                             "molecules of u are consumed"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ReactantFirstOrderRxn.C
+++ b/src/kernels/ReactantFirstOrderRxn.C
@@ -20,9 +20,8 @@ InputParameters
 validParams<ReactantFirstOrderRxn>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addClassDescription(
-    "Generic first order reaction sink term for u (u is the reactant)"
-    "(Densities must be in log form)");
+  params.addClassDescription("Generic first order reaction sink term for u (u is the reactant)"
+                             "(Densities must be in log form)");
   return params;
 }
 

--- a/src/kernels/ScaledReaction.C
+++ b/src/kernels/ScaledReaction.C
@@ -19,15 +19,15 @@ validParams<ScaledReaction>()
   InputParameters params = validParams<Kernel>();
   params.addRequiredParam<Real>("collision_freq", "The ion-neutral collision frequency.");
   params.addClassDescription(
-    "The multiple of a given variable"
-    "(Used for calculating the effective ion potential for a given collision frequency)");
+      "The multiple of a given variable"
+      "(Used for calculating the effective ion potential for a given collision frequency)");
   return params;
 }
 
 ScaledReaction::ScaledReaction(const InputParameters & parameters)
   : Kernel(parameters),
 
-  _nu(getParam<Real>("collision_freq"))
+    _nu(getParam<Real>("collision_freq"))
 
 {
 }

--- a/src/kernels/UserSource.C
+++ b/src/kernels/UserSource.C
@@ -18,8 +18,7 @@ validParams<UserSource>()
 {
   InputParameters params = validParams<Kernel>();
   params.addRequiredParam<Real>("source_magnitude", "The numerical value of the source magnitude.");
-  params.addClassDescription(
-    "User defined source term");
+  params.addClassDescription("User defined source term");
   return params;
 }
 

--- a/src/materials/Gas.C
+++ b/src/materials/Gas.C
@@ -54,9 +54,8 @@ validParams<Gas>()
   params.addCoupledVar("em", "Species concentration needed to calculate the poisson source");
   params.addCoupledVar("mean_en", "The electron mean energy in log form.");
   params.addCoupledVar("ip", "The ion density.");
-  params.addClassDescription(
-    "Material properties of electron and ions for argon gas"
-     "(Defines reaction properties with Townsend coefficients)");
+  params.addClassDescription("Material properties of electron and ions for argon gas"
+                             "(Defines reaction properties with Townsend coefficients)");
   return params;
 }
 
@@ -371,15 +370,17 @@ Gas::computeQpProperties()
 
   _kiz[_qp] = 2.34e-14 * std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]);
   _d_kiz_d_actual_mean_en[_qp] =
-      2.34e-14 * (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.34e-14 *
+      (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
   _kex[_qp] = 2.48e-14 * std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]);
   _d_kex_d_actual_mean_en[_qp] =
-      2.48e-14 * (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.48e-14 *
+      (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
   // _kel[_qp] = 2.3363-14 * std::pow(_TemVolts[_qp], 1.609) * std::exp(.0618 *
   // std::pow(std::log(_TemVolts[_qp]), 2.) - .1171 * std::pow(std::log(_TemVolts[_qp]), 3.));

--- a/src/materials/GasBase.C
+++ b/src/materials/GasBase.C
@@ -58,9 +58,8 @@ validParams<GasBase>()
   params.addCoupledVar("em", "Species concentration needed to calculate the poisson source");
   params.addCoupledVar("mean_en", "The electron mean energy in log form.");
   params.addCoupledVar("ip", "The ion density.");
-  params.addClassDescription(
-    "Material properties of electrons"
-    "(Defines reaction properties with Townsend coefficients)");
+  params.addClassDescription("Material properties of electrons"
+                             "(Defines reaction properties with Townsend coefficients)");
   return params;
 }
 
@@ -256,7 +255,6 @@ GasBase::computeQpProperties()
   _sgnmean_en[_qp] = -1.;
   _diffpotential[_qp] = _eps[_qp];
 
-
   // With the exception of temperature/energy (generally in eV), all properties are in standard SI
   // units unless otherwise indicated
 
@@ -306,7 +304,6 @@ GasBase::computeQpProperties()
   _iz_coeff_energy_a[_qp] = 1.52165930e+8;
   _iz_coeff_energy_b[_qp] = -2.87277596e-1;
   _iz_coeff_energy_c[_qp] = 5.51972192e+1;
-
 
   _actual_mean_energy[_qp] = std::exp(_mean_en[_qp] - _em[_qp]);
   _alpha_iz[_qp] = _alpha_interpolation.sample(_actual_mean_energy[_qp]);
@@ -359,20 +356,22 @@ GasBase::computeQpProperties()
 
   _kiz[_qp] = 2.34e-14 * std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]);
   _d_kiz_d_actual_mean_en[_qp] =
-      2.34e-14 * (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.34e-14 *
+      (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
   _kex[_qp] = 2.48e-14 * std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]);
   _kArp[_qp] = 2.48e-14 * std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]);
   _d_kex_d_actual_mean_en[_qp] =
-      2.48e-14 * (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.48e-14 *
+      (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
 
   // EField calculation test
-  _EField[_qp] = _grad_potential[_qp](0)*_r_units;
+  _EField[_qp] = _grad_potential[_qp](0) * _r_units;
 
   // Townsend calculation test
   // _alpha_ArIz[_qp] = _n_gas[_qp]*_kArIz[_qp]/(_muem[_qp]*_EField[_qp]);

--- a/src/materials/GasElectronMoments.C
+++ b/src/materials/GasElectronMoments.C
@@ -58,11 +58,12 @@ validParams<GasElectronMoments>()
 
   params.addParam<Real>("user_electron_mobility", 0, "The electron mobility coefficient.");
   params.addParam<Real>("user_electron_diffusion_coeff", 0, "The electron diffusion coefficient.");
-  params.addParam<bool>("pressure_dependent_electron_coeff",false,
-                      "Are the values for the electron mobility and diffusion coefficient dependent on gas pressure");
-  params.addClassDescription(
-    "Material properties of electrons"
-    "(Defines reaction properties with rate coefficients)");
+  params.addParam<bool>("pressure_dependent_electron_coeff",
+                        false,
+                        "Are the values for the electron mobility and diffusion coefficient "
+                        "dependent on gas pressure");
+  params.addClassDescription("Material properties of electrons"
+                             "(Defines reaction properties with rate coefficients)");
 
   return params;
 }
@@ -188,9 +189,9 @@ GasElectronMoments::GasElectronMoments(const InputParameters & parameters)
     _voltage_scaling = 1000;
 
   std::vector<Real> actual_mean_energy;
-  //std::vector<Real> alpha;
-  //std::vector<Real> alphaEx;
-  //std::vector<Real> alphaEl;
+  // std::vector<Real> alpha;
+  // std::vector<Real> alphaEx;
+  // std::vector<Real> alphaEl;
   std::vector<Real> mu;
   std::vector<Real> diff;
   // std::vector<Real> d_alpha_d_actual_mean_energy;
@@ -206,12 +207,12 @@ GasElectronMoments::GasElectronMoments(const InputParameters & parameters)
     while (myfile >> value)
     {
       actual_mean_energy.push_back(value);
-      //myfile >> value;
-      //alpha.push_back(value);
-      //myfile >> value;
-      //alphaEx.push_back(value);
-      //myfile >> value;
-      //alphaEl.push_back(value);
+      // myfile >> value;
+      // alpha.push_back(value);
+      // myfile >> value;
+      // alphaEx.push_back(value);
+      // myfile >> value;
+      // alphaEl.push_back(value);
       myfile >> value;
       mu.push_back(value);
       myfile >> value;
@@ -270,114 +271,121 @@ GasElectronMoments::computeQpProperties()
   // if (!_jac_test)
   // {
 
-  if (_pressure_dependent) //If the mobility and diff. does depend on pressure
+  if (_pressure_dependent) // If the mobility and diff. does depend on pressure
   {
 
-  if (_interp_trans_coeffs)
-  {
-    if (_ramp_trans_coeffs)
+    if (_interp_trans_coeffs)
     {
-      _muem[_qp] =
-          (std::tanh(_t / 1e-6) * _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
-           (1. - std::tanh(_t / 1e-6)) * .0352) *
-          _voltage_scaling * _time_units * _N_inverse;
-      _d_muem_d_actual_mean_en[_qp] =
-          std::tanh(_t / 1e-6) *
-          _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units * _N_inverse;
-      _diffem[_qp] =
-          std::tanh(_t / 1e-6) * _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
-          (1. - std::tanh(_t / 1e-6)) * .30 * _time_units * _N_inverse;
-      _d_diffem_d_actual_mean_en[_qp] =
-          std::tanh(_t / 1e-6) *
-          _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units * _N_inverse;
+      if (_ramp_trans_coeffs)
+      {
+        _muem[_qp] =
+            (std::tanh(_t / 1e-6) * _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
+             (1. - std::tanh(_t / 1e-6)) * .0352) *
+            _voltage_scaling * _time_units * _N_inverse;
+        _d_muem_d_actual_mean_en[_qp] =
+            std::tanh(_t / 1e-6) *
+            _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) *
+            _voltage_scaling * _time_units * _N_inverse;
+        _diffem[_qp] =
+            std::tanh(_t / 1e-6) * _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
+            (1. - std::tanh(_t / 1e-6)) * .30 * _time_units * _N_inverse;
+        _d_diffem_d_actual_mean_en[_qp] =
+            std::tanh(_t / 1e-6) *
+            _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units *
+            _N_inverse;
+      }
+      else
+      {
+        _muem[_qp] = _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) *
+                     _voltage_scaling * _time_units * _N_inverse;
+        _d_muem_d_actual_mean_en[_qp] =
+            _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) *
+            _voltage_scaling * _time_units * _N_inverse;
+        _diffem[_qp] = _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) *
+                       _time_units * _N_inverse;
+        _d_diffem_d_actual_mean_en[_qp] =
+            _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units *
+            _N_inverse;
+      }
     }
     else
     {
-      _muem[_qp] = _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units * _N_inverse;
-      _d_muem_d_actual_mean_en[_qp] =
-          _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units * _N_inverse;
-      _diffem[_qp] = _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units * _N_inverse;
-      _d_diffem_d_actual_mean_en[_qp] =
-          _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units * _N_inverse;
+
+      // Need to Change
+      // From bolos at atmospheric pressure and an EField of 2e5 V/m
+      //_muem[_qp] =
+      //    0.0352103411399 * _voltage_scaling * _time_units; // units of m^2/(kV*s) if
+      //    _voltage_scaling = 1000
+      _muem[_qp] = _user_muem * _voltage_scaling * _time_units * _N_inverse;
+      _d_muem_d_actual_mean_en[_qp] = 0.0;
+      //_diffem[_qp] = 0.297951680159 * _time_units;
+      _diffem[_qp] = _user_diffem * _time_units * _N_inverse;
+      _d_diffem_d_actual_mean_en[_qp] = 0.0;
     }
   }
-  else
+
+  else // If the mobility and diff. does not depend on pressure
   {
 
-    //Need to Change
-    // From bolos at atmospheric pressure and an EField of 2e5 V/m
-    //_muem[_qp] =
-    //    0.0352103411399 * _voltage_scaling * _time_units; // units of m^2/(kV*s) if _voltage_scaling = 1000
-    _muem[_qp] =
-        _user_muem * _voltage_scaling * _time_units * _N_inverse;
-    _d_muem_d_actual_mean_en[_qp] = 0.0;
-    //_diffem[_qp] = 0.297951680159 * _time_units;
-    _diffem[_qp] = _user_diffem * _time_units * _N_inverse;
-    _d_diffem_d_actual_mean_en[_qp] = 0.0;
+    if (_interp_trans_coeffs)
+    {
+      if (_ramp_trans_coeffs)
+      {
+        _muem[_qp] =
+            (std::tanh(_t / 1e-6) * _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
+             (1. - std::tanh(_t / 1e-6)) * .0352) *
+            _voltage_scaling * _time_units;
+        _d_muem_d_actual_mean_en[_qp] =
+            std::tanh(_t / 1e-6) *
+            _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) *
+            _voltage_scaling * _time_units;
+        _diffem[_qp] =
+            std::tanh(_t / 1e-6) * _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
+            (1. - std::tanh(_t / 1e-6)) * .30 * _time_units;
+        _d_diffem_d_actual_mean_en[_qp] =
+            std::tanh(_t / 1e-6) *
+            _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
+      }
+      else
+      {
+        _muem[_qp] = _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) *
+                     _voltage_scaling * _time_units;
+        _d_muem_d_actual_mean_en[_qp] =
+            _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) *
+            _voltage_scaling * _time_units;
+        _diffem[_qp] = _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
+        _d_diffem_d_actual_mean_en[_qp] =
+            _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
+      }
+    }
+    else
+    {
+
+      // Need to Change
+      // From bolos at atmospheric pressure and an EField of 2e5 V/m
+      //_muem[_qp] =
+      //    0.0352103411399 * _voltage_scaling * _time_units; // units of m^2/(kV*s) if
+      //    _voltage_scaling = 1000
+      _muem[_qp] = _user_muem * _voltage_scaling * _time_units;
+      _d_muem_d_actual_mean_en[_qp] = 0.0;
+      //_diffem[_qp] = 0.297951680159 * _time_units;
+      _diffem[_qp] = _user_diffem * _time_units;
+      _d_diffem_d_actual_mean_en[_qp] = 0.0;
+    }
   }
 
-}
-
-else //If the mobility and diff. does not depend on pressure
-{
-
-if (_interp_trans_coeffs)
-{
-  if (_ramp_trans_coeffs)
-  {
-    _muem[_qp] =
-        (std::tanh(_t / 1e-6) * _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
-         (1. - std::tanh(_t / 1e-6)) * .0352) *
-        _voltage_scaling * _time_units;
-    _d_muem_d_actual_mean_en[_qp] =
-        std::tanh(_t / 1e-6) *
-        _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units;
-    _diffem[_qp] =
-        std::tanh(_t / 1e-6) * _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) +
-        (1. - std::tanh(_t / 1e-6)) * .30 * _time_units;
-    _d_diffem_d_actual_mean_en[_qp] =
-        std::tanh(_t / 1e-6) *
-        _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
-  }
-  else
-  {
-    _muem[_qp] = _mu_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units;
-    _d_muem_d_actual_mean_en[_qp] =
-        _mu_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _voltage_scaling * _time_units;
-    _diffem[_qp] = _diff_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
-    _d_diffem_d_actual_mean_en[_qp] =
-        _diff_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp])) * _time_units;
-  }
-}
-else
-{
-
-  //Need to Change
-  // From bolos at atmospheric pressure and an EField of 2e5 V/m
-  //_muem[_qp] =
-  //    0.0352103411399 * _voltage_scaling * _time_units; // units of m^2/(kV*s) if _voltage_scaling = 1000
-  _muem[_qp] =
-      _user_muem * _voltage_scaling * _time_units;
-  _d_muem_d_actual_mean_en[_qp] = 0.0;
-  //_diffem[_qp] = 0.297951680159 * _time_units;
-  _diffem[_qp] = _user_diffem * _time_units;
-  _d_diffem_d_actual_mean_en[_qp] = 0.0;
-}
-
-}
-
-  //From H.W. Ellis for He^+ at T=300, K_0=10.6 [cm^2/Vs] and k_0=mu*(p/760)*(273.15/T)
-  //Using Einstein relation for diff, where diff=(mu*k_b*T)/e
+  // From H.W. Ellis for He^+ at T=300, K_0=10.6 [cm^2/Vs] and k_0=mu*(p/760)*(273.15/T)
+  // Using Einstein relation for diff, where diff=(mu*k_b*T)/e
   //_muArp[_qp] = 1.16e-3 * _voltage_scaling * _time_units;
-      //10.6 * 0.0001 * _voltage_scaling * _time_units
-      //* (300 / 273.15) * (760 / _p_gas[_qp]); // units of m^2/(kV*s) if _voltage_scaling = 1000
+  // 10.6 * 0.0001 * _voltage_scaling * _time_units
+  //* (300 / 273.15) * (760 / _p_gas[_qp]); // units of m^2/(kV*s) if _voltage_scaling = 1000
   //_diffArp[_qp] = _muArp[_qp] * _k_boltz[_qp] * 300 / _e[_qp]; // covert to m^2 and include press
 
   // 100 times less than electrons
   // _muArp[_qp] = 3.52e-4;
   // _diffArp[_qp] = 2.98e-3;
 
-  //Might need to change?
+  // Might need to change?
   // From curve fitting with bolos
 
   //_iz_coeff_efield_a[_qp] = 1.43171672e-1;
@@ -396,28 +404,28 @@ else
   //       _iz_coeff_energy_b[_qp] = -2.70610234e-1;
   //       _iz_coeff_energy_c[_qp] = 7.64727794e+1;
   // }
-/*
-  _actual_mean_energy[_qp] = std::exp(_mean_en[_qp] - _em[_qp]);
-  _alpha_iz[_qp] = _alpha_interpolation.sample(_actual_mean_energy[_qp]);
-  _d_iz_d_actual_mean_en[_qp] =
-      _alpha_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
-  // _d_iz_d_actual_mean_en[_qp] =
-  // _d_alpha_d_actual_mean_energy_interpolation.sample(std::exp(_mean_en[_qp]-_em[_qp]));
-  _alpha_ex[_qp] = _alphaEx_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp]));
-  _d_ex_d_actual_mean_en[_qp] =
-      _alphaEx_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
-  if (_interp_elastic_coeff)
-  {
-    _alpha_el[_qp] = _alphaEl_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp]));
-    _d_el_d_actual_mean_en[_qp] =
-        _alphaEl_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
-  }
-  else
-  {
-    _alpha_el[_qp] = 5e8;
-    _d_el_d_actual_mean_en[_qp] = 0.0;
-  }
-  */
+  /*
+    _actual_mean_energy[_qp] = std::exp(_mean_en[_qp] - _em[_qp]);
+    _alpha_iz[_qp] = _alpha_interpolation.sample(_actual_mean_energy[_qp]);
+    _d_iz_d_actual_mean_en[_qp] =
+        _alpha_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
+    // _d_iz_d_actual_mean_en[_qp] =
+    // _d_alpha_d_actual_mean_energy_interpolation.sample(std::exp(_mean_en[_qp]-_em[_qp]));
+    _alpha_ex[_qp] = _alphaEx_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp]));
+    _d_ex_d_actual_mean_en[_qp] =
+        _alphaEx_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
+    if (_interp_elastic_coeff)
+    {
+      _alpha_el[_qp] = _alphaEl_interpolation.sample(std::exp(_mean_en[_qp] - _em[_qp]));
+      _d_el_d_actual_mean_en[_qp] =
+          _alphaEl_interpolation.sampleDerivative(std::exp(_mean_en[_qp] - _em[_qp]));
+    }
+    else
+    {
+      _alpha_el[_qp] = 5e8;
+      _d_el_d_actual_mean_en[_qp] = 0.0;
+    }
+    */
 
   //_el_coeff_energy_a[_qp] = 1.60638169e-13;
   //_el_coeff_energy_b[_qp] = 3.17917979e-1;
@@ -450,7 +458,7 @@ else
     _d_diffmean_en_d_actual_mean_en[_qp] = 0.0;
   }
 
-  //Might needed to change
+  // Might needed to change
   _rate_coeff_elastic[_qp] = 1e-13;
 
   _TemVolts[_qp] = 2. / 3. * std::exp(_mean_en[_qp] - _em[_qp]);
@@ -458,15 +466,17 @@ else
 
   _kiz[_qp] = 2.34e-14 * std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]);
   _d_kiz_d_actual_mean_en[_qp] =
-      2.34e-14 * (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.34e-14 *
+      (.59 * std::pow(_TemVolts[_qp], .59 - 1.) * std::exp(-17.44 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .59) * std::exp(-17.44 / _TemVolts[_qp]) * 17.44 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
   _kex[_qp] = 2.48e-14 * std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]);
   _d_kex_d_actual_mean_en[_qp] =
-      2.48e-14 * (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
-                  std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
-                      std::pow(_TemVolts[_qp], 2.)) *
+      2.48e-14 *
+      (.33 * std::pow(_TemVolts[_qp], .33 - 1.) * std::exp(-12.78 / _TemVolts[_qp]) +
+       std::pow(_TemVolts[_qp], .33) * std::exp(-12.78 / _TemVolts[_qp]) * 12.78 /
+           std::pow(_TemVolts[_qp], 2.)) *
       2. / 3.;
   // _kel[_qp] = 2.3363-14 * std::pow(_TemVolts[_qp], 1.609) * std::exp(.0618 *
   // std::pow(std::log(_TemVolts[_qp]), 2.) - .1171 * std::pow(std::log(_TemVolts[_qp]), 3.));

--- a/src/materials/HeavySpecies.C
+++ b/src/materials/HeavySpecies.C
@@ -26,9 +26,8 @@ validParams<HeavySpecies>()
   params.addRequiredParam<Real>("heavy_species_mass", "Mass of the heavy species");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addRequiredParam<Real>("heavy_species_charge", "Charge of heavy species.");
-  params.addClassDescription(
-    "Material properties of ions"
-    "(Old Materials Object, use HeavySepciesMaterial.C instead)");
+  params.addClassDescription("Material properties of ions"
+                             "(Old Materials Object, use HeavySepciesMaterial.C instead)");
   return params;
 }
 

--- a/src/materials/Water.C
+++ b/src/materials/Water.C
@@ -39,8 +39,7 @@ validParams<Water>()
   params.addCoupledVar("O3", "ozone molecules");
   params.addCoupledVar("O3m", "ozone anions");
   params.addCoupledVar("potential", "The potential");
-  params.addClassDescription(
-    "Material properties of water species");
+  params.addClassDescription("Material properties of water species");
   return params;
 }
 

--- a/src/meshmodifiers/NodeAndSidesetBetweenSubdomains.C
+++ b/src/meshmodifiers/NodeAndSidesetBetweenSubdomains.C
@@ -28,9 +28,8 @@ validParams<NodeAndSidesetBetweenSubdomains>()
                                          "The second block for which to draw a sideset between");
   params.addRequiredParam<std::vector<BoundaryName>>("new_boundary",
                                                      "The name of the boundary to create");
-  params.addClassDescription(
-    "Creates a boundary between two block"
-    "(This boundary is one way when used with InterfaceKernels)");
+  params.addClassDescription("Creates a boundary between two block"
+                             "(This boundary is one way when used with InterfaceKernels)");
   return params;
 }
 

--- a/src/postprocessors/PlasmaFrequencyInverse.C
+++ b/src/postprocessors/PlasmaFrequencyInverse.C
@@ -24,8 +24,7 @@ validParams<PlasmaFrequencyInverse>()
   InputParameters params = validParams<ElementVariablePostprocessor>();
   params.addRequiredParam<bool>("use_moles",
                                 "Whether to use units of moles as opposed to # of molecules.");
-  params.addClassDescription(
-    "Returns the inverse of the peak electron frequency");
+  params.addClassDescription("Returns the inverse of the peak electron frequency");
 
   return params;
 }
@@ -42,33 +41,32 @@ void
 PlasmaFrequencyInverse::initialize()
 {
 
-      _value = -std::numeric_limits<Real>::max(); // start w/ the min
-
+  _value = -std::numeric_limits<Real>::max(); // start w/ the min
 }
 
 void
 PlasmaFrequencyInverse::computeQpValue()
 {
 
-      _value = std::max(_value, _u[_qp]);
+  _value = std::max(_value, _u[_qp]);
 }
 
 Real
 PlasmaFrequencyInverse::getValue()
 {
 
-      gatherMax(_value);
+  gatherMax(_value);
 
-      if (_use_moles)
-      {
-        _em_density = std::exp(_value) * 6.022e23;
-      }
-      else
-      {
-        _em_density = std::exp(_value);
-      }
+  if (_use_moles)
+  {
+    _em_density = std::exp(_value) * 6.022e23;
+  }
+  else
+  {
+    _em_density = std::exp(_value);
+  }
 
-      Real _plasma_freq = std::sqrt(std::pow(1.6022e-19,2) * _em_density / (8.8542e-12 * 9.1094e-31));
+  Real _plasma_freq = std::sqrt(std::pow(1.6022e-19, 2) * _em_density / (8.8542e-12 * 9.1094e-31));
 
   return 1. / _plasma_freq;
 }
@@ -78,6 +76,5 @@ PlasmaFrequencyInverse::threadJoin(const UserObject & y)
 {
   const PlasmaFrequencyInverse & pps = static_cast<const PlasmaFrequencyInverse &>(y);
 
-      _value = std::max(_value, pps._value);
-
+  _value = std::max(_value, pps._value);
 }

--- a/src/postprocessors/SideCurrent.C
+++ b/src/postprocessors/SideCurrent.C
@@ -95,7 +95,8 @@ SideCurrent::computeQpIntegral()
   _ion_flux = 0.0;
 
   for (unsigned int i = 0; i < _num_ions; ++i)
-    _ion_flux += 0.5 * std::sqrt(8 * _kb[_qp] * (*_T_ions[i])[_qp] / (M_PI * (*_mass_ions[i])[_qp])) *
+    _ion_flux += 0.5 *
+                     std::sqrt(8 * _kb[_qp] * (*_T_ions[i])[_qp] / (M_PI * (*_mass_ions[i])[_qp])) *
                      std::exp((*_ions[i])[_qp]) +
                  (2 * _a - 1) * (*_sgn_ions[i])[_qp] * (*_mu_ions[i])[_qp] * -_grad_potential[_qp] *
                      _r_units * std::exp((*_ions[i])[_qp]) * _normals[_qp];

--- a/src/postprocessors/SideTotFluxIntegral.C
+++ b/src/postprocessors/SideTotFluxIntegral.C
@@ -30,8 +30,7 @@ validParams<SideTotFluxIntegral>()
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addParam<Real>(
       "user_velocity", -1., "Optional parameter if user wants to specify the thermal velocity");
-  params.addClassDescription(
-    "Returns the flux of a defined species at a boundary");
+  params.addClassDescription("Returns the flux of a defined species at a boundary");
   return params;
 }
 

--- a/src/userobjects/BlockAverageValue.C
+++ b/src/userobjects/BlockAverageValue.C
@@ -25,8 +25,7 @@ validParams<BlockAverageValue>()
   // Since we are inheriting from a Postprocessor we override this to make sure
   // That MOOSE (and Peacock) know that this object is _actually_ a UserObject
   params.set<std::string>("built_by_action") = "add_user_object";
-  params.addClassDescription(
-    "Returns the average value of a defined variable for a given domain");
+  params.addClassDescription("Returns the average value of a defined variable for a given domain");
 
   return params;
 }

--- a/src/userobjects/CurrentDensityShapeSideUserObject.C
+++ b/src/userobjects/CurrentDensityShapeSideUserObject.C
@@ -23,8 +23,7 @@ validParams<CurrentDensityShapeSideUserObject>()
   params.addRequiredCoupledVar("potential", "The electrical potential.");
   params.addRequiredCoupledVar("mean_en", "The mean energy variable.");
   params.addRequiredParam<bool>("use_moles", "Whether the densities are in molar units.");
-  params.addClassDescription(
-    "Calculates the total current at a boundary");
+  params.addClassDescription("Calculates the total current at a boundary");
   return params;
 }
 

--- a/src/userobjects/ProvideMobility.C
+++ b/src/userobjects/ProvideMobility.C
@@ -20,9 +20,8 @@ validParams<ProvideMobility>()
   params.addRequiredParam<Real>("electrode_area", "The area of the electrode or plasma.");
   params.addRequiredParam<Real>("ballast_resist", "The magnitude of the ballasting resistance.");
   params.addRequiredParam<Real>("e", "The Coulomb charge");
-  params.addClassDescription(
-    "Defines ballast resistance and the area of an electrode"
-    "(Used with Circuit BCs)");
+  params.addClassDescription("Defines ballast resistance and the area of an electrode"
+                             "(Used with Circuit BCs)");
   return params;
 }
 


### PR DESCRIPTION
While working on other tasks, I noted that we had several source files that hadn't been run through clang format. This PR fixes that up. A CIVET clang format precheck also now exists to avoid formatting issues in the future. Commit 9f90ed5 tests this and will be removed before merge.