### PR TITLE
Update MOOSE and add docker badge to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DON'T FORGET: Modify this hash to be consistent with the MOOSE submodule!
-FROM idaholab/moose:0090e43293b4309135c6a763a79536aba89d3f1c
+FROM idaholab/moose:d8ab3269c2d2be61bdc35e3454af69c5894f2a60
 
 WORKDIR /opt
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.801834.svg)](https://doi.org/10.5281/zenodo.801834)
 
+[![Docker Image Version (tag latest semver)](https://img.shields.io/docker/v/shannonlab/zapdos/latest?color=green&label=docker%20latest&logo=docker&logoColor=white)](https://hub.docker.com/r/shannonlab/zapdos)
+
 # Zapdos
 
 Free (in all senses of the word) and open source software for modeling plasmas using finite elements. This application is built on top of [the MOOSE Framework](https://mooseframework.inl.gov).


### PR DESCRIPTION
Trying to do more regular MOOSE updates for Zapdos (last was ~16 days ago). This PR also adds a badge referring to the hash for the latest docker release as well as a link to the Docker Hub page on the README. 

Website update forthcoming.