### PR TITLE
Neumann sign

### DIFF
--- a/src/bcs/ADNeumannCircuitVoltageMoles_KV.C
+++ b/src/bcs/ADNeumannCircuitVoltageMoles_KV.C
@@ -136,7 +136,7 @@ ADNeumannCircuitVoltageMoles_KV::computeQpResidual()
                       (M_PI * _massem[_qp]));
 
   return _test[_i][_qp] * _r_units * _eps[_qp] *
-         (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+         (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
           _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
               _voltage_scaling * (-1. + _r) *
               ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +

--- a/src/bcs/NeumannCircuitVoltageMoles_KV.C
+++ b/src/bcs/NeumannCircuitVoltageMoles_KV.C
@@ -160,7 +160,7 @@ NeumannCircuitVoltageMoles_KV::computeQpResidual()
                       (M_PI * _massem[_qp]));
 
   return _test[_i][_qp] * _r_units * _eps[_qp] *
-         (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+         (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
           _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
               _voltage_scaling * (-1. + _r) *
               ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +
@@ -219,7 +219,7 @@ NeumannCircuitVoltageMoles_KV::computeQpJacobian()
   _v_e_th = std::sqrt(8 * _data.coulomb_charge() * 2.0 / 3 * std::exp(_mean_en[_qp] - _em[_qp]) /
                       (M_PI * _massem[_qp]));
 
-  _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+  _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
                 _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
                     _voltage_scaling * (-1. + _r) *
                     ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +
@@ -300,7 +300,7 @@ NeumannCircuitVoltageMoles_KV::computeQpOffDiagJacobian(unsigned int jvar)
     _v_e_th = std::sqrt(8 * _data.coulomb_charge() * 2.0 / 3 * std::exp(_mean_en[_qp] - _em[_qp]) /
                         (M_PI * _massem[_qp]));
 
-    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
                   _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
                       _voltage_scaling * (-1. + _r) *
                       ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +
@@ -373,7 +373,7 @@ NeumannCircuitVoltageMoles_KV::computeQpOffDiagJacobian(unsigned int jvar)
     _d_v_e_th_d_em = 0.5 / _v_e_th * 8 * _data.coulomb_charge() * 2.0 / 3 * _actual_mean_en /
                      (M_PI * _massem[_qp]) * -_phi[_j][_qp];
 
-    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
                   _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
                       _voltage_scaling * (-1. + _r) *
                       ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +
@@ -443,7 +443,7 @@ NeumannCircuitVoltageMoles_KV::computeQpOffDiagJacobian(unsigned int jvar)
     _d_v_e_th_d_mean_en = 0.5 / _v_e_th * 8 * _data.coulomb_charge() * 2.0 / 3 * _actual_mean_en /
                           (M_PI * _massem[_qp]) * _phi[_j][_qp];
 
-    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * _V_bat.value(_t, _q_point[_qp]) +
+    _numerator = (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
                   _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
                       _voltage_scaling * (-1. + _r) *
                       ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +

--- a/tests/1d_dc/mean_en.i
+++ b/tests/1d_dc/mean_en.i
@@ -946,7 +946,7 @@ dom1Scale=1e-7
   [./potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
-    value = 1.25
+    value = -1.25
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/1d_dc/mean_en_multi.i
+++ b/tests/1d_dc/mean_en_multi.i
@@ -1044,7 +1044,7 @@ dom1Scale=1e-7
   [./potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
-    value = 1.25
+    value = -1.25
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/DriftDiffusionAction/mean_en_actions.i
+++ b/tests/DriftDiffusionAction/mean_en_actions.i
@@ -606,7 +606,7 @@ dom1Scale=1e-7
   [./potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
-    value = 1.25
+    value = -1.25
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/DriftDiffusionAction/mean_en_no_actions.i
+++ b/tests/DriftDiffusionAction/mean_en_no_actions.i
@@ -986,7 +986,7 @@ dom1Scale=1e-7
   [./potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
-    value = 1.25
+    value = -1.25
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/Schottky_emission/Example1/Input.i
+++ b/tests/Schottky_emission/Example1/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 4E-6 #m
-vhigh = 200E-3 #kV
+vhigh = -200E-3 #kV
 
 [GlobalParams]
         offset = 25

--- a/tests/Schottky_emission/Example2/Input.i
+++ b/tests/Schottky_emission/Example2/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 12E-6 #m
-vhigh = 80E-3 #kV
+vhigh = -80E-3 #kV
 
 [GlobalParams]
         offset = 25

--- a/tests/Schottky_emission/Example3/Input.i
+++ b/tests/Schottky_emission/Example3/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 2E-6 #m
-vhigh = 230E-3 #kV
+vhigh = -230E-3 #kV
 relaxTime = 50E-6 #s
 
 [GlobalParams]

--- a/tests/Schottky_emission/Example4/Input.i
+++ b/tests/Schottky_emission/Example4/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 2E-6 #m
-vhigh = 230E-3 #kV
+vhigh = -230E-3 #kV
 relaxTime = 1e-9 #s
 resistance = 1
 area = 5.02e-7 # Formerly 3.14e-6

--- a/tests/Schottky_emission/PaschenLaw/Input.i
+++ b/tests/Schottky_emission/PaschenLaw/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 5E-6 #m
-vhigh = 0.10 #kV
+vhigh = -0.10 #kV
 
 [GlobalParams]
 #       offset = 25

--- a/tests/automatic_differentiation/ad_argon.i
+++ b/tests/automatic_differentiation/ad_argon.i
@@ -637,7 +637,7 @@ dom0Scale=1e-3
 [Functions]
   [./potential_bc_func]
     type = ParsedFunction
-    value = 0.8
+    value = -0.8
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/crane_action/townsend_units.i
+++ b/tests/crane_action/townsend_units.i
@@ -855,7 +855,7 @@ dom1Scale=1e-7
   [./potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
-    value = 1.25
+    value = -1.25
   [../]
   [./potential_ic_func]
     type = ParsedFunction

--- a/tests/field_emission/field_emission.i
+++ b/tests/field_emission/field_emission.i
@@ -1,6 +1,6 @@
 dom0Scale=1
 dom0Size=5E-6 #m
-vhigh=0.15 #kV
+vhigh=-0.15 #kV
 
 [GlobalParams]
         offset = 20
@@ -648,7 +648,7 @@ vhigh=0.15 #kV
         [./potential_bc_func]
                 type = ParsedFunction
                 vars = 'period dutyCycle riseTime VHigh VLow'
-                vals = '3E-6 0.1 5E-7 ${vhigh} 0.001')
+                vals = '3E-6 0.1 5E-7 ${vhigh} -0.001')
                 value = 'if((t % period) < dutyCycle*period           , VHigh                                                                  ,
                                  if((t % period) < dutyCycle*period + riseTime, ((VLow - VHigh)/riseTime) * ((t % period) - period * dutyCycle) + VHigh,
                                  if((t % period) < period - riseTime          , VLow                                                                                                                               ,

--- a/tests/reflections/Schottky/Input.i
+++ b/tests/reflections/Schottky/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 10E-6 #m
-vhigh = 150E-3 #kV
+vhigh = -150E-3 #kV
 
 [GlobalParams]
         offset = 25

--- a/tests/reflections/Schottky_300_V_5_um/Input.i
+++ b/tests/reflections/Schottky_300_V_5_um/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 5E-6 #m
-vhigh = 400E-3 #kV
+vhigh = -400E-3 #kV
 
 [GlobalParams]
         offset = 25

--- a/tests/reflections/Schottky_400_V_10_um/Input.i
+++ b/tests/reflections/Schottky_400_V_10_um/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 5E-6 #m
-vhigh = 175E-3 #kV
+vhigh = -175E-3 #kV
 
 [GlobalParams]
         offset = 25

--- a/tests/reflections/base/Input.i
+++ b/tests/reflections/base/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 6E-6 #m
-vhigh = 175E-3 #kV
+vhigh = -175E-3 #kV
 
 [GlobalParams]
 #       offset = 20

--- a/tests/reflections/high_initial/Input.i
+++ b/tests/reflections/high_initial/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 6E-6 #m
-vhigh = 175E-3 #kV
+vhigh = -175E-3 #kV
 
 [GlobalParams]
 #       offset = 20

--- a/tests/reflections/low_initial/Input.i
+++ b/tests/reflections/low_initial/Input.i
@@ -1,6 +1,6 @@
 dom0Scale = 1
 dom0Size = 6E-6 #m
-vhigh = 175E-3 #kV
+vhigh = -175E-3 #kV
 
 [GlobalParams]
 #       offset = 20


### PR DESCRIPTION
Minor change fixing a sign discrepancy in the (AD)NeumannCircuitVoltageMoles_kV boundary condition. The sign of the voltage in the input file does not correspond to the sign of the voltage seen in the output, e.g. setting a voltage of 1.25 (1250 V) was interpreted as -1.25 by the circuit BC. This simply changes the sign of _V_bat in the boundary condition. The tests using this BC have also been updated to reflect the change. 