### PR TITLE
Automate Zapdos website regeneration

### DIFF
--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -1,0 +1,58 @@
+name: Generate Zapdos Website
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-website:
+    runs-on: ubuntu-latest
+    # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+    - name: Checkout Zapdos
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Mambaforge3 and Zapdos environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        activate-environment: zapdos
+        environment-file: scripts/conda_environment.yml
+    # Note for build step: GitHub-hosted runners are currently limited to 2 cores
+    # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+    - name: Build Zapdos
+      run: |
+        conda activate zapdos
+        make -j2
+    # GITHUB_WORKSPACE contains the location of the repository when using the checkout action
+    # See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+    - name: Build Zapdos documentation
+      run: |
+        cd doc
+        ./moosedocs.py build --destination=$GITHUB_WORKSPACE/../zapdos-site
+    - name: Clean-up Zapdos
+      run: |
+        git submodule deinit -f moose crane squirrel
+        git clean -xfd
+    # GITHUB_SHA contains the commit SHA that triggered the workflow (the head commit of the master branch)
+    - name: Checkout gh-pages and push new website
+      run: |
+        git fetch origin gh-pages
+        git checkout gh-pages
+        rm -rf *
+        cd $GITHUB_WORKSPACE/../zapdos-site
+        rm test.html
+        mv * $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        git status
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "Update zapdos website based on $GITHUB_SHA"
+        git push origin gh-pages

--- a/scripts/conda_environment.yml
+++ b/scripts/conda_environment.yml
@@ -1,0 +1,8 @@
+# This YML file is used within the Generate Zapdos Website action to setup the build environment for Zapdos.
+# See .github/workflows/generate_website.yml
+channels:
+  - https://conda.software.inl.gov/public
+dependencies:
+  - python=3.10
+  - moose-libmesh
+  - moose-tools


### PR DESCRIPTION
At long last - this PR adds a GitHub actions workflow to regenerate the Zapdos website after each push to master. An example of this workflow being run in my personal fork can be found [here](https://github.com/cticenhour/zapdos/actions/runs/3635323557). If the website build fails, GitHub can also send out notifications for troubleshooting. 

The total time from a merge to master to a website update should be around 30-45 minutes using this system. 

Refs #41