### PR TITLE
Specify moose submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "moose"]
 	path = moose
 	url = ../../idaholab/moose
+	branch = master
 [submodule "crane"]
 	path = crane
 	url = ../../lcpp-org/crane


### PR DESCRIPTION
This helps dependabot monitor the master MOOSE branch using the gitmodules file settings instead of defaulting to the next branch. 

@csdechant apologies for the flood of PRs this week, but can you take a look at this one as well?