### PR TITLE
Add Dependabot to Zapdos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  #  Check all submodule dependencies every week (Fridays at 6PM MT / 1AM UTC)
+  - package-ecosystem: "gitsubmodule"
+    schedule:
+        interval: "weekly"
+        day: "friday"
+        time: "01:00"
+    directory: "/"
+  # Maintain dependencies for GitHub Actions once a month
+  - package-ecosystem: "github-actions"
+    schedule:
+      interval: "monthly"
+    directory: "/"

--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -52,7 +52,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         git status
         git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.email actions@github.com
         git add .
         git commit -m "Update zapdos website based on $GITHUB_SHA"
         git push origin gh-pages


### PR DESCRIPTION
This sets up the following update schedule:

- Weekly updates for submodule checks. This is initially set to Fridays at 6pm MT, so that we're past the end-of-day for most MOOSE team development. Can't (yet) do a biweekly option for dependabot here.
- Monthly updates for the GitHub Actions we have configured (currently only website generation).

Tossing in a change to the "proper" github actions bot email so commits to `gh-pages` might associate properly to a bot. 

Refs #158 