### PR TITLE
Allow creation of Zapdos docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt
 
 RUN git clone -b master https://github.com/shannon-lab/zapdos.git ; \
 cd zapdos ; \
-git submodule update --init ; \
+git submodule update --init crane squirrel ; \
 make -j $(grep -c ^processor /proc/cpuinfo)
 
 WORKDIR /opt/zapdos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# DON'T FORGET: Modify this hash to be consistent with the MOOSE submodule!
 FROM idaholab/moose:d73fc06368c8b33549cd1ec86f8863920789a878
 
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DON'T FORGET: Modify this hash to be consistent with the MOOSE submodule!
-FROM idaholab/moose:d73fc06368c8b33549cd1ec86f8863920789a878
+FROM idaholab/moose:0090e43293b4309135c6a763a79536aba89d3f1c
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM idaholab/moose:d73fc06368c8b33549cd1ec86f8863920789a878
+
+WORKDIR /opt
+
+RUN git clone -b master https://github.com/shannon-lab/zapdos.git ; \
+cd zapdos ; \
+git submodule update --init ; \
+make -j $(grep -c ^processor /proc/cpuinfo)
+
+WORKDIR /opt/zapdos

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -27,6 +27,7 @@ Extensions:
                 List of Publications: publications.md
             Help:
                 Zapdos Discussions Forum: https://github.com/shannon-lab/zapdos/discussions
+                Zapdos Developer Information: development/zapdos_developer_info.md
                 MOOSE Discussions Forum: https://github.com/idaholab/moose/discussions
                 MOOSE Homepage: https://mooseframework.inl.gov/
                 MOOSE Developer Information: development/moose_developer_info.md

--- a/doc/content/development/moose_developer_info.md
+++ b/doc/content/development/moose_developer_info.md
@@ -1,4 +1,4 @@
-# MOOSE Developer Information
+# MOOSE Developer Information (external links!)
 
 New users of Zapdos and MOOSE may find the following external links useful:
 

--- a/doc/content/development/zapdos_developer_info.md
+++ b/doc/content/development/zapdos_developer_info.md
@@ -1,0 +1,74 @@
+# Zapdos Developer Information
+
+This page is meant for Zapdos developers and will change over time as development practices and
+processes change - please refer back to this page regularly. If MOOSE user and developer information
+is desired, please refer to the [moose_developer_info.md] page.
+
+## Update and Build a New Docker Container
+
+!style halign=left
+The Zapdos docker container image should be updated whenever Zapdos source code or submodules (CRANE,
+Squirrel, or MOOSE) are updated and those changes are merged into the master branch. Whenever the
+MOOSE submodule is updated, in particular, the submodule git commit hash must be copied and entered
+into the `Dockerfile` so that the proper MOOSE docker image can be used with the Zapdos image.
+
+To build a new docker container, first fetch the most up-to-date version of the Zapdos master branch.
+Assuming that Zapdos is stored in `~/projects/` and that your `upstream` remote is referencing
+[shannon-lab/zapdos](https://github.com/shannon-lab/zapdos.git):
+
+```bash
+cd ~/projects/zapdos
+git fetch upstream
+git checkout master
+git rebase upstream/master
+```
+
+Once your local master branch is up-to-date, the `build_socker.sh` script can be used to create two
+new images, one tagged with the most recent git commit hash for the master branch and one tagged
+`latest`. The script has two parameters:
+
+- `ZAPDOS_DIR` - the current Zapdos directory (set in the environment, or on the command line when
+  the script is run). This parameter is required!
+- `PUSH` - a boolean value that sets whether the built packages should be pushed to the `shannonlab/zapdos`
+  Docker Hub repository when the build is completed (defaults to `0`)
+
+Example usage of the script is outlined as follows. First, start the script from the Zapdos directory:
+
+```bash
+cd ~/projects/zapdos
+ZAPDOS_DIR=$(pwd) scripts/build_docker.sh
+```
+
+In this case, the docker images will remain local and will not be pushed to Docker Hub (`PUSH=0`).
+Example output for this command is shown below:
+
+```bash
+% ZAPDOS_DIR=$(pwd) scripts/build_docker.sh
+[+] Building 0.5s (8/8) FINISHED
+ => [internal] load build definition from Dockerfile                                                                                                     0.0s
+ => => transferring dockerfile: 44B                                                                                                                      0.0s
+ => [internal] load .dockerignore                                                                                                                        0.0s
+ => => transferring context: 2B                                                                                                                          0.0s
+ => [internal] load metadata for docker.io/idaholab/moose:d73fc06368c8b33549cd1ec86f8863920789a878                                                       0.4s
+ => [1/4] FROM docker.io/idaholab/moose:d73fc06368c8b33549cd1ec86f8863920789a878@sha256:89d12bcc14b06e71d5f0e267412b718dfe1d63c984b2bb67dcc1b76f0f995cc  0.0s
+pick 79e7daa2 Add docker build and upload script
+ => CACHED [2/4] WORKDIR /opt                                                                                                                            0.0s
+ => CACHED [3/4] RUN git clone -b master https://github.com/shannon-lab/zapdos.git ; cd zapdos ; git submodule update --init crane squirrel ; make -j $  0.0s
+ => CACHED [4/4] WORKDIR /opt/zapdos                                                                                                                     0.0s
+ => exporting to image                                                                                                                                   0.0s
+ => => exporting layers                                                                                                                                  0.0s
+ => => writing image sha256:26565cd5c868ecd702d727fa9c2a95caf24d9741e629d1cc3f39261b9b592570                                                             0.0s
+ => => naming to docker.io/shannonlab/zapdos:2c4a214d4d55106ac6c8c9058e3b224a46ba416d                                                                    0.0s
+
+Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
+
+INFO: Push to Docker Hub disabled. If desired in the future, run this script
+      with PUSH=1 in your environment or run the following two commands:
+
+      docker push shannonlab/zapdos:2c4a214d4d55106ac6c8c9058e3b224a46ba416d
+      docker push shannonlab/zapdos:latest
+```
+
+
+
+

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -80,18 +80,23 @@ git rebase origin/master
 
 ## Alternate Installation: Docker
 
-Zapdos is also available a container hosted on Docker Hub in the repository [shannonlab/zapdos](https://hub.docker.com/r/shannonlab/zapdos) for Ubuntu 20.04. The tag "latest" is kept current with the master branch of the Zapdos repository, and the other tags are commit hashes in line with git commit hashes for prior Zapdos updates. The Docker image contains a prebuilt copy of Zapdos, installable with one command (once Docker is installed on the host machine):
+!style halign=left
+Zapdos is also available as a container hosted on Docker Hub in the repository [shannonlab/zapdos](https://hub.docker.com/r/shannonlab/zapdos)
+for Ubuntu 20.04. The tag "latest" is kept current with the master branch of the Zapdos repository,
+and the other tags are commit hashes in line with git commit hashes for prior Zapdos updates. The
+Docker image contains a prebuilt copy of Zapdos, installable with one command (once Docker is installed
+on the host machine):
 
 ```bash
 docker run -ti shannonlab/zapdos:latest
 ```
 
-### Zapdos Docker Container Minimum System Requirements
+#### Zapdos Docker Container Minimum System Requirements
 
 - Some flavor of Linux, MacOS, or Windows with [Docker](https://www.docker.com) installed
-- Memory: 16GBs (debug builds)
+- Memory: 16 GBs (debug builds)
 - Processor: 64-bit x86 or ARM64 (Apple Silicon)
-- Disk: 6GB (image size)
+- Disk: 6 GB (image size)
 
 ## Troubleshooting
 

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -84,8 +84,14 @@ git rebase origin/master
 Zapdos is also available as a container hosted on Docker Hub in the repository [shannonlab/zapdos](https://hub.docker.com/r/shannonlab/zapdos)
 for Ubuntu 20.04. The tag "latest" is kept current with the master branch of the Zapdos repository,
 and the other tags are commit hashes in line with git commit hashes for prior Zapdos updates. The
-Docker image contains a prebuilt copy of Zapdos, installable with one command (once Docker is installed
+Docker image contains a prebuilt copy of Zapdos, installable with two commands (once Docker is installed
 on the host machine):
+
+```bash
+docker pull shannonlab/zapdos:latest
+```
+
+then
 
 ```bash
 docker run -ti shannonlab/zapdos:latest

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -78,6 +78,20 @@ git fetch origin
 git rebase origin/master
 ```
 
+## Alternate Installation: Docker
+
+Zapdos is also available a container hosted on Docker Hub in the repository [shannonlab/zapdos](https://hub.docker.com/r/shannonlab/zapdos) for Ubuntu 20.04. The tag "latest" is kept current with the master branch of the Zapdos repository, and the other tags are commit hashes in line with git commit hashes for prior Zapdos updates. The Docker image contains a prebuilt copy of Zapdos, installable with one command (once Docker is installed on the host machine):
+
+```bash
+docker run -ti shannonlab/zapdos:latest
+```
+
+### Zapdos Docker Container Minimum System Requirements
+
+- Some flavor of Linux, MacOS, or Windows with [Docker](https://www.docker.com) installed
+- Memory: 16GBs (debug builds)
+- Processor: 64-bit x86 or ARM64 (Apple Silicon)
+- Disk: 6GB (image size)
 
 ## Troubleshooting
 

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -19,8 +19,7 @@ if [ -z "$PUSH" ]; then
   PUSH=0
 fi
 
-
-# Check for and set ZAPDOS_DIR
+# Check for ZAPDOS_DIR and if it exists; throw errors if either is false
 if [ -z "$ZAPDOS_DIR" ]; then
     echo "ERROR: ZAPDOS_DIR is not set for build_docker"
     exit 1
@@ -30,18 +29,18 @@ if [ ! -d "$ZAPDOS_DIR" ]; then
   exit 1
 fi
 
-# Enter Zapdos and get latest master branch git commit hash
+# Enter Zapdos source location, checkout master branch, and save latest git commit hash
 cd $ZAPDOS_DIR
 git checkout master
 MASTER_HASH=$(git rev-parse master)
 
-# Build docker container
+# Build docker container and tag it with master git hash
 docker build -t shannonlab/zapdos:"$MASTER_HASH" . || exit $?
 
 # Retag newly built container with "latest"
 docker tag shannonlab/zapdos:"$MASTER_HASH" shannonlab/zapdos:latest
 
-# Push all containers to Docker Hub, if enabled
+# Push all containers to Docker Hub, if enabled. If not, display a notice to the screen with more info
 if [[ $PUSH == 1 ]]; then
   docker push shannonlab/zapdos:$MASTER_HASH
   docker push shannonlab/zapdos:latest

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#* This file is part of Zapdos, an open-source
+#* application for the simulation of plasmas
+#* https://github.com/shannon-lab/zapdos
+#*
+#* Zapdos is powered by the MOOSE Framework
+#* https://www.mooseframework.org
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+
+# This script builds a Zapdos docker container based on the current master branch
+# for upload to Docker Hub
+
+# Set optional push parameter (defaults to NO / 0 if not set by the user)
+if [ -z "$PUSH" ]; then
+  PUSH=0
+fi
+
+
+# Check for and set ZAPDOS_DIR
+if [ -z "$ZAPDOS_DIR" ]; then
+    echo "ERROR: ZAPDOS_DIR is not set for build_docker"
+    exit 1
+fi
+if [ ! -d "$ZAPDOS_DIR" ]; then
+  echo "ERROR: $ZAPDOS_DIR=ZAPDOS_DIR does not exist"
+  exit 1
+fi
+
+# Enter Zapdos and get latest master branch git commit hash
+cd $ZAPDOS_DIR
+git checkout master
+MASTER_HASH=$(git rev-parse master)
+
+# Build docker container
+docker build -t shannonlab/zapdos:"$MASTER_HASH" . || exit $?
+
+# Retag newly built container with "latest"
+docker tag shannonlab/zapdos:"$MASTER_HASH" shannonlab/zapdos:latest
+
+# Push all containers to Docker Hub, if enabled
+if [[ $PUSH == 1 ]]; then
+  docker push shannonlab/zapdos:$MASTER_HASH
+  docker push shannonlab/zapdos:latest
+else
+  echo ""
+  echo "INFO: Push to Docker Hub disabled. If desired in the future, run this script"
+  echo "      with PUSH=1 in your environment. To push now, run the following two"
+  echo "      commands:"
+  echo ""
+  echo "      docker push shannonlab/zapdos:$MASTER_HASH"
+  echo "      docker push shannonlab/zapdos:latest"
+fi


### PR DESCRIPTION
@csdechant This was a bit easier than I expected it to be. In order to try out this image, you need to do the following: 

1. Download and setup Docker Desktop via the [docker website](https://www.docker.com) in order to get all the dependencies you need. You should be able to do this using Windows, Mac, or Linux, but the container will currently present an Ubuntu 20.04 x86_64 virtual OS. 
2. In your terminal, run 
    ```
    docker pull shannonlab/zapdos:latest
    ```
    in order to pull down the docker image of zapdos based on the current master branch. 
3. Run the image by running the command 
    ```
    docker run -ti shannonlab/zapdos:latest
    ```

Step 3 will drop you into a terminal prompt within the docker container like the following
    
```
root@b8a8da88ae2b:/opt/zapdos#
```

where you can perform an `ls` showing you are in the root directory of a built copy of the zapdos source code:

```
root@b8a8da88ae2b:/opt/zapdos# ls
LICENSE  Makefile  README.md  build  crane  doc  include  lib  moose  run_tests  scripts  squirrel src  test  tutorial  unit  zapdos-opt
```

From here you can run and test zapdos as normal! I still need to put up some directions on how to use the docker image for the website as well as some build instructions for future administrators, but I thought I should let you know that something is publicly available. The Docker Hub repository is located at https://hub.docker.com/r/shannonlab/zapdos.