### PR TITLE
Ignore JIT files and remove deprecated MeshModifiers and print_perf_log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,11 @@ peacock_*.e
 *.cpa-*
 *.cpr-*
 
+# JIT and automatic differentiation cache files
+.jitcache/
+.jitdir/
+tmp_jit_*
+
 *.unv
 *.ogv
 

--- a/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion.i
+++ b/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion.i
@@ -1,21 +1,21 @@
 [Mesh]
-  type = FileMesh
-  file = 'Sample_Periodic_Diffusion.msh'
-[]
-
-[MeshModifiers]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Sample_Periodic_Diffusion.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
-
 
 [Problem]
   type = FEProblem
@@ -142,7 +142,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion_Log.i
+++ b/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion_Log.i
@@ -1,21 +1,21 @@
 [Mesh]
-  type = FileMesh
-  file = 'Sample_Periodic_Diffusion.msh'
-[]
-
-[MeshModifiers]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Sample_Periodic_Diffusion.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
-
 
 [Problem]
   type = FEProblem
@@ -157,7 +157,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/tests/accelerations/Acceleration_By_Averaging_acceleration.i
+++ b/tests/accelerations/Acceleration_By_Averaging_acceleration.i
@@ -1,25 +1,26 @@
 dom0Scale=25.4e-3
 
-[Mesh]
-  type = FileMesh
-  file = 'Lymberopoulos_paper.msh'
-[]
-
 [GlobalParams]
   potential_units = kV
   use_moles = true
 []
 
-[MeshModifiers]
+[Mesh]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Lymberopoulos_paper.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
 
@@ -150,7 +151,7 @@ dom0Scale=25.4e-3
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]

--- a/tests/accelerations/Acceleration_By_Averaging_acceleration_sub.i
+++ b/tests/accelerations/Acceleration_By_Averaging_acceleration_sub.i
@@ -6,20 +6,21 @@ dom0Scale = 25.4e-3
 []
 
 [Mesh]
-  type = FileMesh
-  file = 'Lymberopoulos_paper.msh'
-[]
-
-[MeshModifiers]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Lymberopoulos_paper.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
 

--- a/tests/accelerations/Acceleration_By_Averaging_main.i
+++ b/tests/accelerations/Acceleration_By_Averaging_main.i
@@ -9,20 +9,21 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  type = FileMesh
-  file = 'Lymberopoulos_paper.msh'
-[]
-
-[MeshModifiers]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Lymberopoulos_paper.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
 

--- a/tests/accelerations/Acceleration_By_Shooting_Method.i
+++ b/tests/accelerations/Acceleration_By_Shooting_Method.i
@@ -12,19 +12,6 @@ dom0Scale=25.4e-3
   file = 'Acceleration_By_Shooting_Method_Initial_Conditions.e'
 []
 
-[MeshModifiers]
-  [./left]
-    type = SideSetsFromNormals
-    normals = '-1 0 0'
-    new_boundary = 'left'
-  [../]
-  [./right]
-    type = SideSetsFromNormals
-    normals = '1 0 0'
-    new_boundary = 'right'
-  [../]
-[]
-
 [Problem]
   type = FEProblem
 []

--- a/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
+++ b/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
@@ -6,20 +6,21 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  type = FileMesh
-  file = 'Lymberopoulos_paper.msh'
-[]
-
-[MeshModifiers]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Lymberopoulos_paper.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
 

--- a/tests/accelerations/Acceleration_By_Shooting_Method_Shooting.i
+++ b/tests/accelerations/Acceleration_By_Shooting_Method_Shooting.i
@@ -1,25 +1,26 @@
 dom0Scale=25.4e-3
 
-[Mesh]
-  type = FileMesh
-  file = 'Lymberopoulos_paper.msh'
-[]
-
 [GlobalParams]
   potential_units = kV
   use_moles = true
 []
 
-[MeshModifiers]
+[Mesh]
+  [./file]
+    type = FileMeshGenerator
+    file = 'Lymberopoulos_paper.msh'
+  [../]
   [./left]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
+    input = file
   [../]
   [./right]
-    type = SideSetsFromNormals
+    type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
+    input = left
   [../]
 []
 
@@ -173,7 +174,7 @@ dom0Scale=25.4e-3
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
   [../]


### PR DESCRIPTION
- Ignores JIT files generated during testing by adding them to the `.gitignore` file
- Removes deprecated `MeshModifiers` from tests introduced in #55 (my mistake in missing them during my review). 
- Removes deprecated `print_perf_log` parameters