### PR TITLE
Fix erroneous doco object types using the MOOSE unregister YAML in MooseDocs

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -36,6 +36,8 @@ Extensions:
         executable: ${ROOT_DIR}
         includes:
             - include
+        unregister:
+            framework: !include ${MOOSE_DIR}/framework/doc/unregister.yml
         remove:
             framework: !include ${MOOSE_DIR}/framework/doc/remove.yml
     MooseDocs.extensions.common:

--- a/doc/content/source/postprocessors/AverageNodalDensity.md
+++ b/doc/content/source/postprocessors/AverageNodalDensity.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/AverageNodalDensity
+!syntax description /Postprocessors/AverageNodalDensity
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the AverageNodalDensity object.
 
-!syntax parameters /UserObjects/AverageNodalDensity
+!syntax parameters /Postprocessors/AverageNodalDensity
 
-!syntax inputs /UserObjects/AverageNodalDensity
+!syntax inputs /Postprocessors/AverageNodalDensity
 
-!syntax children /UserObjects/AverageNodalDensity
+!syntax children /Postprocessors/AverageNodalDensity

--- a/doc/content/source/postprocessors/AverageNodalDifference.md
+++ b/doc/content/source/postprocessors/AverageNodalDifference.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/AverageNodalDifference
+!syntax description /Postprocessors/AverageNodalDifference
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the AverageNodalDifference object.
 
-!syntax parameters /UserObjects/AverageNodalDifference
+!syntax parameters /Postprocessors/AverageNodalDifference
 
-!syntax inputs /UserObjects/AverageNodalDifference
+!syntax inputs /Postprocessors/AverageNodalDifference
 
-!syntax children /UserObjects/AverageNodalDifference
+!syntax children /Postprocessors/AverageNodalDifference

--- a/doc/content/source/postprocessors/PeriodicComparisonCounter.md
+++ b/doc/content/source/postprocessors/PeriodicComparisonCounter.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/PeriodicComparisonCounter
+!syntax description /Postprocessors/PeriodicComparisonCounter
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the PeriodicComparisonCounter object.
 
-!syntax parameters /UserObjects/PeriodicComparisonCounter
+!syntax parameters /Postprocessors/PeriodicComparisonCounter
 
-!syntax inputs /UserObjects/PeriodicComparisonCounter
+!syntax inputs /Postprocessors/PeriodicComparisonCounter
 
-!syntax children /UserObjects/PeriodicComparisonCounter
+!syntax children /Postprocessors/PeriodicComparisonCounter

--- a/doc/content/source/postprocessors/PlasmaFrequencyInverse.md
+++ b/doc/content/source/postprocessors/PlasmaFrequencyInverse.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/PlasmaFrequencyInverse
+!syntax description /Postprocessors/PlasmaFrequencyInverse
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the PlasmaFrequencyInverse object.
 
-!syntax parameters /UserObjects/PlasmaFrequencyInverse
+!syntax parameters /Postprocessors/PlasmaFrequencyInverse
 
-!syntax inputs /UserObjects/PlasmaFrequencyInverse
+!syntax inputs /Postprocessors/PlasmaFrequencyInverse
 
-!syntax children /UserObjects/PlasmaFrequencyInverse
+!syntax children /Postprocessors/PlasmaFrequencyInverse

--- a/doc/content/source/postprocessors/RelativeElementL2Difference.md
+++ b/doc/content/source/postprocessors/RelativeElementL2Difference.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/RelativeElementL2Difference
+!syntax description /Postprocessors/RelativeElementL2Difference
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the RelativeElementL2Difference object.
 
-!syntax parameters /UserObjects/RelativeElementL2Difference
+!syntax parameters /Postprocessors/RelativeElementL2Difference
 
-!syntax inputs /UserObjects/RelativeElementL2Difference
+!syntax inputs /Postprocessors/RelativeElementL2Difference
 
-!syntax children /UserObjects/RelativeElementL2Difference
+!syntax children /Postprocessors/RelativeElementL2Difference

--- a/doc/content/source/postprocessors/SideCurrent.md
+++ b/doc/content/source/postprocessors/SideCurrent.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/SideCurrent
+!syntax description /Postprocessors/SideCurrent
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the SideCurrent object.
 
-!syntax parameters /UserObjects/SideCurrent
+!syntax parameters /Postprocessors/SideCurrent
 
-!syntax inputs /UserObjects/SideCurrent
+!syntax inputs /Postprocessors/SideCurrent
 
-!syntax children /UserObjects/SideCurrent
+!syntax children /Postprocessors/SideCurrent

--- a/doc/content/source/postprocessors/SideTotFluxIntegral.md
+++ b/doc/content/source/postprocessors/SideTotFluxIntegral.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/SideTotFluxIntegral
+!syntax description /Postprocessors/SideTotFluxIntegral
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the SideTotFluxIntegral object.
 
-!syntax parameters /UserObjects/SideTotFluxIntegral
+!syntax parameters /Postprocessors/SideTotFluxIntegral
 
-!syntax inputs /UserObjects/SideTotFluxIntegral
+!syntax inputs /Postprocessors/SideTotFluxIntegral
 
-!syntax children /UserObjects/SideTotFluxIntegral
+!syntax children /Postprocessors/SideTotFluxIntegral

--- a/doc/content/source/userobjects/BlockAverageValue.md
+++ b/doc/content/source/userobjects/BlockAverageValue.md
@@ -6,7 +6,7 @@ documenting the class, which includes the typical automatic documentation associ
 MooseObject; however, what is contained is ultimately determined by what is necessary to make the
 documentation clear for users.
 
-!syntax description /UserObjects/BlockAverageValue
+!syntax description /Postprocessors/BlockAverageValue
 
 ## Overview
 
@@ -16,8 +16,8 @@ documentation clear for users.
 
 !! Describe and include an example of how to use the BlockAverageValue object.
 
-!syntax parameters /UserObjects/BlockAverageValue
+!syntax parameters /Postprocessors/BlockAverageValue
 
-!syntax inputs /UserObjects/BlockAverageValue
+!syntax inputs /Postprocessors/BlockAverageValue
 
-!syntax children /UserObjects/BlockAverageValue
+!syntax children /Postprocessors/BlockAverageValue

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -7,6 +7,8 @@ Applications:
             - ${MOOSE_DIR}/framework/doc/remove.yml
         log_default: WARNING
         show_warning: false
+        unregister:
+            - ${MOOSE_DIR}/framework/doc/unregister.yml
 
 Documents:
     software_requirements_specification: sqa/zapdos_srs.md


### PR DESCRIPTION
This was fixed a while ago in idaholab/moose#18136, but hadn't been applied to Zapdos yet. `AuxKernels` and `Postprocessors` were getting miss-attributed to `Bounds` and `UserObjects` respectively when using the MooseDocs generate command to create template documentation. This PR fixes this issue by including the `unregister.yml` from MOOSE in the Zapdos documentation configuration. 

Tagging @csdechant for a review.