### PR TITLE
Fixup deprecation errors related to master_block

### DIFF
--- a/problems/ad_argon_chemistry.i
+++ b/problems/ad_argon_chemistry.i
@@ -16,14 +16,14 @@ dom1Scale=1.0
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/1d_dc/densities_mean_en.i
+++ b/tests/1d_dc/densities_mean_en.i
@@ -18,14 +18,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/1d_dc/mean_en.i
+++ b/tests/1d_dc/mean_en.i
@@ -16,14 +16,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/1d_dc/mean_en_multi.i
+++ b/tests/1d_dc/mean_en_multi.i
@@ -15,14 +15,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/DriftDiffusionAction/mean_en_actions.i
+++ b/tests/DriftDiffusionAction/mean_en_actions.i
@@ -16,14 +16,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/DriftDiffusionAction/mean_en_no_actions.i
+++ b/tests/DriftDiffusionAction/mean_en_no_actions.i
@@ -20,14 +20,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface

--- a/tests/TM10_circular_wg/TM_steady_dieletric.i
+++ b/tests/TM10_circular_wg/TM_steady_dieletric.i
@@ -10,7 +10,7 @@
   [../]
   [./interface_dielectric]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'interface_dielectric'
     input = file

--- a/tests/crane_action/townsend_units.i
+++ b/tests/crane_action/townsend_units.i
@@ -16,14 +16,14 @@ dom1Scale=1e-7
   [../]
   [./interface]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '0'
+    primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
   [../]
   [./interface_again]
     type = SideSetsBetweenSubdomainsGenerator
-    master_block = '1'
+    primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface


### PR DESCRIPTION
Removes usage of `master_block` in `Mesh` sub-blocks in test input files and replaces with `primary_block`. Should finally remove deprecation messages from Zapdos CIVET dashboard. 

Also updates moose submodule.

Tagging @csdechant for review.