### PR TITLE
Switch away from deprecated items and update fixup_headers.py

### DIFF
--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         git submodule deinit -f moose crane squirrel
         git clean -xfd
+        git reset --hard HEAD
     # GITHUB_SHA contains the commit SHA that triggered the workflow (the head commit of the master branch)
     - name: Checkout gh-pages and push new website
       run: |

--- a/doc/tutorial_pdf/Zapdos_Tutorial.tex
+++ b/doc/tutorial_pdf/Zapdos_Tutorial.tex
@@ -430,25 +430,25 @@
   \begin{verbatim}
   [Kernels] #Begining/Name of Object Block (This example is the Kernel Block)
     #Time Derivative of electrons
-    [./em_time_deriv] #Begining/Custom Name of kernel (User Defined)
+    [em_time_deriv] #Begining/Custom Name of kernel (User Defined)
         type = ElectronTimeDerivative #Type of kernel
         variable = em #Variable effected by kernel
-    [../] #End of first kernel
+    [] #End of first kernel
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
         type = EFieldAdvectionElectrons
         variable = em
         potential = potential #Coupled variable
         mean_en = mean_en #Coupled variable
         position_units = ${dom0Scale} #Scaling Option
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
         type = CoeffDiffusionElectrons
         variable = em
         mean_en = mean_en
         position_units = ${dom0Scale}
-    [../]
+    []
   [] #End of Object Block
   \end{verbatim}
 
@@ -486,7 +486,7 @@
 
   \begin{verbatim}
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     electrons = em
     charged_particle = Ar+
     Neutrals = Ar*
@@ -495,11 +495,11 @@
     mean_energy = mean_en
     position_units = ${dom0Scale}
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
+  []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     species = 'Ar* em Ar+'
     aux_species = 'Ar'
     reaction_coefficient_format = 'rate'
@@ -520,7 +520,7 @@
                  Ar* + Ar* -> Ar+ + Ar + em : 373364000
                  Ar* + Ar -> Ar + Ar        : 1806.6
                  Ar* + Ar + Ar -> Ar_2 + Ar : 39890.9324'
-  [../]
+  []
 []
   \end{verbatim}
 
@@ -530,19 +530,19 @@
   \begin{verbatim}
   [MeshModifiers]
     #Setting the path from plasma to water
-    [./interface]
+    [interface]
         type = SideSetsBetweenSubdomains
         master_block = '0' #plasma
         paired_block = '1' #water
         new_boundary = 'master0_interface'
-    [../]
+    []
   []
   \end{verbatim}
 
   \begin{verbatim}
   [InterfaceKernels]
     #Defining election advection to the water
-    [./em_advection]
+    [em_advection]
         type = InterfaceAdvection
         mean_en_neighbor = mean_en
         potential_neighbor = potential
@@ -551,9 +551,9 @@
         boundary = master1_interface
         position_units = ${dom1Scale}
         neighbor_position_units = ${dom0Scale}
-    [../]
+    []
     #Defining election diffusion to the water
-    [./em_diffusion]
+    [em_diffusion]
         type = InterfaceLogDiffusionElectrons
         mean_en_neighbor = mean_en
         neighbor_var = em
@@ -561,7 +561,7 @@
         boundary = master1_interface
         position_units = ${dom1Scale}
         neighbor_position_units = ${dom0Scale}
-    [../]
+    []
 []
   \end{verbatim}
 

--- a/scripts/fixup_headers.py
+++ b/scripts/fixup_headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # This script checks and can optionally update Zapdos source files.
 # You should always run this script without the "-u" option
@@ -65,12 +65,12 @@ def checkAndUpdateCPlusPlus(filename):
     header = unified_header
 
     # Check (exact match only)
-    if (string.find(text, header) == -1 or global_options.force == True):
+    if (text.find(header) == -1 or global_options.force == True):
         # print the first 10 lines or so of the file
         if global_options.update == False: # Report only
-            print filename + ' does not contain an up to date header'
+            print(filename + ' does not contain an up to date header')
             if global_options.verbose == True:
-                print '>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5
+                print('>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5)
         else:
             # Make sure any previous C-style header version is removed
             text = re.sub(r'^/\*+/$.*^/\*+/$', '', text, flags=re.S | re.M)
@@ -98,12 +98,12 @@ def checkAndUpdatePython(filename):
     header = python_header
 
     # Check (exact match only)
-    if (string.find(text, header) == -1):
+    if (text.find(header) == -1):
         # print the first 10 lines or so of the file
         if global_options.update == False: # Report only
-            print filename + ' does not contain an up to date header'
+            print(filename + ' does not contain an up to date header')
             if global_options.verbose == True:
-                print '>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5
+                print('>'*40, '\n', '\n'.join((text.split('\n', 10))[:10]), '\n'*5)
         else:
             # Save off the shebang line if it exists
             m = re.match(r'#!.*\n', text)

--- a/scripts/fixup_headers.py
+++ b/scripts/fixup_headers.py
@@ -82,9 +82,20 @@ def checkAndUpdateCPlusPlus(filename):
             # Now cleanup extra blank lines
             text = re.sub(r'\A(^\s*\n)', '', text)
 
+            # Remove ifdefs in favor of pragmas
+            suffix = os.path.splitext(filename)
+            if suffix[-1] == '.h':
+                text = re.sub(r'^#ifndef\s*\S+_H_?\s*\n#define.*\n', '', text, flags=re.M)
+                text = re.sub(r'^#endif.*\n[\s]*\Z', '', text, flags=re.M)
+
             # Update
             f = open(filename + '~tmp', 'w')
             f.write(header + '\n\n')
+
+            # Insert pragma once if not already present
+            if suffix[-1] == '.h':
+                if not re.search(r'#pragma once', text):
+                    f.write("#pragma once\n")
 
             f.write(text)
             f.close()

--- a/scripts/fixup_headers.py
+++ b/scripts/fixup_headers.py
@@ -10,7 +10,8 @@
 import os, string, re, shutil
 from optparse import OptionParser
 
-global_ignores = ['contrib', '.svn', '.git', 'crane', 'moose', 'squirrel']
+global_dir_ignores = ['contrib', '.svn', '.git', 'crane', 'moose', 'squirrel']
+global_file_ignores = ['moosedocs.py']
 
 unified_header = """\
 //* This file is part of Zapdos, an open-source
@@ -40,12 +41,15 @@ def fixupHeader():
     for dirpath, dirnames, filenames in os.walk(os.getcwd() + ""):
 
         # Don't traverse into ignored directories
-        for ignore in global_ignores:
+        for ignore in global_dir_ignores:
             if ignore in dirnames:
                 dirnames.remove(ignore)
 
-        #print dirpath
-        #print dirnames
+        # Don't check ignored files
+        for ignore in global_file_ignores:
+            if ignore in filenames:
+                filenames.remove(ignore)
+
         for file in filenames:
             suffix = os.path.splitext(file)
             if (suffix[-1] == '.C' or suffix[-1] == '.h') and not global_options.python_only:

--- a/src/base/ZapdosApp.C
+++ b/src/base/ZapdosApp.C
@@ -21,9 +21,7 @@ ZapdosApp::validParams()
 {
   InputParameters params = MooseApp::validParams();
 
-  params.set<bool>("use_legacy_output_syntax") = false;
-  params.set<bool>("use_legacy_uo_initialization") = false;
-  params.set<bool>("use_legacy_uo_aux_computation") = false;
+  params.set<bool>("use_legacy_material_output") = false;
   return params;
 }
 

--- a/test/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/test/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -11,22 +11,22 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -35,10 +35,10 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -61,22 +61,22 @@ area = 5.02e-7 # Formerly 3.14e-6
         dtmin = 1e-15
         # dtmax = 1E-6
         nl_max_its = 50
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 20
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
                 execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -84,7 +84,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [UserObjects]
-        [./current_density_user_object]
+        [current_density_user_object]
                 type = CurrentDensityShapeSideUserObject
                 boundary = left
                 potential = potential
@@ -92,61 +92,61 @@ area = 5.02e-7 # Formerly 3.14e-6
                 ip = Arp
                 mean_en = mean_en
                 execute_on = 'linear nonlinear'
-        [../]
-        [./data_provider]
+        []
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = ${area}
                 ballast_resist = ${resistance}
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 20
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 20
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 35
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -154,48 +154,48 @@ area = 5.02e-7 # Formerly 3.14e-6
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -203,160 +203,160 @@ area = 5.02e-7 # Formerly 3.14e-6
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -365,8 +365,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -375,8 +375,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -384,8 +384,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -393,8 +393,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -402,65 +402,65 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = DensityMoles
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = DensityMoles
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -468,8 +468,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -477,27 +477,27 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-#       [./potential_left]
+#       [potential_left]
 #               type = NeumannCircuitVoltageMoles_KV
 #               variable = potential
 #               boundary = left
@@ -508,9 +508,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-        # [./potential_left]
+        # [potential_left]
         #       boundary = left
         #       type = NeumannCircuitVoltageNew
         #       variable = potential
@@ -525,9 +525,9 @@ area = 5.02e-7 # Formerly 3.14e-6
         #       data_provider = data_provider
 
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./potential_left]
+        [potential_left]
           boundary = left
           type = PenaltyCircuitPotential
           variable = potential
@@ -543,17 +543,17 @@ area = 5.02e-7 # Formerly 3.14e-6
           potential_units = 'kV'
           position_units = ${dom0Scale}
           resistance = ${resistance}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -565,9 +565,9 @@ area = 5.02e-7 # Formerly 3.14e-6
                 position_units = ${dom0Scale}
                 tau = ${relaxTime}
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -575,52 +575,52 @@ area = 5.02e-7 # Formerly 3.14e-6
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -628,9 +628,9 @@ area = 5.02e-7 # Formerly 3.14e-6
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -638,53 +638,53 @@ area = 5.02e-7 # Formerly 3.14e-6
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -25
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -700,5 +700,5 @@ area = 5.02e-7 # Formerly 3.14e-6
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/1d_dc/densities_mean_en.i
+++ b/test/tests/1d_dc/densities_mean_en.i
@@ -12,36 +12,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'liquidNew.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -50,11 +50,11 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -68,25 +68,25 @@ dom1Scale=1e-7
   nl_abs_tol = 7.6e-5
   dtmin = 1e-12
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
    optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
   # print_linear_residuals = false
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
-  [./dof_map]
+  []
+  [dof_map]
     type = DOFMap
-  [../]
+  []
 []
 
 [Debug]
@@ -94,7 +94,7 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
@@ -102,29 +102,29 @@ dom1Scale=1e-7
     # electrode_area = 1.1
     # ballast_resist = 1.1
     # e = 1.1
-  [../]
+  []
 []
 
 [Kernels]
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_ionization]
+  []
+  [em_ionization]
     type = ElectronsFromIonization
     variable = em
     potential = potential
@@ -132,103 +132,103 @@ dom1Scale=1e-7
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_log_stabilization]
+  []
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
+  []
 
-  [./emliq_time_deriv]
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
     block = 1
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_reactant_first_order_rxn]
+  []
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_log_stabilization]
+  []
+  [emliq_log_stabilization]
     type = LogStabilizationMoles
     variable = emliq
     block = 1
-  [../]
+  []
 
-  [./potential_diffusion_dom1]
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom2]
+  []
+  [potential_diffusion_dom2]
     type = CoeffDiffusionLin
     variable = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
-  [./emliq_charge_source]
+  []
+  [emliq_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = emliq
     block = 1
-  [../]
-  [./OHm_charge_source]
+  []
+  [OHm_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = OHm
     block = 1
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = ElectronTimeDerivative
     variable = Arp
     block = 0
-  [../]
-  [./Arp_advection]
+  []
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Arp_diffusion]
+  []
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_ionization]
+  []
+  [Arp_ionization]
     type = IonsFromIonization
     variable = Arp
     potential = potential
@@ -236,263 +236,263 @@ dom1Scale=1e-7
     mean_en = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_log_stabilization]
+  []
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
     block = 1
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_log_stabilization]
+  []
+  [OHm_log_stabilization]
     type = LogStabilizationMoles
     variable = OHm
     block = 1
-  [../]
-  [./OHm_product_first_order_rxn]
+  []
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_ionization]
+  []
+  [mean_en_ionization]
     type = ElectronEnergyLossFromIonization
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_elastic]
+  []
+  [mean_en_elastic]
     type = ElectronEnergyLossFromElastic
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_excitation]
+  []
+  [mean_en_excitation]
     type = ElectronEnergyLossFromExcitation
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
-  [./em]
+  [potential]
+  []
+  [em]
     block = 0
-  [../]
-  [./emliq]
+  []
+  [emliq]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
     # scaling = 1e-1
-  [../]
+  []
 
-  [./OHm]
+  [OHm]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x]
+  []
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./rholiq]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./em_lin]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [rholiq]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [emliq_lin]
+    order = CONSTANT
+    family = MONOMIAL
     block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Efield]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Current_em]
+  []
+  [Arp_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_emliq]
+  []
+  [OHm_lin]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Current_Arp]
+  []
+  [Efield]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_OHm]
-    block = 1
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+    block = 1
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [Current_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [tot_liq_current]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [tot_flux_OHm]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [DiffusiveFlux_em]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -501,8 +501,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -511,8 +511,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
     type = ADProcRate
     em = em
     potential = potential
@@ -520,8 +520,8 @@ dom1Scale=1e-7
     variable = ProcRate_el
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
     type = ADProcRate
     em = em
     potential = potential
@@ -529,8 +529,8 @@ dom1Scale=1e-7
     variable = ProcRate_ex
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
     type = ADProcRate
     em = em
     potential = potential
@@ -538,111 +538,111 @@ dom1Scale=1e-7
     variable = ProcRate_iz
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_l]
+  []
+  [x_l]
     type = Position
     variable = x
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_lin Arp_lin'
     function = 'Arp_lin - em_lin'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_lin OHm_lin' # H3Op_lin OHm_lin'
     function = '-emliq_lin - OHm_lin' # 'H3Op_lin - em_lin - OHm_lin'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = Density
     variable = em_lin
     density_log = em
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = Density
     variable = emliq_lin
     density_log = emliq
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = Density
     variable = Arp_lin
     density_log = Arp
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = Density
     variable = OHm_lin
     density_log = OHm
     block = 1
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -650,8 +650,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
@@ -659,8 +659,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -668,8 +668,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     type = ADCurrent
     potential = potential
@@ -677,48 +677,48 @@ dom1Scale=1e-7
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -727,8 +727,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -736,11 +736,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -751,14 +751,14 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -766,23 +766,23 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_right]
+  []
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -790,8 +790,8 @@ dom1Scale=1e-7
     em = em
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -799,8 +799,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -809,23 +809,23 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -833,109 +833,109 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./emliq_right]
+  []
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
-  # [./em_ic]
+  []
+  # [em_ic]
   #   type = RandomIC
   #   variable = em
   #   block = 0
   #   min = -21.5
   #   max = -20.5
-  # [../]
-  # [./emliq_ic]
+  # []
+  # [emliq_ic]
   #   type = RandomIC
   #   variable = emliq
   #   block = 1
   #   min = -21.5
   #   max = -20.5
-  # [../]
-  # [./Arp_ic]
+  # []
+  # [Arp_ic]
   #   type = RandomIC
   #   variable = Arp
   #   block = 0
   #   min = -21.5
   #   max = -20.5
-  # [../]
-  # [./mean_en_ic]
+  # []
+  # [mean_en_ic]
   #   type = RandomIC
   #   variable = mean_en
   #   block = 0
   #   min = -20.5
   #   max = -19.5
-  # [../]
+  # []
   #   type = RandomIC
   #   variable = OHm
   #   block = 1
   #   min = -16.1
   #   max = -15.1
-  # [../]
+  # []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = 1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_block]
+  [gas_block]
     type = Gas
     interp_trans_coeffs = true
     interp_elastic_coeff = true
@@ -947,10 +947,10 @@ dom1Scale=1e-7
     user_se_coeff = .05
     block = 0
     property_tables_file = td_argon_mean_en.txt
- [../]
- [./water_block]
+ []
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 []

--- a/test/tests/1d_dc/mean_en.i
+++ b/test/tests/1d_dc/mean_en.i
@@ -10,36 +10,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'liquidNew.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -48,11 +48,11 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -72,26 +72,26 @@ dom1Scale=1e-7
  nl_abs_tol = 7.6e-5
   dtmin = 1e-12
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     # dt = 1.1
     growth_factor = 1.2
    optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
   # print_linear_residuals = false
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
-  [./dof_map]
+  []
+  [dof_map]
     type = DOFMap
-  [../]
+  []
 []
 
 [Debug]
@@ -99,34 +99,34 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [Kernels]
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_ionization]
+  []
+  [em_ionization]
     type = ElectronsFromIonization
     variable = em
     potential = potential
@@ -134,103 +134,103 @@ dom1Scale=1e-7
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_log_stabilization]
+  []
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
+  []
 
-  [./emliq_time_deriv]
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
     block = 1
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_reactant_first_order_rxn]
+  []
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_log_stabilization]
+  []
+  [emliq_log_stabilization]
     type = LogStabilizationMoles
     variable = emliq
     block = 1
-  [../]
+  []
 
-  [./potential_diffusion_dom1]
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom2]
+  []
+  [potential_diffusion_dom2]
     type = CoeffDiffusionLin
     variable = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
-  [./emliq_charge_source]
+  []
+  [emliq_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = emliq
     block = 1
-  [../]
-  [./OHm_charge_source]
+  []
+  [OHm_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = OHm
     block = 1
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = ElectronTimeDerivative
     variable = Arp
     block = 0
-  [../]
-  [./Arp_advection]
+  []
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Arp_diffusion]
+  []
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_ionization]
+  []
+  [Arp_ionization]
     type = IonsFromIonization
     variable = Arp
     potential = potential
@@ -238,263 +238,263 @@ dom1Scale=1e-7
     mean_en = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_log_stabilization]
+  []
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
     block = 1
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_log_stabilization]
+  []
+  [OHm_log_stabilization]
     type = LogStabilizationMoles
     variable = OHm
     block = 1
-  [../]
-  [./OHm_product_first_order_rxn]
+  []
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_ionization]
+  []
+  [mean_en_ionization]
     type = ElectronEnergyLossFromIonization
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_elastic]
+  []
+  [mean_en_elastic]
     type = ElectronEnergyLossFromElastic
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_excitation]
+  []
+  [mean_en_excitation]
     type = ElectronEnergyLossFromExcitation
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
-  [./em]
+  [potential]
+  []
+  [em]
     block = 0
-  [../]
-  [./emliq]
+  []
+  [emliq]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
     # scaling = 1e-1
-  [../]
+  []
 
-  [./OHm]
+  [OHm]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x]
+  []
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./rholiq]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./em_lin]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [rholiq]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [emliq_lin]
+    order = CONSTANT
+    family = MONOMIAL
     block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Efield]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Current_em]
+  []
+  [Arp_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_emliq]
+  []
+  [OHm_lin]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Current_Arp]
+  []
+  [Efield]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_OHm]
-    block = 1
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+    block = 1
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [Current_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [tot_liq_current]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [tot_flux_OHm]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [DiffusiveFlux_em]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -503,8 +503,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -513,8 +513,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
     type = ADProcRate
     em = em
     potential = potential
@@ -522,8 +522,8 @@ dom1Scale=1e-7
     variable = ProcRate_el
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
     type = ADProcRate
     em = em
     potential = potential
@@ -531,8 +531,8 @@ dom1Scale=1e-7
     variable = ProcRate_ex
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
     type = ADProcRate
     em = em
     potential = potential
@@ -540,111 +540,111 @@ dom1Scale=1e-7
     variable = ProcRate_iz
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_l]
+  []
+  [x_l]
     type = Position
     variable = x
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_lin Arp_lin'
     function = 'Arp_lin - em_lin'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_lin OHm_lin' # H3Op_lin OHm_lin'
     function = '-emliq_lin - OHm_lin' # 'H3Op_lin - em_lin - OHm_lin'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = DensityMoles
     variable = emliq_lin
     density_log = emliq
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = DensityMoles
     variable = Arp_lin
     density_log = Arp
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = DensityMoles
     variable = OHm_lin
     density_log = OHm
     block = 1
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -652,8 +652,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
@@ -661,8 +661,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -670,8 +670,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     type = ADCurrent
     potential = potential
@@ -679,48 +679,48 @@ dom1Scale=1e-7
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -729,8 +729,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -738,11 +738,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -750,8 +750,8 @@ dom1Scale=1e-7
     em = em
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -759,8 +759,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -769,9 +769,9 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -782,15 +782,15 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
     preset = false
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -798,24 +798,24 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -823,8 +823,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -833,91 +833,91 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./emliq_right]
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_block]
+  [gas_block]
     type = Gas
     interp_trans_coeffs = true
     interp_elastic_coeff = true
@@ -929,10 +929,10 @@ dom1Scale=1e-7
     user_se_coeff = 0.05
     block = 0
     property_tables_file = td_argon_mean_en.txt
- [../]
- [./water_block]
+ []
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 []

--- a/test/tests/1d_dc/mean_en_multi.i
+++ b/test/tests/1d_dc/mean_en_multi.i
@@ -9,36 +9,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'liquidNew.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -46,11 +46,11 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -65,25 +65,25 @@ dom1Scale=1e-7
   nl_rel_tol = 1e-4
   nl_abs_tol = 7.6e-5
   dtmin = 1e-12
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
    optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
   # print_linear_residuals = false
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
-  [./dof_map]
+  []
+  [dof_map]
     type = DOFMap
-  [../]
+  []
 []
 
 [Debug]
@@ -91,34 +91,34 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [Kernels]
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_ionization]
+  []
+  [em_ionization]
     type = ElectronsFromIonization
     variable = em
     potential = potential
@@ -126,97 +126,97 @@ dom1Scale=1e-7
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_log_stabilization]
+  []
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
-  [./emliq_time_deriv]
+  []
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
     block = 1
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_reactant_first_order_rxn]
+  []
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_log_stabilization]
+  []
+  [emliq_log_stabilization]
     type = LogStabilizationMoles
     variable = emliq
     block = 1
-  [../]
-  [./potential_diffusion_dom1]
+  []
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom2]
+  []
+  [potential_diffusion_dom2]
     type = CoeffDiffusionLin
     variable = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
-  [./emliq_charge_source]
+  []
+  [emliq_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = emliq
     block = 1
-  [../]
-  [./OHm_charge_source]
+  []
+  [OHm_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = OHm
     block = 1
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = ElectronTimeDerivative
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./Arp_advection]
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
+  []
 
-  [./ArEx_excitation]
+  [ArEx_excitation]
     type = ExcitationReaction
     variable = ArEx
     potential = potential
@@ -225,9 +225,9 @@ dom1Scale=1e-7
     block = 0
     position_units = ${dom0Scale}
     reactant = false
-  [../]
+  []
 
-  [./ArEx_deexcitation]
+  [ArEx_deexcitation]
     type = ExcitationReaction
     variable = ArEx
     potential = potential
@@ -236,15 +236,15 @@ dom1Scale=1e-7
     block = 0
     position_units = ${dom0Scale}
     reactant = true
-  [../]
+  []
 
-  [./Arp_diffusion]
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_ionization]
+  []
+  [Arp_ionization]
     type = IonsFromIonization
     variable = Arp
     potential = potential
@@ -252,321 +252,321 @@ dom1Scale=1e-7
     mean_en = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_log_stabilization]
+  []
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./ArEx_time_deriv]
+  [ArEx_time_deriv]
     type = ElectronTimeDerivative
     variable = ArEx
     block = 0
-  [../]
+  []
 
-  [./ArEx_diffusion]
+  [ArEx_diffusion]
     type = CoeffDiffusion
     variable = ArEx
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./ArEx_log_stabilization]
+  [ArEx_log_stabilization]
     type = LogStabilizationMoles
     variable = ArEx
     block = 0
     offset = 30
-  [../]
+  []
 
-  [./ArTest_time_deriv]
+  [ArTest_time_deriv]
     type = ElectronTimeDerivative
     variable = ArTest
     block = 0
-  [../]
+  []
 
-  [./ArTest_diffusion]
+  [ArTest_diffusion]
     type = CoeffDiffusion
     variable = ArTest
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./ArTest_log_stabilization]
+  [ArTest_log_stabilization]
     type = LogStabilizationMoles
     variable = ArTest
     block = 0
-  [../]
+  []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
     block = 1
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_log_stabilization]
+  []
+  [OHm_log_stabilization]
     type = LogStabilizationMoles
     variable = OHm
     block = 1
-  [../]
-  [./OHm_product_first_order_rxn]
+  []
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_ionization]
+  []
+  [mean_en_ionization]
     type = ElectronEnergyLossFromIonization
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./mean_en_elastic]
+  [mean_en_elastic]
     type = ElectronEnergyLossFromElastic
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_excitation]
+  []
+  [mean_en_excitation]
     type = ElectronEnergyLossFromExcitation
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
-  [./em]
+  [potential]
+  []
+  [em]
     block = 0
-  [../]
-  [./emliq]
+  []
+  [emliq]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     block = 0
-  [../]
+  []
 
-  [./ArEx]
+  [ArEx]
     block = 0
-  [../]
+  []
 
-  [./ArTest]
+  [ArTest]
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
     # scaling = 1e-1
-  [../]
+  []
 
-  [./OHm]
+  [OHm]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x]
+  []
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ArEx_lin]
+  []
+  [ArEx_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ArTest_lin]
+  []
+  [ArTest_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efield]
+  []
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Current_em]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./Current_emliq]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 1
-  [../]
-  [./Current_Arp]
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_OHm]
-    block = 1
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+    block = 1
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [Current_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [tot_liq_current]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [tot_flux_OHm]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [DiffusiveFlux_em]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -575,8 +575,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -585,8 +585,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
     type = ADProcRate
     em = em
     potential = potential
@@ -594,8 +594,8 @@ dom1Scale=1e-7
     variable = ProcRate_el
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
     type = ADProcRate
     em = em
     potential = potential
@@ -603,8 +603,8 @@ dom1Scale=1e-7
     variable = ProcRate_ex
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
     type = ADProcRate
     em = em
     potential = potential
@@ -612,123 +612,123 @@ dom1Scale=1e-7
     variable = ProcRate_iz
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_l]
+  []
+  [x_l]
     type = Position
     variable = x
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_lin Arp_lin'
     function = 'Arp_lin - em_lin'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_lin OHm_lin' # H3Op_lin OHm_lin'
     function = '-emliq_lin - OHm_lin' # 'H3Op_lin - em_lin - OHm_lin'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = DensityMoles
     variable = emliq_lin
     density_log = emliq
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = DensityMoles
     variable = Arp_lin
     density_log = Arp
     block = 0
-  [../]
-  [./ArEx_lin]
+  []
+  [ArEx_lin]
     type = DensityMoles
     variable = ArEx_lin
     density_log = ArEx
     block = 0
-  [../]
-  [./ArTest_lin]
+  []
+  [ArTest_lin]
     type = DensityMoles
     variable = ArTest_lin
     density_log = ArTest
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = DensityMoles
     variable = OHm_lin
     density_log = OHm
     block = 1
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -736,8 +736,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
@@ -745,8 +745,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -754,8 +754,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     type = ADCurrent
     potential = potential
@@ -763,48 +763,48 @@ dom1Scale=1e-7
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -813,8 +813,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -822,11 +822,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -837,14 +837,14 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -852,23 +852,23 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_right]
+  []
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -876,8 +876,8 @@ dom1Scale=1e-7
     em = em
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -885,8 +885,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -895,51 +895,51 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./ArEx_physical_right_diffusion]
+  []
+  [ArEx_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = ArEx
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./ArEx_physical_left_diffusion]
+  []
+  [ArEx_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = ArEx
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./ArTest_physical_right_diffusion]
+  []
+  [ArTest_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = ArTest
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./ArTest_physical_left_diffusion]
+  []
+  [ArTest_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = ArTest
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -947,8 +947,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -957,89 +957,89 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./emliq_right]
+  []
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./ArEx_ic]
+  []
+  [ArEx_ic]
     type = ConstantIC
     variable = ArEx
     value = -16
     #value = -21
     block = 0
-  [../]
-  [./ArTest_ic]
+  []
+  [ArTest_ic]
     type = ConstantIC
     variable = ArTest
     value = -31
     #value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_block]
+  [gas_block]
     type = GasBase
     interp_trans_coeffs = true
     interp_elastic_coeff = true
@@ -1052,31 +1052,31 @@ dom1Scale=1e-7
     block = 0
     property_tables_file = td_argon_mean_en.txt
     position_units = ${dom0Scale}
- [../]
- [./gas_species_0]
+ []
+ [gas_species_0]
    type = ADHeavySpecies
    heavy_species_name = Arp
    heavy_species_mass = 6.64e-26
    heavy_species_charge = 1.0
    block = 0
- [../]
- [./gas_species_1]
+ []
+ [gas_species_1]
    type = ADHeavySpecies
    heavy_species_name = ArEx
    heavy_species_mass = 6.64e-26
    heavy_species_charge = 1.0
    block = 0
- [../]
- [./gas_species_2]
+ []
+ [gas_species_2]
    type = ADHeavySpecies
    heavy_species_name = ArTest
    heavy_species_mass = 6.64e-26
    heavy_species_charge = 1.0
    block = 0
- [../]
- [./water_block]
+ []
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 []

--- a/test/tests/1d_dc/tests
+++ b/test/tests/1d_dc/tests
@@ -1,29 +1,29 @@
 [Tests]
-  [./1d_dc]
+  [1d_dc]
     type = 'Exodiff'
     input = 'mean_en.i'
     exodiff = 'mean_en_out.e'
     group = '1d_dc'
     custom_cmp = 'mean_en_out.cmp'
-  [../]
-  [./1d_dc_densities]
+  []
+  [1d_dc_densities]
     type = 'RunApp'
     input = 'densities_mean_en.i'
     group = '1d_dc'
-  [../]
-  [./non_local_potential_bc]
+  []
+  [non_local_potential_bc]
     type = 'Exodiff'
     input = 'NonlocalPotentialBCWithSchottky.i'
     exodiff = 'NonlocalPotentialBCWithSchottky_out.e'
     group = '1d_dc'
     heavy = true
     custom_cmp = 'NonlocalPotentialBCWithSchottky.cmp'
-  [../]
-  [./1d_dc_multispecies]
+  []
+  [1d_dc_multispecies]
     type = 'Exodiff'
     input = 'mean_en_multi.i'
     exodiff = 'mean_en_multi_out.e'
     group = '1d_dc'
     custom_cmp = 'mean_en_multi_out.cmp'
-  [../]
+  []
 []

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables.i
@@ -6,22 +6,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -29,44 +29,44 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -74,9 +74,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -84,37 +84,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -122,9 +122,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -132,31 +132,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -164,9 +164,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -174,9 +174,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -184,9 +184,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -194,9 +194,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -205,9 +205,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -215,9 +215,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -226,332 +226,332 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  #[./emDeBug]
-  #[../]
-  #[./Ar+_DeBug]
-  #[../]
-  #[./Ar*_DeBug]
-  #[../]
-  #[./mean_enDeBug]
-  #[../]
+  #[emDeBug]
+  #[]
+  #[Ar+_DeBug]
+  #[]
+  #[Ar*_DeBug]
+  #[]
+  #[mean_enDeBug]
+  #[]
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  #[./emDeBug]
+  #[emDeBug]
   #  type = DebugResidualAux
   #  variable = emDeBug
   #  debug_variable = em
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./Ar+_DeBug]
+  #[]
+  #[Ar+_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar+_DeBug
   #  debug_variable = Ar+
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./mean_enDeBug]
+  #[]
+  #[mean_enDeBug]
   #  type = DebugResidualAux
   #  variable = mean_enDeBug
   #  debug_variable = mean_en
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./Ar*_DeBug]
+  #[]
+  #[Ar*_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar*_DeBug
   #  debug_variable = Ar*
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
+  #[]
 
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -559,8 +559,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -568,27 +568,27 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -599,8 +599,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -611,108 +611,108 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 100
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -724,108 +724,108 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -843,15 +843,15 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  [./TimeStepper]
+  [TimeStepper]
     type = PostprocessorDT
     postprocessor = InversePlasmaFreq
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At100mTorr.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At100mTorr.i
@@ -13,47 +13,47 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./potential_ion]
-  [../]
+  [potential_ion]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -61,9 +61,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -71,37 +71,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential_ion
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -109,9 +109,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -119,31 +119,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -151,9 +151,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -161,9 +161,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -171,9 +171,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -181,9 +181,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -192,9 +192,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -202,9 +202,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -213,389 +213,389 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
     # Energy loss from elastic collisions
-    [./Elastic_loss]
+    [Elastic_loss]
       type = EEDFElasticLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar'
-    [../]
+    []
 
     #Effective potential for the Ions
-    [./Ion_potential_time_deriv]
+    [Ion_potential_time_deriv]
       type = TimeDerivative
       variable = potential_ion
-    [../]
-    [./Ion_potential_reaction]
+    []
+    [Ion_potential_reaction]
       type = ScaledReaction
       variable = potential_ion
       collision_freq = 1283370.875
-    [../]
-    [./Ion_potential_coupled_force]
+    []
+    [Ion_potential_coupled_force]
       type = CoupledForce
       variable = potential_ion
       v = potential
       coef = 1283370.875
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./emDeBug]
-  [../]
-  [./Ar+_DeBug]
-  [../]
-  [./Ar*_DeBug]
-  [../]
-  [./mean_enDeBug]
-  [../]
-  [./potential_DeBug]
-  [../]
+  [emDeBug]
+  []
+  [Ar+_DeBug]
+  []
+  [Ar*_DeBug]
+  []
+  [mean_enDeBug]
+  []
+  [potential_DeBug]
+  []
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
+  []
+  [x_node]
+  []
 
-  [./y]
+  [y]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./y_node]
-  [../]
+  []
+  [y_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efieldx]
+  [Efieldx]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efieldy]
+  []
+  [Efieldy]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
+  []
 
 []
 
 [AuxKernels]
-  #[./emDeBug]
+  #[emDeBug]
   #  type = DebugResidualAux
   #  variable = emDeBug
   #  debug_variable = em
-  #[../]
-  #[./Ar+_DeBug]
+  #[]
+  #[Ar+_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar+_DeBug
   #  debug_variable = Ar+
-  #[../]
-  #[./mean_enDeBug]
+  #[]
+  #[mean_enDeBug]
   #  type = DebugResidualAux
   #  variable = mean_enDeBug
   #  debug_variable = mean_en
-  #[../]
-  #[./Ar*_DeBug]
+  #[]
+  #[Ar*_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar*_DeBug
   #  debug_variable = Ar*
-  #[../]
-  #[./Potential_DeBug]
+  #[]
+  #[Potential_DeBug]
   #  type = DebugResidualAux
   #  variable = potential_DeBug
   #  debug_variable = potential
-  #[../]
+  #[]
 
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./y_g]
+  [y_g]
     type = Position
     variable = y
     position_units = ${dom0Scale}
-  [../]
-  [./y_ng]
+  []
+  [y_ng]
     type = Position
     variable = y_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e2
     value = -5.231208
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efieldx_calc]
+  [Efieldx_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efieldx
     position_units = ${dom0Scale}
-  [../]
-  [./Efieldy_calc]
+  []
+  [Efieldy_calc]
     type = Efield
     component = 1
     potential = potential
     variable = Efieldy
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -603,8 +603,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential_ion
     density_log = Ar+
@@ -612,32 +612,32 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_top_plate]
+  [potential_top_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Top_Electrode'
     function = potential_top_bc_func
-  [../]
-  [./potential_bottom_plate]
+  []
+  [potential_bottom_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Bottom_Electrode'
     function = potential_bottom_bc_func
-  [../]
-  [./potential_dirichlet_bottom_plate]
+  []
+  [potential_dirichlet_bottom_plate]
     type = DirichletBC
     variable = potential
     boundary = 'Walls'
     value = 0
-  [../]
-  [./potential_Dielectric]
+  []
+  [potential_Dielectric]
     type = EconomouDielectricBC
     variable = potential
     boundary = 'Top_Insulator Bottom_Insulator'
@@ -649,18 +649,18 @@ dom0Scale=25.4e-3
     thickness = 0.0127
     users_gamma = 0.01
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_diffusion]
+  [em_physical_diffusion]
     type = SakiyamaElectronDiffusionBC
     variable = em
     mean_en = mean_en
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
-  [./em_Ar+_second_emissions]
+  []
+  [em_Ar+_second_emissions]
     type = SakiyamaSecondaryElectronBC
     variable = em
     potential = potential_ion
@@ -668,35 +668,35 @@ dom0Scale=25.4e-3
     users_gamma = 0.01
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential_ion
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_diffusion]
+  [Ar*_physical_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-[./mean_en_physical_diffusion]
+[mean_en_physical_diffusion]
   type = SakiyamaEnergyDiffusionBC
   variable = mean_en
   em = em
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
-[./mean_en_Ar+_second_emissions]
+[]
+[mean_en_Ar+_second_emissions]
   type = SakiyamaEnergySecondaryElectronBC
   variable = mean_en
   em = em
@@ -706,69 +706,69 @@ dom0Scale=25.4e-3
   se_coeff = 0.01
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
+[]
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = meta_density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_top_bc_func]
+  [potential_top_bc_func]
     type = ParsedFunction
     value = '50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_bottom_bc_func]
+  []
+  [potential_bottom_bc_func]
     type = ParsedFunction
     value = '-50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = 0
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./meta_density_ic_func]
+  []
+  [meta_density_ic_func]
     type = ParsedFunction
     value = 'log((1e16)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.) * 4) + log((1e14)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = true
     interp_elastic_coeff = false
@@ -779,116 +779,116 @@ dom0Scale=25.4e-3
     mean_en = mean_en
     user_se_coeff = 0.00
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 1.44409938
     diffusivity = 6.428571e-2
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-2
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_00]
+  []
+  [reaction_00]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_elastic.txt'
     reaction = 'em + Ar -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -906,16 +906,16 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  #[./TimeStepper]
+  #[TimeStepper]
   #  type = PostprocessorDT
   #  postprocessor = InversePlasmaFreq
   #  scale = 0.1
-  #[../]
+  #[]
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At1Torr.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At1Torr.i
@@ -14,47 +14,47 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./potential_ion]
-  [../]
+  [potential_ion]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -62,9 +62,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -72,37 +72,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential_ion
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -110,9 +110,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -120,31 +120,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -152,9 +152,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -162,9 +162,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -172,9 +172,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -182,9 +182,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -193,9 +193,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -203,9 +203,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -214,389 +214,389 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
     # Energy loss from elastic collisions
-    [./Elastic_loss]
+    [Elastic_loss]
       type = EEDFElasticLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar'
-    [../]
+    []
 
     #Effective potential for the Ions
-    [./Ion_potential_time_deriv]
+    [Ion_potential_time_deriv]
       type = TimeDerivative
       variable = potential_ion
-    [../]
-    [./Ion_potential_reaction]
+    []
+    [Ion_potential_reaction]
       type = ScaledReaction
       variable = potential_ion
       collision_freq = 1283370.875
-    [../]
-    [./Ion_potential_coupled_force]
+    []
+    [Ion_potential_coupled_force]
       type = CoupledForce
       variable = potential_ion
       v = potential
       coef = 1283370.875
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./emDeBug]
-  [../]
-  [./Ar+_DeBug]
-  [../]
-  [./Ar*_DeBug]
-  [../]
-  [./mean_enDeBug]
-  [../]
-  [./potential_DeBug]
-  [../]
+  [emDeBug]
+  []
+  [Ar+_DeBug]
+  []
+  [Ar*_DeBug]
+  []
+  [mean_enDeBug]
+  []
+  [potential_DeBug]
+  []
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
+  []
+  [x_node]
+  []
 
-  [./y]
+  [y]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./y_node]
-  [../]
+  []
+  [y_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efieldx]
+  [Efieldx]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efieldy]
+  []
+  [Efieldy]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
+  []
 
 []
 
 [AuxKernels]
-  #[./emDeBug]
+  #[emDeBug]
   #  type = DebugResidualAux
   #  variable = emDeBug
   #  debug_variable = em
-  #[../]
-  #[./Ar+_DeBug]
+  #[]
+  #[Ar+_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar+_DeBug
   #  debug_variable = Ar+
-  #[../]
-  #[./mean_enDeBug]
+  #[]
+  #[mean_enDeBug]
   #  type = DebugResidualAux
   #  variable = mean_enDeBug
   #  debug_variable = mean_en
-  #[../]
-  #[./Ar*_DeBug]
+  #[]
+  #[Ar*_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar*_DeBug
   #  debug_variable = Ar*
-  #[../]
-  #[./Potential_DeBug]
+  #[]
+  #[Potential_DeBug]
   #  type = DebugResidualAux
   #  variable = potential_DeBug
   #  debug_variable = potential
-  #[../]
+  #[]
 
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./y_g]
+  [y_g]
     type = Position
     variable = y
     position_units = ${dom0Scale}
-  [../]
-  [./y_ng]
+  []
+  [y_ng]
     type = Position
     variable = y_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efieldx_calc]
+  [Efieldx_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efieldx
     position_units = ${dom0Scale}
-  [../]
-  [./Efieldy_calc]
+  []
+  [Efieldy_calc]
     type = Efield
     component = 1
     potential = potential
     variable = Efieldy
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -604,8 +604,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential_ion
     density_log = Ar+
@@ -613,32 +613,32 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_top_plate]
+  [potential_top_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Top_Electrode'
     function = potential_top_bc_func
-  [../]
-  [./potential_bottom_plate]
+  []
+  [potential_bottom_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Bottom_Electrode'
     function = potential_bottom_bc_func
-  [../]
-  [./potential_dirichlet_bottom_plate]
+  []
+  [potential_dirichlet_bottom_plate]
     type = DirichletBC
     variable = potential
     boundary = 'Walls'
     value = 0
-  [../]
-  [./potential_Dielectric]
+  []
+  [potential_Dielectric]
     type = EconomouDielectricBC
     variable = potential
     boundary = 'Top_Insulator Bottom_Insulator'
@@ -650,18 +650,18 @@ dom0Scale=25.4e-3
     thickness = 0.0127
     users_gamma = 0.01
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_diffusion]
+  [em_physical_diffusion]
     type = SakiyamaElectronDiffusionBC
     variable = em
     mean_en = mean_en
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
-  [./em_Ar+_second_emissions]
+  []
+  [em_Ar+_second_emissions]
     type = SakiyamaSecondaryElectronBC
     variable = em
     potential = potential_ion
@@ -669,35 +669,35 @@ dom0Scale=25.4e-3
     users_gamma = 0.01
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential_ion
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_diffusion]
+  [Ar*_physical_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-[./mean_en_physical_diffusion]
+[mean_en_physical_diffusion]
   type = SakiyamaEnergyDiffusionBC
   variable = mean_en
   em = em
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
-[./mean_en_Ar+_second_emissions]
+[]
+[mean_en_Ar+_second_emissions]
   type = SakiyamaEnergySecondaryElectronBC
   variable = mean_en
   em = em
@@ -707,69 +707,69 @@ dom0Scale=25.4e-3
   se_coeff = 0.01
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
+[]
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = meta_density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_top_bc_func]
+  [potential_top_bc_func]
     type = ParsedFunction
     value = '30*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_bottom_bc_func]
+  []
+  [potential_bottom_bc_func]
     type = ParsedFunction
     value = '-30*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = 0
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./meta_density_ic_func]
+  []
+  [meta_density_ic_func]
     type = ParsedFunction
     value = 'log((1e16)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.)) + log((1e14)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = true
     interp_elastic_coeff = false
@@ -780,116 +780,116 @@ dom0Scale=25.4e-3
     mean_en = mean_en
     user_se_coeff = 0.00
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 1.44409938
     diffusivity = 6.428571e-2
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-2
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_00]
+  []
+  [reaction_00]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_elastic.txt'
     reaction = 'em + Ar -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -908,16 +908,16 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  #[./TimeStepper]
+  #[TimeStepper]
   #  type = PostprocessorDT
   #  postprocessor = InversePlasmaFreq
   #  scale = 0.1
-  #[../]
+  #[]
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/Conference_Syntax_Tests/tests
+++ b/test/tests/Conference_Syntax_Tests/tests
@@ -1,21 +1,21 @@
 [Tests]
-  [./Lymberopoulos_with_argon_metastables]
+  [Lymberopoulos_with_argon_metastables]
     type = RunApp
     input = 'Lymberopoulos_with_argon_metastables.i'
     check_input = True
     method = opt
-  [../]
-  [./Lymberopoulos_with_argon_metastables_2D_At100mTorr]
+  []
+  [Lymberopoulos_with_argon_metastables_2D_At100mTorr]
     type = RunApp
     input = 'Lymberopoulos_with_argon_metastables_2D_At100mTorr.i'
     check_input = True
     method = opt
-  [../]
-  [./Lymberopoulos_with_argon_metastables_2D_At1Torr]
+  []
+  [Lymberopoulos_with_argon_metastables_2D_At1Torr]
     type = RunApp
     input = 'Lymberopoulos_with_argon_metastables_2D_At1Torr.i'
     check_input = True
     method = opt
     petsc_version = '>=3.9.0'
-  [../]
+  []
 []

--- a/test/tests/DriftDiffusionAction/2D_RF_Plasma_actions.i
+++ b/test/tests/DriftDiffusionAction/2D_RF_Plasma_actions.i
@@ -16,14 +16,14 @@ dom0Scale=25.4e-3
 #DriftDiffusionAction, but charged particles effective by
 #this potential can by defined by the action.
 [Variables]
-  [./potential_ion]
-  [../]
+  [potential_ion]
+  []
 []
 
 #Action the supplies the drift-diffusion equations
 #This action also adds JouleHeating and the ChargeSourceMoles_KV Kernels
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     electrons = em
     secondary_charged_particles = Ar+
     Neutrals = Ar*
@@ -34,13 +34,13 @@ dom0Scale=25.4e-3
     using_offset = false
     position_units = ${dom0Scale}
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
+  []
 []
 
 #The Kernels supply the sources terms
 [Kernels]
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -48,9 +48,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -58,19 +58,19 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -78,9 +78,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -88,19 +88,19 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -108,9 +108,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -118,9 +118,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -128,9 +128,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -138,9 +138,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -149,9 +149,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -159,9 +159,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -170,237 +170,237 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
     # Energy loss from elastic collisions
-    [./Elastic_loss]
+    [Elastic_loss]
       type = EEDFElasticLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar'
-    [../]
+    []
 
     #Effective potential for the Ions
-    [./Ion_potential_time_deriv]
+    [Ion_potential_time_deriv]
       type = TimeDerivative
       variable = potential_ion
-    [../]
-    [./Ion_potential_reaction]
+    []
+    [Ion_potential_reaction]
       type = ScaledReaction
       variable = potential_ion
       collision_freq = 1283370.875
-    [../]
-    [./Ion_potential_coupled_force]
+    []
+    [Ion_potential_coupled_force]
       type = CoupledForce
       variable = potential_ion
       v = potential
       coef = 1283370.875
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./y_node]
-  [../]
+  [y_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./emRate]
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
+  []
 
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     component = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./y_ng]
+  [y_ng]
     type = Position
     variable = y_node
     component = 1
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e2
     value = -5.231208
     execute_on = INITIAL
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_top_plate]
+  [potential_top_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Top_Electrode'
     function = potential_top_bc_func
     preset = false
-  [../]
-  [./potential_bottom_plate]
+  []
+  [potential_bottom_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Bottom_Electrode'
     function = potential_bottom_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_bottom_plate]
+  []
+  [potential_dirichlet_bottom_plate]
     type = DirichletBC
     variable = potential
     boundary = 'Walls'
     value = 0
     preset = false
-  [../]
-  [./potential_Dielectric]
+  []
+  [potential_Dielectric]
     type = EconomouDielectricBC
     variable = potential
     boundary = 'Top_Insulator Bottom_Insulator'
@@ -412,18 +412,18 @@ dom0Scale=25.4e-3
     thickness = 0.0127
     users_gamma = 0.01
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_diffusion]
+  [em_physical_diffusion]
     type = SakiyamaElectronDiffusionBC
     variable = em
     mean_en = mean_en
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
-  [./em_Ar+_second_emissions]
+  []
+  [em_Ar+_second_emissions]
     type = SakiyamaSecondaryElectronBC
     variable = em
     potential = potential_ion
@@ -431,35 +431,35 @@ dom0Scale=25.4e-3
     users_gamma = 0.01
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential_ion
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_diffusion]
+  [Ar*_physical_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-[./mean_en_physical_diffusion]
+[mean_en_physical_diffusion]
   type = SakiyamaEnergyDiffusionBC
   variable = mean_en
   em = em
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
-[./mean_en_Ar+_second_emissions]
+[]
+[mean_en_Ar+_second_emissions]
   type = SakiyamaEnergySecondaryElectronBC
   variable = mean_en
   em = em
@@ -469,69 +469,69 @@ dom0Scale=25.4e-3
   se_coeff = 0.01
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
+[]
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = meta_density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_top_bc_func]
+  [potential_top_bc_func]
     type = ParsedFunction
     value = '50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_bottom_bc_func]
+  []
+  [potential_bottom_bc_func]
     type = ParsedFunction
     value = '-50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = 0
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./meta_density_ic_func]
+  []
+  [meta_density_ic_func]
     type = ParsedFunction
     value = 'log((1e16)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.) * 4) + log((1e14)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = true
     interp_elastic_coeff = false
@@ -542,116 +542,116 @@ dom0Scale=25.4e-3
     mean_en = mean_en
     user_se_coeff = 0.00
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 1.44409938
     diffusivity = 6.428571e-2
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-2
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_00]
+  []
+  [reaction_00]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_elastic.txt'
     reaction = 'em + Ar -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + Ar'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + em + Ar+'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -670,17 +670,17 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  #[./TimeStepper]
+  #[TimeStepper]
   #  type = PostprocessorDT
   #  postprocessor = InversePlasmaFreq
   #  scale = 0.1
-  #[../]
+  #[]
 []
 
 [Outputs]
   file_base = '2D_RF_out'
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/DriftDiffusionAction/2D_RF_Plasma_no_actions.i
+++ b/test/tests/DriftDiffusionAction/2D_RF_Plasma_no_actions.i
@@ -18,47 +18,47 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./potential_ion]
-  [../]
+  [potential_ion]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -66,9 +66,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -76,37 +76,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential_ion
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -114,9 +114,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -124,31 +124,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -156,9 +156,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -166,9 +166,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -176,9 +176,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -186,9 +186,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -197,9 +197,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -207,9 +207,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -218,356 +218,356 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
     # Energy loss from elastic collisions
-    [./Elastic_loss]
+    [Elastic_loss]
       type = EEDFElasticLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar'
-    [../]
+    []
 
     #Effective potential for the Ions
-    [./Ion_potential_time_deriv]
+    [Ion_potential_time_deriv]
       type = TimeDerivative
       variable = potential_ion
-    [../]
-    [./Ion_potential_reaction]
+    []
+    [Ion_potential_reaction]
       type = ScaledReaction
       variable = potential_ion
       collision_freq = 1283370.875
-    [../]
-    [./Ion_potential_coupled_force]
+    []
+    [Ion_potential_coupled_force]
       type = CoupledForce
       variable = potential_ion
       v = potential
       coef = 1283370.875
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_position]
+  [x_position]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
+  []
+  [x_node]
+  []
 
-  [./y_position]
+  [y_position]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./y_node]
-  [../]
+  []
+  [y_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_density]
+  [em_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_density]
+  [Ar+_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_density]
+  [Ar*_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efieldx]
+  [Efieldx]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efieldy]
+  []
+  [Efieldy]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./Current_Ar+]
+  []
+  [Current_Ar+]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
+  []
 
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x_position
     component = 0
     position_units = ${dom0Scale}
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     component = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./y_g]
+  [y_g]
     type = Position
     variable = y_position
     component = 1
     position_units = ${dom0Scale}
-  [../]
-  [./y_ng]
+  []
+  [y_ng]
     type = Position
     variable = y_node
     component = 1
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_density]
+  [em_density]
     type = DensityMoles
     variable = em_density
     density_log = em
-  [../]
-  [./Ar+_density]
+  []
+  [Ar+_density]
     type = DensityMoles
     variable = Ar+_density
     density_log = Ar+
-  [../]
-  [./Ar*_density]
+  []
+  [Ar*_density]
     type = DensityMoles
     variable = Ar*_density
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e2
     value = -5.231208
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efieldx_calc]
+  [Efieldx_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efieldx
     position_units = ${dom0Scale}
-  [../]
-  [./Efieldy_calc]
+  []
+  [Efieldy_calc]
     type = Efield
     component = 1
     potential = potential
     variable = Efieldy
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -575,8 +575,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential_ion
     density_log = Ar+
@@ -584,32 +584,32 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_top_plate]
+  [potential_top_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Top_Electrode'
     function = potential_top_bc_func
-  [../]
-  [./potential_bottom_plate]
+  []
+  [potential_bottom_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Bottom_Electrode'
     function = potential_bottom_bc_func
-  [../]
-  [./potential_dirichlet_bottom_plate]
+  []
+  [potential_dirichlet_bottom_plate]
     type = DirichletBC
     variable = potential
     boundary = 'Walls'
     value = 0
-  [../]
-  [./potential_Dielectric]
+  []
+  [potential_Dielectric]
     type = EconomouDielectricBC
     variable = potential
     boundary = 'Top_Insulator Bottom_Insulator'
@@ -621,18 +621,18 @@ dom0Scale=25.4e-3
     thickness = 0.0127
     users_gamma = 0.01
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_diffusion]
+  [em_physical_diffusion]
     type = SakiyamaElectronDiffusionBC
     variable = em
     mean_en = mean_en
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
-  [./em_Ar+_second_emissions]
+  []
+  [em_Ar+_second_emissions]
     type = SakiyamaSecondaryElectronBC
     variable = em
     potential = potential_ion
@@ -640,35 +640,35 @@ dom0Scale=25.4e-3
     users_gamma = 0.01
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential_ion
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_diffusion]
+  [Ar*_physical_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-[./mean_en_physical_diffusion]
+[mean_en_physical_diffusion]
   type = SakiyamaEnergyDiffusionBC
   variable = mean_en
   em = em
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
-[./mean_en_Ar+_second_emissions]
+[]
+[mean_en_Ar+_second_emissions]
   type = SakiyamaEnergySecondaryElectronBC
   variable = mean_en
   em = em
@@ -678,69 +678,69 @@ dom0Scale=25.4e-3
   se_coeff = 0.01
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
+[]
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = meta_density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_top_bc_func]
+  [potential_top_bc_func]
     type = ParsedFunction
     value = '50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_bottom_bc_func]
+  []
+  [potential_bottom_bc_func]
     type = ParsedFunction
     value = '-50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = 0
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./meta_density_ic_func]
+  []
+  [meta_density_ic_func]
     type = ParsedFunction
     value = 'log((1e16)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.) * 4) + log((1e14)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = true
     interp_elastic_coeff = false
@@ -751,116 +751,116 @@ dom0Scale=25.4e-3
     mean_en = mean_en
     user_se_coeff = 0.00
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 1.44409938
     diffusivity = 6.428571e-2
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-2
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_00]
+  []
+  [reaction_00]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_elastic.txt'
     reaction = 'em + Ar -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + Ar'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + em + Ar+'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -879,17 +879,17 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  #[./TimeStepper]
+  #[TimeStepper]
   #  type = PostprocessorDT
   #  postprocessor = InversePlasmaFreq
   #  scale = 0.1
-  #[../]
+  #[]
 []
 
 [Outputs]
   file_base = '2D_RF_out'
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/DriftDiffusionAction/RF_Plasma_actions.i
+++ b/test/tests/DriftDiffusionAction/RF_Plasma_actions.i
@@ -6,22 +6,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -31,7 +31,7 @@ dom0Scale=25.4e-3
 #Action the supplies the drift-diffusion equations
 #This action also adds JouleHeating and the ChargeSourceMoles_KV Kernels
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     electrons = em
     charged_particle = Ar+
     Neutrals = Ar*
@@ -41,13 +41,13 @@ dom0Scale=25.4e-3
     using_offset = false
     position_units = ${dom0Scale}
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
+  []
 []
 
 #The Kernels supply the sources terms
 [Kernels]
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -55,9 +55,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -65,19 +65,19 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -85,9 +85,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -95,19 +95,19 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -115,9 +115,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -125,9 +125,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -135,9 +135,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -145,9 +145,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -156,9 +156,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -166,9 +166,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -177,187 +177,187 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./emRate]
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -368,8 +368,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -380,108 +380,108 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 100
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -493,108 +493,108 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -616,7 +616,7 @@ dom0Scale=25.4e-3
 [Outputs]
   file_base = 'RF_out'
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/DriftDiffusionAction/RF_Plasma_no_actions.i
+++ b/test/tests/DriftDiffusionAction/RF_Plasma_no_actions.i
@@ -11,22 +11,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,44 +34,44 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -79,9 +79,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -89,37 +89,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -127,9 +127,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -137,31 +137,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -169,9 +169,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -179,9 +179,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -189,9 +189,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -199,9 +199,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -210,9 +210,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -220,9 +220,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -231,323 +231,323 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./position]
+  [position]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_density]
+  [em_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_density]
+  [Ar+_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_density]
+  [Ar*_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./EFieldx]
+  [EFieldx]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Current_Ar+]
+  []
+  [Current_Ar+]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = position
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_density]
+  [em_density]
     type = DensityMoles
     variable = em_density
     density_log = em
-  [../]
-  [./Ar+_density]
+  []
+  [Ar+_density]
     type = DensityMoles
     variable = Ar+_density
     density_log = Ar+
-  [../]
-  [./Ar*_density]
+  []
+  [Ar*_density]
     type = DensityMoles
     variable = Ar*_density
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = EFieldx
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
     variable = Current_em
     art_diff = false
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar+]
+  []
+  [Current_Ar+]
     type = ADCurrent
     potential = potential
     density_log = Ar+
     variable = Current_Ar+
     art_diff = false
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -558,8 +558,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -570,108 +570,108 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 100
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -683,108 +683,108 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -806,7 +806,7 @@ dom0Scale=25.4e-3
 [Outputs]
   file_base = 'RF_out'
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/DriftDiffusionAction/mean_en_actions.i
+++ b/test/tests/DriftDiffusionAction/mean_en_actions.i
@@ -10,36 +10,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'liquidNew.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -48,11 +48,11 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -71,23 +71,23 @@ dom1Scale=1e-7
  nl_abs_tol = 7.6e-5
   dtmin = 1e-12
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     # dt = 1.1
     growth_factor = 1.2
    optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   file_base = out
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
+  []
 []
 
 [Debug]
@@ -95,7 +95,7 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
@@ -103,20 +103,20 @@ dom1Scale=1e-7
     # electrode_area = 1.1
     # ballast_resist = 1.1
     # e = 1.1
-  [../]
+  []
 []
 
 #The potential needs to be defined outside of the Action,
 #since it is present in both Blocks
 [Variables]
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 #Action the supplies the drift-diffusion equations for both Blocks,
 #This action also adds JouleHeating and the ChargeSourceMoles_KV Kernels
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     electrons = em
     charged_particle = Arp
     potential = potential
@@ -126,8 +126,8 @@ dom1Scale=1e-7
     position_units = ${dom0Scale}
     block = 0
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
-  [./Water]
+  []
+  [Water]
     electrons = emliq
     charged_particle = OHm
     potential = potential
@@ -136,12 +136,12 @@ dom1Scale=1e-7
     position_units = ${dom1Scale}
     block = 1
     Additional_Outputs = 'Current EField'
-  [../]
+  []
 []
 
 #The Kernels supply the sources terms
 [Kernels]
-  [./em_ionization]
+  [em_ionization]
     type = ElectronsFromIonization
     variable = em
     potential = potential
@@ -149,20 +149,20 @@ dom1Scale=1e-7
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./emliq_reactant_first_order_rxn]
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
     block = 1
-  [../]
+  []
 
-  [./Arp_ionization]
+  [Arp_ionization]
     type = IonsFromIonization
     variable = Arp
     potential = potential
@@ -170,124 +170,124 @@ dom1Scale=1e-7
     mean_en = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./OHm_product_first_order_rxn]
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
+  []
 
-  [./mean_en_ionization]
+  [mean_en_ionization]
     type = ElectronEnergyLossFromIonization
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_elastic]
+  []
+  [mean_en_elastic]
     type = ElectronEnergyLossFromElastic
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_excitation]
+  []
+  [mean_en_excitation]
     type = ElectronEnergyLossFromExcitation
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./x_node]
-  [../]
-  [./rho]
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -296,8 +296,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -306,8 +306,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
     type = ADProcRate
     em = em
     potential = potential
@@ -315,8 +315,8 @@ dom1Scale=1e-7
     variable = ProcRate_el
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
     type = ADProcRate
     em = em
     potential = potential
@@ -324,8 +324,8 @@ dom1Scale=1e-7
     variable = ProcRate_ex
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
     type = ADProcRate
     em = em
     potential = potential
@@ -333,92 +333,92 @@ dom1Scale=1e-7
     variable = ProcRate_iz
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_density Arp_density'
     function = 'Arp_density - em_density'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_density OHm_density'
     function = '-emliq_density - OHm_density'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -427,8 +427,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -436,11 +436,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -448,8 +448,8 @@ dom1Scale=1e-7
     em = em
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -457,8 +457,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -467,9 +467,9 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -480,14 +480,14 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -495,24 +495,24 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -520,8 +520,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -530,91 +530,91 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./emliq_right]
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_block]
+  [gas_block]
     type = Gas
     interp_trans_coeffs = true
     interp_elastic_coeff = true
@@ -626,10 +626,10 @@ dom1Scale=1e-7
     user_se_coeff = 0.05
     block = 0
     property_tables_file = td_argon_mean_en.txt
- [../]
- [./water_block]
+ []
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 []

--- a/test/tests/DriftDiffusionAction/mean_en_no_actions.i
+++ b/test/tests/DriftDiffusionAction/mean_en_no_actions.i
@@ -14,36 +14,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'liquidNew.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -52,11 +52,11 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -75,23 +75,23 @@ dom1Scale=1e-7
  nl_abs_tol = 7.6e-5
   dtmin = 1e-12
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     # dt = 1.1
     growth_factor = 1.2
    optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   file_base = out
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
+  []
 []
 
 [Debug]
@@ -99,7 +99,7 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
@@ -107,29 +107,29 @@ dom1Scale=1e-7
     # electrode_area = 1.1
     # ballast_resist = 1.1
     # e = 1.1
-  [../]
+  []
 []
 
 [Kernels]
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_ionization]
+  []
+  [em_ionization]
     type = ElectronsFromIonization
     variable = em
     potential = potential
@@ -137,115 +137,115 @@ dom1Scale=1e-7
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_log_stabilization]
+  []
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
-  # [./em_advection_stabilization]
+  []
+  # [em_advection_stabilization]
   #   type = EFieldArtDiff
   #   variable = em
   #   potential = potential
   #   block = 0
-  # [../]
+  # []
 
-  [./emliq_time_deriv]
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
     block = 1
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_reactant_first_order_rxn]
+  []
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
     block = 1
-  [../]
-  [./emliq_log_stabilization]
+  []
+  [emliq_log_stabilization]
     type = LogStabilizationMoles
     variable = emliq
     block = 1
-  [../]
-  # [./emliq_advection_stabilization]
+  []
+  # [emliq_advection_stabilization]
   #   type = EFieldArtDiff
   #   variable = emliq
   #   potential = potential
   #   block = 1
-  # [../]
+  # []
 
-  [./potential_diffusion_dom1]
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom2]
+  []
+  [potential_diffusion_dom2]
     type = CoeffDiffusionLin
     variable = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
-  [./emliq_charge_source]
+  []
+  [emliq_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = emliq
     block = 1
-  [../]
-  [./OHm_charge_source]
+  []
+  [OHm_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = OHm
     block = 1
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = ElectronTimeDerivative
     variable = Arp
     block = 0
-  [../]
-  [./Arp_advection]
+  []
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Arp_diffusion]
+  []
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_ionization]
+  []
+  [Arp_ionization]
     type = IonsFromIonization
     variable = Arp
     potential = potential
@@ -253,321 +253,321 @@ dom1Scale=1e-7
     mean_en = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_log_stabilization]
+  []
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
-  # [./Arp_advection_stabilization]
+  []
+  # [Arp_advection_stabilization]
   #   type = EFieldArtDiff
   #   variable = Arp
   #   potential = potential
   #   block = 0
-  # [../]
+  # []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
     block = 1
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_log_stabilization]
+  []
+  [OHm_log_stabilization]
     type = LogStabilizationMoles
     variable = OHm
     block = 1
-  [../]
-  # [./OHm_advection_stabilization]
+  []
+  # [OHm_advection_stabilization]
   #   type = EFieldArtDiff
   #   variable = OHm
   #   potential = potential
   #   block = 1
-  # [../]
-  [./OHm_product_first_order_rxn]
+  # []
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
     block = 1
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_ionization]
+  []
+  [mean_en_ionization]
     type = ElectronEnergyLossFromIonization
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_elastic]
+  []
+  [mean_en_elastic]
     type = ElectronEnergyLossFromElastic
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_excitation]
+  []
+  [mean_en_excitation]
     type = ElectronEnergyLossFromExcitation
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15.0
-  [../]
-  # [./mean_en_advection_stabilization]
+  []
+  # [mean_en_advection_stabilization]
   #   type = EFieldArtDiff
   #   variable = mean_en
   #   potential = potential
   #   block = 0
-  # [../]
+  # []
 []
 
 [Variables]
-  [./potential]
-  [../]
-  [./em]
+  [potential]
+  []
+  [em]
     block = 0
-  [../]
-  [./emliq]
+  []
+  [emliq]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
     # scaling = 1e-1
-  [../]
+  []
 
-  [./OHm]
+  [OHm]
     block = 1
     # scaling = 1e-5
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./e_temp]
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-    #[./x]
+  []
+    #[x]
     #  order = CONSTANT
     #  family = MONOMIAL
-    #[../]
-  [./position0]
+    #[]
+  [position0]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./position1]
+  []
+  [position1]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-    #[./em_lin]
-    #  order = CONSTANT
-    #  family = MONOMIAL
-    #  block = 0
-    #[../]
-  [./em_density]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-    #[./emliq_lin]
-    #  order = CONSTANT
-    #  family = MONOMIAL
-    #  block = 1
-    #[../]
-  [./emliq_density]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 1
-  [../]
-    #[./Arp_lin]
+  []
+    #[em_lin]
     #  order = CONSTANT
     #  family = MONOMIAL
     #  block = 0
-    #[../]
-  [./Arp_density]
+    #[]
+  [em_density]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-    #[./OHm_lin]
+  []
+    #[emliq_lin]
+    #  order = CONSTANT
+    #  family = MONOMIAL
+    #  block = 1
+    #[]
+  [emliq_density]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 1
+  []
+    #[Arp_lin]
+    #  order = CONSTANT
+    #  family = MONOMIAL
+    #  block = 0
+    #[]
+  [Arp_density]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+    #[OHm_lin]
     #  block = 1
     #  order = CONSTANT
     #  family = MONOMIAL
-    #[../]
-  [./OHm_density]
+    #[]
+  [OHm_density]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-    #[./Efield]
+  []
+    #[Efield]
     #  order = CONSTANT
     #  family = MONOMIAL
-    #[../]
-  [./EFieldx0]
+    #[]
+  [EFieldx0]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldx1]
+  []
+  [EFieldx1]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -576,8 +576,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -586,8 +586,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_el]
+  []
+  [ProcRate_el]
     type = ADProcRate
     em = em
     potential = potential
@@ -595,8 +595,8 @@ dom1Scale=1e-7
     variable = ProcRate_el
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_ex]
+  []
+  [ProcRate_ex]
     type = ADProcRate
     em = em
     potential = potential
@@ -604,8 +604,8 @@ dom1Scale=1e-7
     variable = ProcRate_ex
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./ProcRate_iz]
+  []
+  [ProcRate_iz]
     type = ADProcRate
     em = em
     potential = potential
@@ -613,111 +613,111 @@ dom1Scale=1e-7
     variable = ProcRate_iz
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = position0
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_l]
+  []
+  [x_l]
     type = Position
     variable = position1
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_density Arp_density'
     function = 'Arp_density - em_density'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_density OHm_density'
     function = '-emliq_density - OHm_density'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = DensityMoles
     variable = em_density
     density_log = em
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = DensityMoles
     variable = emliq_density
     density_log = emliq
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = DensityMoles
     variable = Arp_density
     density_log = Arp
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = DensityMoles
     variable = OHm_density
     density_log = OHm
     block = 1
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = EFieldx0
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = EFieldx1
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -725,8 +725,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
@@ -734,8 +734,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -743,8 +743,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     type = ADCurrent
     potential = potential
@@ -752,48 +752,48 @@ dom1Scale=1e-7
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -802,8 +802,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -811,11 +811,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -823,8 +823,8 @@ dom1Scale=1e-7
     em = em
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -832,8 +832,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -842,9 +842,9 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -855,14 +855,14 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -870,24 +870,24 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.99
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -895,8 +895,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -905,91 +905,91 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./emliq_right]
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_block]
+  [gas_block]
     type = Gas
     interp_trans_coeffs = true
     interp_elastic_coeff = true
@@ -1001,10 +1001,10 @@ dom1Scale=1e-7
     user_se_coeff = 0.05
     block = 0
     property_tables_file = td_argon_mean_en.txt
- [../]
- [./water_block]
+ []
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 []

--- a/test/tests/DriftDiffusionAction/tests
+++ b/test/tests/DriftDiffusionAction/tests
@@ -1,46 +1,46 @@
 [Tests]
-  [./WaterPlasma]
+  [WaterPlasma]
     type = 'Exodiff'
     input = 'mean_en_actions.i'
     exodiff = 'out.e'
     custom_cmp = 'mean_en_out.cmp'
     group = 'drift_diffusion'
-  [../]
-  [./WaterPlasma_no_action_syntax]
+  []
+  [WaterPlasma_no_action_syntax]
     type = RunApp
     input = 'mean_en_no_actions.i'
     check_input = True
     method = opt
     prereq = WaterPlasma
     group = 'drift_diffusion'
-  [../]
-  [./RFPlasma]
+  []
+  [RFPlasma]
     type = 'Exodiff'
     input = 'RF_Plasma_actions.i'
     exodiff = 'RF_out.e'
     group = 'drift_diffusion'
-  [../]
-  [./RFPlasma_no_action_syntax]
+  []
+  [RFPlasma_no_action_syntax]
     type = RunApp
     input = 'RF_Plasma_no_actions.i'
     check_input = True
     method = opt
     prereq = RFPlasma
     group = 'drift_diffusion'
-  [../]
-  [./2D_RFPlasma]
+  []
+  [2D_RFPlasma]
     type = 'Exodiff'
     input = '2D_RF_Plasma_actions.i'
     exodiff = '2D_RF_out.e'
     custom_cmp = '2D_RF_out.cmp'
     group = 'drift_diffusion'
-  [../]
-  [./2D_RFPlasma_no_action_syntax]
+  []
+  [2D_RFPlasma_no_action_syntax]
     type = RunApp
     input = '2D_RF_Plasma_no_actions.i'
     check_input = True
     method = opt
     prereq = 2D_RFPlasma
     group = 'drift_diffusion'
-  [../]
+  []
 []

--- a/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i
+++ b/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i
@@ -6,22 +6,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -29,44 +29,44 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -74,9 +74,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -84,37 +84,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -122,9 +122,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -132,31 +132,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -164,9 +164,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -174,9 +174,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -184,9 +184,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -194,9 +194,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -205,9 +205,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -215,9 +215,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -226,332 +226,332 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  #[./emDeBug]
-  #[../]
-  #[./Ar+_DeBug]
-  #[../]
-  #[./Ar*_DeBug]
-  #[../]
-  #[./mean_enDeBug]
-  #[../]
+  #[emDeBug]
+  #[]
+  #[Ar+_DeBug]
+  #[]
+  #[Ar*_DeBug]
+  #[]
+  #[mean_enDeBug]
+  #[]
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  #[./emDeBug]
+  #[emDeBug]
   #  type = DebugResidualAux
   #  variable = emDeBug
   #  debug_variable = em
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./Ar+_DeBug]
+  #[]
+  #[Ar+_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar+_DeBug
   #  debug_variable = Ar+
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./mean_enDeBug]
+  #[]
+  #[mean_enDeBug]
   #  type = DebugResidualAux
   #  variable = mean_enDeBug
   #  debug_variable = mean_en
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
-  #[./Ar*_DeBug]
+  #[]
+  #[Ar*_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar*_DeBug
   #  debug_variable = Ar*
   #  #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  #[../]
+  #[]
 
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -559,8 +559,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -568,29 +568,29 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -601,8 +601,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -613,108 +613,108 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 100
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -726,108 +726,108 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -845,15 +845,15 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  [./TimeStepper]
+  [TimeStepper]
     type = PostprocessorDT
     postprocessor = InversePlasmaFreq
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh.i
+++ b/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh.i
@@ -13,47 +13,47 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./potential_ion]
-  [../]
+  [potential_ion]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -61,9 +61,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -71,37 +71,37 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential_ion
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -109,9 +109,9 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -119,31 +119,31 @@ dom0Scale=25.4e-3
       mean_energy = mean_en
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -151,9 +151,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -161,9 +161,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -171,9 +171,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -181,9 +181,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -192,9 +192,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -202,9 +202,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -213,389 +213,389 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
     # Energy loss from elastic collisions
-    [./Elastic_loss]
+    [Elastic_loss]
       type = EEDFElasticLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar'
-    [../]
+    []
 
     #Effective potential for the Ions
-    [./Ion_potential_time_deriv]
+    [Ion_potential_time_deriv]
       type = TimeDerivative
       variable = potential_ion
-    [../]
-    [./Ion_potential_reaction]
+    []
+    [Ion_potential_reaction]
       type = ScaledReaction
       variable = potential_ion
       collision_freq = 1283370.875
-    [../]
-    [./Ion_potential_coupled_force]
+    []
+    [Ion_potential_coupled_force]
       type = CoupledForce
       variable = potential_ion
       v = potential
       coef = 1283370.875
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./emDeBug]
-  [../]
-  [./Ar+_DeBug]
-  [../]
-  [./Ar*_DeBug]
-  [../]
-  [./mean_enDeBug]
-  [../]
-  [./potential_DeBug]
-  [../]
+  [emDeBug]
+  []
+  [Ar+_DeBug]
+  []
+  [Ar*_DeBug]
+  []
+  [mean_enDeBug]
+  []
+  [potential_DeBug]
+  []
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
+  []
+  [x_node]
+  []
 
-  [./y]
+  [y]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./y_node]
-  [../]
+  []
+  [y_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efieldx]
+  [Efieldx]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efieldy]
+  []
+  [Efieldy]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 'plasma'
-  [../]
+  []
 
 []
 
 [AuxKernels]
-  #[./emDeBug]
+  #[emDeBug]
   #  type = DebugResidualAux
   #  variable = emDeBug
   #  debug_variable = em
-  #[../]
-  #[./Ar+_DeBug]
+  #[]
+  #[Ar+_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar+_DeBug
   #  debug_variable = Ar+
-  #[../]
-  #[./mean_enDeBug]
+  #[]
+  #[mean_enDeBug]
   #  type = DebugResidualAux
   #  variable = mean_enDeBug
   #  debug_variable = mean_en
-  #[../]
-  #[./Ar*_DeBug]
+  #[]
+  #[Ar*_DeBug]
   #  type = DebugResidualAux
   #  variable = Ar*_DeBug
   #  debug_variable = Ar*
-  #[../]
-  #[./Potential_DeBug]
+  #[]
+  #[Potential_DeBug]
   #  type = DebugResidualAux
   #  variable = potential_DeBug
   #  debug_variable = potential
-  #[../]
+  #[]
 
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./y_g]
+  [y_g]
     type = Position
     variable = y
     position_units = ${dom0Scale}
-  [../]
-  [./y_ng]
+  []
+  [y_ng]
     type = Position
     variable = y_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e2
     value = -5.231208
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efieldx_calc]
+  [Efieldx_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efieldx
     position_units = ${dom0Scale}
-  [../]
-  [./Efieldy_calc]
+  []
+  [Efieldy_calc]
     type = Efield
     component = 1
     potential = potential
     variable = Efieldy
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -603,8 +603,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential_ion
     density_log = Ar+
@@ -612,35 +612,35 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 'plasma'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_top_plate]
+  [potential_top_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Top_Electrode'
     function = potential_top_bc_func
     preset = false
-  [../]
-  [./potential_bottom_plate]
+  []
+  [potential_bottom_plate]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'Bottom_Electrode'
     function = potential_bottom_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_bottom_plate]
+  []
+  [potential_dirichlet_bottom_plate]
     type = DirichletBC
     variable = potential
     boundary = 'Walls'
     value = 0
     preset = false
-  [../]
-  [./potential_Dielectric]
+  []
+  [potential_Dielectric]
     type = EconomouDielectricBC
     variable = potential
     boundary = 'Top_Insulator Bottom_Insulator'
@@ -652,18 +652,18 @@ dom0Scale=25.4e-3
     thickness = 0.0127
     users_gamma = 0.01
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_diffusion]
+  [em_physical_diffusion]
     type = SakiyamaElectronDiffusionBC
     variable = em
     mean_en = mean_en
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
-  [./em_Ar+_second_emissions]
+  []
+  [em_Ar+_second_emissions]
     type = SakiyamaSecondaryElectronBC
     variable = em
     potential = potential_ion
@@ -671,35 +671,35 @@ dom0Scale=25.4e-3
     users_gamma = 0.01
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential_ion
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_diffusion]
+  [Ar*_physical_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-[./mean_en_physical_diffusion]
+[mean_en_physical_diffusion]
   type = SakiyamaEnergyDiffusionBC
   variable = mean_en
   em = em
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
-[./mean_en_Ar+_second_emissions]
+[]
+[mean_en_Ar+_second_emissions]
   type = SakiyamaEnergySecondaryElectronBC
   variable = mean_en
   em = em
@@ -709,69 +709,69 @@ dom0Scale=25.4e-3
   se_coeff = 0.01
   boundary = 'Top_Electrode Bottom_Electrode Top_Insulator Bottom_Insulator Walls'
   position_units = ${dom0Scale}
-[../]
+[]
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = meta_density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_top_bc_func]
+  [potential_top_bc_func]
     type = ParsedFunction
     value = '50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_bottom_bc_func]
+  []
+  [potential_bottom_bc_func]
     type = ParsedFunction
     value = '-50*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = 0
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./meta_density_ic_func]
+  []
+  [meta_density_ic_func]
     type = ParsedFunction
     value = 'log((1e16)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.) * 4) + log((1e14)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = true
     interp_elastic_coeff = false
@@ -782,116 +782,116 @@ dom0Scale=25.4e-3
     mean_en = mean_en
     user_se_coeff = 0.00
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 1.44409938
     diffusivity = 6.428571e-2
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-2
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_00]
+  []
+  [reaction_00]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_elastic.txt'
     reaction = 'em + Ar -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excitation.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_ionization.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + Ar'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_deexcitation.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     reaction = 'em + Ar* -> em + em + Ar+'
     property_file = 'Argon_reactions_paper_RateCoefficients/ar_excited_ionization.txt'
     file_location = ''
     mean_energy = mean_en
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-42
     reaction_rate_value = 398909.324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -910,16 +910,16 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  #[./TimeStepper]
+  #[TimeStepper]
   #  type = PostprocessorDT
   #  postprocessor = InversePlasmaFreq
   #  scale = 0.1
-  #[../]
+  #[]
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/Lymberopoulos_rf_discharge/tests
+++ b/test/tests/Lymberopoulos_rf_discharge/tests
@@ -1,16 +1,16 @@
 [Tests]
-  [./Lymberopoulos_with_argon_metastables]
+  [Lymberopoulos_with_argon_metastables]
     type = 'Exodiff'
     input = 'Lymberopoulos_with_argon_metastables.i'
     exodiff = 'Lymberopoulos_with_argon_metastables_out.e'
     group = 'lymberopoulos'
-  [../]
+  []
 
-  [./Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh]
+  [Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh]
     type = 'Exodiff'
     input = 'Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh.i'
     exodiff = 'Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh_out.e'
     group = 'lymberopoulos'
     custom_cmp = 2d.cmp
-  [../]
+  []
 []

--- a/test/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion.i
+++ b/test/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion.i
@@ -1,20 +1,20 @@
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Sample_Periodic_Diffusion.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -22,34 +22,34 @@
 []
 
 [Variables]
-  [./y]
-  [../]
+  [y]
+  []
 []
 
 [Kernels]
-  [./Time_Deriv]
+  [Time_Deriv]
     type = TimeDerivative
     variable = y
-  [../]
-  [./Diff]
+  []
+  [Diff]
     type = ADMatDiffusion
     variable = y
     diffusivity = 'diffy'
-  [../]
-  [./First_Term]
+  []
+  [First_Term]
     type = BodyForce
     variable = y
     function = '0.25 * sin(2.0*pi * t) * sin(2.0*pi * t)'
-  [../]
-  [./Second_Term]
+  []
+  [Second_Term]
     type = ReactionFirstOrder
     variable = y
     v = y
     coefficient = -1
     reaction = 'firstorder'
     _v_eq_u = true
-  [../]
-  [./Thrid_Term]
+  []
+  [Thrid_Term]
     type = ReactionSecondOrder
     variable = y
     v = y
@@ -58,72 +58,72 @@
     reaction = 'secondorder'
     _v_eq_u = true
     _w_eq_u = true
-  [../]
+  []
 []
 
 [BCs]
-  [./Walls]
+  [Walls]
     type = DirichletBC
     variable = y
     value = 0
     boundary = 'left right'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_species_0]
+  [gas_species_0]
     type = ADGenericConstantMaterial
     prop_names = 'diffy'
     prop_values = 0.001
-  [../]
-  [./firstorder_coefficient]
+  []
+  [firstorder_coefficient]
     type = GenericRateConstant
     reaction = 'firstorder'
     reaction_rate_value = 0.05
-  [../]
-  [./secondorder_coefficient]
+  []
+  [secondorder_coefficient]
     type = GenericRateConstant
     reaction = 'secondorder'
     reaction_rate_value = 0.015
-  [../]
+  []
 []
 
 [PeriodicRelativeNodalDifference]
-  [./Periodic_Y_Diff]
+  [Periodic_Y_Diff]
     periodic_variable = y
     cycle_frequency = 1.0
     num_cycles = 75
     starting_cycle = 25
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./diff_counter]
+  [diff_counter]
     type = PeriodicComparisonCounter
     value1 = y_periodic_difference
     value2 = 1e-5
     frequency = 1
     comparison_type = less_than
-  [../]
+  []
 []
 
 [UserObjects]
-  [./End]
+  [End]
     type = Terminator
     expression = '(if(diff_counter>=10,1,0)) = 1'
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
-  [./fdp]
+  []
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -143,7 +143,7 @@
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion_Log.i
+++ b/test/tests/PeriodicRelativeNodalDifference/Sample_Periodic_Diffusion_Log.i
@@ -1,20 +1,20 @@
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Sample_Periodic_Diffusion.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -22,35 +22,35 @@
 []
 
 [Variables]
-  [./y]
+  [y]
     initial_condition = -23
-  [../]
+  []
 []
 
 [Kernels]
-  [./Time_Deriv]
+  [Time_Deriv]
     type = TimeDerivativeLog
     variable = y
-  [../]
-  [./Diff]
+  []
+  [Diff]
     type = CoeffDiffusion
     variable = y
     position_units = 1.0
-  [../]
-  [./First_Term]
+  []
+  [First_Term]
     type = BodyForce
     variable = y
     function = '0.25 * sin(2.0*pi * t) * sin(2.0*pi * t)'
-  [../]
-  [./Second_Term]
+  []
+  [Second_Term]
     type = ReactionFirstOrderLog
     variable = y
     v = y
     coefficient = -1
     reaction = 'firstorder'
     _v_eq_u = true
-  [../]
-  [./Thrid_Term]
+  []
+  [Thrid_Term]
     type = ReactionSecondOrderLog
     variable = y
     v = y
@@ -59,86 +59,86 @@
     reaction = 'secondorder'
     _v_eq_u = true
     _w_eq_u = true
-  [../]
+  []
 []
 
 [BCs]
-  [./Walls]
+  [Walls]
     type = DirichletBC
     variable = y
     value = -23.0
     boundary = 'left right'
-  [../]
+  []
 []
 
 [Materials]
-  [./gas_species_0]
+  [gas_species_0]
     type = ADGenericConstantMaterial
     prop_names = 'diffy'
     prop_values = 0.001
-  [../]
-  [./firstorder_coefficient]
+  []
+  [firstorder_coefficient]
     type = GenericRateConstant
     reaction = 'firstorder'
     reaction_rate_value = 0.05
-  [../]
-  [./secondorder_coefficient]
+  []
+  [secondorder_coefficient]
     type = GenericRateConstant
     reaction = 'secondorder'
     reaction_rate_value = 0.015
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./yLog]
-  [../]
+  [yLog]
+  []
 []
 
 [AuxKernels]
-  [./Log_Func]
+  [Log_Func]
     type = DensityLogConvert
     variable = yLog
     density_log = y
     use_moles = false
-  [../]
+  []
 []
 
 [PeriodicRelativeNodalDifference]
-  [./test]
+  [test]
     periodic_variable_log = y
     cycle_frequency = 1.0
     num_cycles = 75
     starting_cycle = 25
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./diff_counter]
+  [diff_counter]
     type = PeriodicComparisonCounter
     value1 = y_periodic_difference
     value2 = 1e-5
     frequency = 1
     comparison_type = less_than
-  [../]
+  []
 []
 
 [UserObjects]
-  [./End]
+  [End]
     type = Terminator
     expression = '(if(diff_counter>=10,1,0)) = 1'
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
-  [./fdp]
+  []
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -158,7 +158,7 @@
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/PeriodicRelativeNodalDifference/tests
+++ b/test/tests/PeriodicRelativeNodalDifference/tests
@@ -1,13 +1,13 @@
 [Tests]
-  [./Sample_Periodic_Diffusion]
+  [Sample_Periodic_Diffusion]
     type = 'Exodiff'
     input = 'Sample_Periodic_Diffusion.i'
     exodiff = 'Sample_Periodic_Diffusion_out.e'
-  [../]
+  []
 
-  [./Sample_Periodic_Diffusion_Log]
+  [Sample_Periodic_Diffusion_Log]
     type = 'Exodiff'
     input = 'Sample_Periodic_Diffusion_Log.i'
     exodiff = 'Sample_Periodic_Diffusion_Log_out.e'
-  [../]
+  []
 []

--- a/test/tests/Schottky_emission/Example1/Input.i
+++ b/test/tests/Schottky_emission/Example1/Input.i
@@ -9,22 +9,22 @@ vhigh = -200E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -33,10 +33,10 @@ vhigh = -200E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -59,22 +59,22 @@ vhigh = -200E-3 #kV
         dtmin = 1e-16
         # dtmax = 1E-6
         nl_max_its = 100
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-11
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -82,60 +82,60 @@ vhigh = -200E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e0
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 50
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 50
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 50
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -143,48 +143,48 @@ vhigh = -200E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -192,160 +192,160 @@ vhigh = -200E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -354,8 +354,8 @@ vhigh = -200E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -364,8 +364,8 @@ vhigh = -200E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -373,8 +373,8 @@ vhigh = -200E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -382,8 +382,8 @@ vhigh = -200E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -391,65 +391,65 @@ vhigh = -200E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -457,8 +457,8 @@ vhigh = -200E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -466,27 +466,27 @@ vhigh = -200E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -497,17 +497,17 @@ vhigh = -200E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -519,9 +519,9 @@ vhigh = -200E-3 #kV
                 position_units = ${dom0Scale}
                 # tau = 10E-6
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -529,52 +529,52 @@ vhigh = -200E-3 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -582,9 +582,9 @@ vhigh = -200E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -592,53 +592,53 @@ vhigh = -200E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -40
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -40
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -39
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -654,5 +654,5 @@ vhigh = -200E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/Example1/tests
+++ b/test/tests/Schottky_emission/Example1/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/Schottky_emission/Example2/Input.i
+++ b/test/tests/Schottky_emission/Example2/Input.i
@@ -9,22 +9,22 @@ vhigh = -80E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -33,10 +33,10 @@ vhigh = -80E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -59,22 +59,22 @@ vhigh = -80E-3 #kV
         dtmin = 1e-16
         # dtmax = 1E-6
         nl_max_its = 100
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-11
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -82,60 +82,60 @@ vhigh = -80E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e0
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 50
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 50
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 50
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -143,48 +143,48 @@ vhigh = -80E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -192,160 +192,160 @@ vhigh = -80E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -354,8 +354,8 @@ vhigh = -80E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -364,8 +364,8 @@ vhigh = -80E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -373,8 +373,8 @@ vhigh = -80E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -382,8 +382,8 @@ vhigh = -80E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -391,65 +391,65 @@ vhigh = -80E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -457,8 +457,8 @@ vhigh = -80E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -466,27 +466,27 @@ vhigh = -80E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -497,17 +497,17 @@ vhigh = -80E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -519,9 +519,9 @@ vhigh = -80E-3 #kV
                 position_units = ${dom0Scale}
                 # tau = 10E-6
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -529,52 +529,52 @@ vhigh = -80E-3 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -582,9 +582,9 @@ vhigh = -80E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -592,53 +592,53 @@ vhigh = -80E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -29
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -654,5 +654,5 @@ vhigh = -80E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/Example2/tests
+++ b/test/tests/Schottky_emission/Example2/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/Schottky_emission/Example3/Input.i
+++ b/test/tests/Schottky_emission/Example3/Input.i
@@ -12,22 +12,22 @@ threeTimesRelaxTime = 150E-6 #s
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -36,10 +36,10 @@ threeTimesRelaxTime = 150E-6 #s
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -62,22 +62,22 @@ threeTimesRelaxTime = 150E-6 #s
         dtmin = 1e-25
         # dtmax = 1E-6
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -85,60 +85,60 @@ threeTimesRelaxTime = 150E-6 #s
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e0
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 20
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 20
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 35
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -146,48 +146,48 @@ threeTimesRelaxTime = 150E-6 #s
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -195,160 +195,160 @@ threeTimesRelaxTime = 150E-6 #s
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -357,8 +357,8 @@ threeTimesRelaxTime = 150E-6 #s
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -367,8 +367,8 @@ threeTimesRelaxTime = 150E-6 #s
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -376,8 +376,8 @@ threeTimesRelaxTime = 150E-6 #s
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -385,8 +385,8 @@ threeTimesRelaxTime = 150E-6 #s
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -394,65 +394,65 @@ threeTimesRelaxTime = 150E-6 #s
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -460,8 +460,8 @@ threeTimesRelaxTime = 150E-6 #s
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -469,27 +469,27 @@ threeTimesRelaxTime = 150E-6 #s
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -500,17 +500,17 @@ threeTimesRelaxTime = 150E-6 #s
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -522,9 +522,9 @@ threeTimesRelaxTime = 150E-6 #s
                 position_units = ${dom0Scale}
                 # tau = ${relaxTime}
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -532,52 +532,52 @@ threeTimesRelaxTime = 150E-6 #s
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -585,9 +585,9 @@ threeTimesRelaxTime = 150E-6 #s
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -595,53 +595,53 @@ threeTimesRelaxTime = 150E-6 #s
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -25
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -657,5 +657,5 @@ threeTimesRelaxTime = 150E-6 #s
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/Example3/tests
+++ b/test/tests/Schottky_emission/Example3/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/Schottky_emission/Example4/Input.i
+++ b/test/tests/Schottky_emission/Example4/Input.i
@@ -13,22 +13,22 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -37,10 +37,10 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -63,22 +63,22 @@ area = 5.02e-7 # Formerly 3.14e-6
         dtmin = 1e-15
         # dtmax = 1E-6
         nl_max_its = 50
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 20
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -86,7 +86,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [UserObjects]
-        [./current_density_user_object]
+        [current_density_user_object]
                 type = CurrentDensityShapeSideUserObject
                 boundary = left
                 potential = potential
@@ -94,61 +94,61 @@ area = 5.02e-7 # Formerly 3.14e-6
                 ip = Arp
                 mean_en = mean_en
                 execute_on = 'linear nonlinear'
-        [../]
-        [./data_provider]
+        []
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = ${area}
                 ballast_resist = ${resistance}
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 20
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 20
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 35
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -156,48 +156,48 @@ area = 5.02e-7 # Formerly 3.14e-6
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -205,160 +205,160 @@ area = 5.02e-7 # Formerly 3.14e-6
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -367,8 +367,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -377,8 +377,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -386,8 +386,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -395,8 +395,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -404,65 +404,65 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = DensityMoles
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = DensityMoles
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -470,8 +470,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -479,27 +479,27 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-#       [./potential_left]
+#       [potential_left]
 #               type = NeumannCircuitVoltageMoles_KV
 #               variable = potential
 #               boundary = left
@@ -510,9 +510,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-        # [./potential_left]
+        # [potential_left]
         #       boundary = left
         #       type = NeumannCircuitVoltageNew
         #       variable = potential
@@ -523,9 +523,9 @@ area = 5.02e-7 # Formerly 3.14e-6
         #       mean_en = mean_en
         #       data_provider = data_provider
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./potential_left]
+        [potential_left]
           boundary = left
           type = PenaltyCircuitPotential
           variable = potential
@@ -541,17 +541,17 @@ area = 5.02e-7 # Formerly 3.14e-6
           potential_units = 'kV'
           position_units = ${dom0Scale}
           resistance = ${resistance}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -563,9 +563,9 @@ area = 5.02e-7 # Formerly 3.14e-6
                 position_units = ${dom0Scale}
                 tau = ${relaxTime}
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -573,52 +573,52 @@ area = 5.02e-7 # Formerly 3.14e-6
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -626,9 +626,9 @@ area = 5.02e-7 # Formerly 3.14e-6
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -636,53 +636,53 @@ area = 5.02e-7 # Formerly 3.14e-6
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -25
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -698,5 +698,5 @@ area = 5.02e-7 # Formerly 3.14e-6
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/Example4/Jac.i
+++ b/test/tests/Schottky_emission/Example4/Jac.i
@@ -29,10 +29,10 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -55,22 +55,22 @@ area = 5.02e-7 # Formerly 3.14e-6
         dtmin = 1e-25
         # dtmax = 1E-6
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -78,7 +78,7 @@ area = 5.02e-7 # Formerly 3.14e-6
 []
 
 [UserObjects]
-        [./current_density_user_object]
+        [current_density_user_object]
                 type = CurrentDensityShapeSideUserObject
                 boundary = left
                 potential = potential
@@ -86,63 +86,63 @@ area = 5.02e-7 # Formerly 3.14e-6
                 ip = Arp
                 mean_en = mean_en
                 execute_on = 'linear nonlinear'
-        [../]
-        [./data_provider]
+        []
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = ${area}
                 ballast_resist = ${resistance}
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-#       [./Arp_log_stabilization]
+#       [Arp_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = Arp
 #               offset = 20
 #               block = 0
-#       [../]
-#       [./em_log_stabilization]
+#       []
+#       [em_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = em
 #               offset = 20
 #               block = 0
-#       [../]
-#       [./mean_en_log_stabilization]
+#       []
+#       [mean_en_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = mean_en
 #               block = 0
 #               offset = 35
-#       [../]
-# #     [./mean_en_advection_stabilization]
+#       []
+# #     [mean_en_advection_stabilization]
 # #             type = EFieldArtDiff
 # #             variable = mean_en
 # #             potential = potential
 # #             block = 0
-# #     [../]
+# #     []
 
-#       [./em_time_deriv]
+#       [em_time_deriv]
 #               type = ElectronTimeDerivative
 #               variable = em
 #               block = 0
-#       [../]
-#       [./em_advection]
+#       []
+#       [em_advection]
 #               type = EFieldAdvection
 #               variable = em
 #               potential = potential
 #               mean_en = mean_en
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./em_diffusion]
+#       []
+#       [em_diffusion]
 #               type = CoeffDiffusion
 #               variable = em
 #               mean_en = mean_en
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./em_ionization]
+#       []
+#       [em_ionization]
 #               type = ElectronsFromIonization
 #               em = em
 #               variable = em
@@ -150,48 +150,48 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
 
-#       [./potential_diffusion_dom1]
+#       [potential_diffusion_dom1]
 #               type = CoeffDiffusionLin
 #               variable = potential
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-#       [./Arp_charge_source]
+#       [Arp_charge_source]
 #               type = ChargeSourceMoles_KV
 #               variable = potential
 #               charged = Arp
 #               block = 0
-#       [../]
-#       [./em_charge_source]
+#       []
+#       [em_charge_source]
 #               type = ChargeSourceMoles_KV
 #               variable = potential
 #               charged = em
 #               block = 0
-#       [../]
+#       []
 
-#       [./Arp_time_deriv]
+#       [Arp_time_deriv]
 #               type = ElectronTimeDerivative
 #               variable = Arp
 #               block = 0
-#       [../]
-#       [./Arp_advection]
+#       []
+#       [Arp_advection]
 #               type = EFieldAdvection
 #               variable = Arp
 #               potential = potential
 #               position_units = ${dom0Scale}
 #               block = 0
-#       [../]
-#       [./Arp_diffusion]
+#       []
+#       [Arp_diffusion]
 #               type = CoeffDiffusion
 #               variable = Arp
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./Arp_ionization]
+#       []
+#       [Arp_ionization]
 #               type = IonsFromIonization
 #               variable = Arp
 #               potential = potential
@@ -199,162 +199,162 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-#       [./mean_en_time_deriv]
+#       [mean_en_time_deriv]
 #               type = ElectronTimeDerivative
 #               variable = mean_en
 #               block = 0
-#       [../]
-#       [./mean_en_advection]
+#       []
+#       [mean_en_advection]
 #               type = EFieldAdvection
 #               variable = mean_en
 #               potential = potential
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./mean_en_diffusion]
+#       []
+#       [mean_en_diffusion]
 #               type = CoeffDiffusion
 #               variable = mean_en
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./mean_en_joule_heating]
+#       []
+#       [mean_en_joule_heating]
 #               type = JouleHeating
 #               variable = mean_en
 #               potential = potential
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./mean_en_ionization]
+#       []
+#       [mean_en_ionization]
 #               type = ElectronEnergyLossFromIonization
 #               variable = mean_en
 #               potential = potential
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./mean_en_elastic]
+#       []
+#       [mean_en_elastic]
 #               type = ElectronEnergyLossFromElastic
 #               variable = mean_en
 #               potential = potential
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./mean_en_excitation]
+#       []
+#       [mean_en_excitation]
 #               type = ElectronEnergyLossFromExcitation
 #               variable = mean_en
 #               potential = potential
 #               em = em
 #               block = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -363,8 +363,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -373,8 +373,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -382,8 +382,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -391,8 +391,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -400,65 +400,65 @@ area = 5.02e-7 # Formerly 3.14e-6
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -466,8 +466,8 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -475,27 +475,27 @@ area = 5.02e-7 # Formerly 3.14e-6
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-#       [./potential_left]
+#       [potential_left]
 #               type = NeumannCircuitVoltageMoles_KV
 #               variable = potential
 #               boundary = left
@@ -506,9 +506,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-        # [./potential_left]
+        # [potential_left]
         #       boundary = left
         #       type = NeumannCircuitVoltageNew
         #       variable = potential
@@ -523,9 +523,9 @@ area = 5.02e-7 # Formerly 3.14e-6
         #       data_provider = data_provider
 
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./potential_left]
+        [potential_left]
           boundary = left
           type = PenaltyCircuitPotential
           variable = potential
@@ -541,17 +541,17 @@ area = 5.02e-7 # Formerly 3.14e-6
           potential_units = 'kV'
           position_units = ${dom0Scale}
           resistance = ${resistance}
-        [../]
+        []
 
-#       [./potential_dirichlet_right]
+#       [potential_dirichlet_right]
 #               type = DirichletBC
 #               variable = potential
 #               boundary = right
 #               value = 0
-#       [../]
+#       []
 
 # ## Electron boundary conditions ##
-#       [./Emission_left]
+#       [Emission_left]
 #               type = SchottkyEmissionBC
 # #             type = SecondaryElectronBC
 #               variable = em
@@ -563,9 +563,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               position_units = ${dom0Scale}
 #               # tau = ${relaxTime}
 #               relax = true
-#       [../]
+#       []
 
-#       # [./em_physical_left]
+#       # [em_physical_left]
 #       #       type = HagelaarElectronBC
 #       #       variable = em
 #       #       boundary = 'left'
@@ -573,9 +573,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #       #       mean_en = mean_en
 #       #       r = 0
 #       #       position_units = ${dom0Scale}
-#       # [../]
+#       # []
 
-#       [./em_physical_right]
+#       [em_physical_right]
 #               type = HagelaarElectronAdvectionBC
 #               variable = em
 #               boundary = right
@@ -583,43 +583,43 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               mean_en = mean_en
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
 # ## Argon boundary conditions ##
-#       [./Arp_physical_left_diffusion]
+#       [Arp_physical_left_diffusion]
 #               type = HagelaarIonDiffusionBC
 #               variable = Arp
 #               boundary = 'left'
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./Arp_physical_left_advection]
+#       []
+#       [Arp_physical_left_advection]
 #               type = HagelaarIonAdvectionBC
 #               variable = Arp
 #               boundary = 'left'
 #               potential = potential
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-#       [./Arp_physical_right_diffusion]
+#       [Arp_physical_right_diffusion]
 #               type = HagelaarIonDiffusionBC
 #               variable = Arp
 #               boundary = right
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
-#       [./Arp_physical_right_advection]
+#       []
+#       [Arp_physical_right_advection]
 #               type = HagelaarIonAdvectionBC
 #               variable = Arp
 #               boundary = right
 #               potential = potential
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
 # ## Mean energy boundary conditions ##
-#       [./mean_en_physical_left]
+#       [mean_en_physical_left]
 #               type = HagelaarEnergyBC
 #               variable = mean_en
 #               boundary = 'left'
@@ -628,9 +628,9 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               ip = Arp
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 
-#       [./mean_en_physical_right]
+#       [mean_en_physical_right]
 #               type = HagelaarEnergyBC
 #               variable = mean_en
 #               boundary = right
@@ -639,56 +639,56 @@ area = 5.02e-7 # Formerly 3.14e-6
 #               ip = Arp
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
+#       []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 variable = em
                 type = RandomIC
                 block = 0
                 min = -20
                 max = -15
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 variable = Arp
                 type = RandomIC
                 block = 0
                 min = -20
                 max = -15
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 variable = mean_en
                 type = RandomIC
                 block = 0
                 min = -20
                 max = -15
-        [../]
+        []
 []
 
 [Functions]
-        # [./potential_bc_func]
+        # [potential_bc_func]
         #       type = ParsedFunction
         #       vars = 'VHigh'
         #       vals = '${vhigh}'
         #       value = 'VHigh'
-        # [../]
-        [./potential_ic_func]
+        # []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -704,5 +704,5 @@ area = 5.02e-7 # Formerly 3.14e-6
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/Example4/tests
+++ b/test/tests/Schottky_emission/Example4/tests
@@ -1,14 +1,14 @@
 [Tests]
-  [./test_input]
+  [test_input]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
-  [./test_user_jac]
+  []
+  [test_user_jac]
     type = RunApp
     input = 'Jac.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/Schottky_emission/PaschenLaw/Input.i
+++ b/test/tests/Schottky_emission/PaschenLaw/Input.i
@@ -10,22 +10,22 @@ vhigh = -0.10 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,10 +34,10 @@ vhigh = -0.10 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -60,22 +60,22 @@ vhigh = -0.10 #kV
         dtmin = 1e-20
         # dtmax = 1E-6
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-11
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -83,60 +83,60 @@ vhigh = -0.10 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e0
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 50
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 50
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 50
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
                 em = em
                 variable = em
@@ -144,48 +144,48 @@ vhigh = -0.10 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -193,160 +193,160 @@ vhigh = -0.10 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -355,8 +355,8 @@ vhigh = -0.10 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -365,8 +365,8 @@ vhigh = -0.10 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -374,8 +374,8 @@ vhigh = -0.10 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -383,8 +383,8 @@ vhigh = -0.10 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -392,65 +392,65 @@ vhigh = -0.10 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -458,8 +458,8 @@ vhigh = -0.10 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -467,27 +467,27 @@ vhigh = -0.10 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -498,17 +498,17 @@ vhigh = -0.10 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -520,9 +520,9 @@ vhigh = -0.10 #kV
                 position_units = ${dom0Scale}
                 # tau = 5E-6
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -530,52 +530,52 @@ vhigh = -0.10 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -583,9 +583,9 @@ vhigh = -0.10 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -593,53 +593,53 @@ vhigh = -0.10 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -33
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -33
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -29
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -655,5 +655,5 @@ vhigh = -0.10 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/Schottky_emission/PaschenLaw/tests
+++ b/test/tests/Schottky_emission/PaschenLaw/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/TM10_circular_wg/TM_steady.i
+++ b/test/tests/TM10_circular_wg/TM_steady.i
@@ -15,11 +15,11 @@
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -37,78 +37,78 @@
 [Outputs]
   perf_graph = true
   print_linear_residuals = false
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []
 
 [Kernels]
-  [./TM]
+  [TM]
     type = TM0Cylindrical
     variable = Hphi
-  [../]
+  []
 []
 
 [Variables]
-  [./Hphi]
-  [../]
+  [Hphi]
+  []
 []
 
 [BCs]
-  [./launcher]
+  [launcher]
     type = TM0AntennaVertBC
     boundary = Antenna
     variable = Hphi
-  [../]
-  [./vert_wall]
+  []
+  [vert_wall]
     type = TM0PECVertBC
     variable = Hphi
     boundary = vert_pec
-  [../]
-  [./axis]
+  []
+  [axis]
     type = DirichletBC
     variable = Hphi
     boundary = Axis
     value = 0
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./Hphi_mag]
-  [../]
-  [./Er]
+  [Hphi_mag]
+  []
+  [Er]
     order = FIRST
     family = MONOMIAL
-  [../]
-  [./Electric_z]
+  []
+  [Electric_z]
     order = FIRST
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./Hphi_mag]
+  [Hphi_mag]
     type = AbsValueAux
     u = Hphi
     variable = Hphi_mag
-  [../]
-  [./Er]
+  []
+  [Er]
     type = TM0CylindricalErAux
     Hphi = Hphi
     variable = Er
-  [../]
-  [./Electric_z]
+  []
+  [Electric_z]
     type = TM0CylindricalEzAux
     Hphi = Hphi
     variable = Electric_z
-  [../]
+  []
 []
 
 [Materials]
-   [./vacuum]
+   [vacuum]
      type = ADGenericConstantMaterial
      prop_names = 'eps_r'
      prop_values = '1'
      block = vacuum
-   [../]
+   []
 []

--- a/test/tests/TM10_circular_wg/TM_steady_dieletric.i
+++ b/test/tests/TM10_circular_wg/TM_steady_dieletric.i
@@ -3,26 +3,26 @@
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'TM_dieletric.msh'
     # construct_side_list_from_node_list = 1
-  [../]
-  [./interface_dielectric]
+  []
+  [interface_dielectric]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'interface_dielectric'
     input = file
-  [../]
+  []
   coord_type = RZ
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -36,186 +36,186 @@
 [Outputs]
   perf_graph = true
   print_linear_residuals = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
-  [./csv]
+  []
+  [csv]
     type = CSV
-  [../]
+  []
 []
 
 [Variables]
-  [./Hphi_dielectric]
+  [Hphi_dielectric]
     block = 1
     order = SECOND
-  [../]
-  [./Hphi_vacuum]
+  []
+  [Hphi_vacuum]
     block = 0
     order = SECOND
-  [../]
-  [./Ez_dielectric]
+  []
+  [Ez_dielectric]
     block = 1
     order = SECOND
-  [../]
-  [./Ez_vacuum]
+  []
+  [Ez_vacuum]
     block = 0
     order = SECOND
-  [../]
-  [./Er_dielectric]
+  []
+  [Er_dielectric]
     block = 1
     order = SECOND
-  [../]
-  [./Er_vacuum]
+  []
+  [Er_vacuum]
     block = 0
     order = SECOND
-  [../]
+  []
 []
 
 [Kernels]
-  [./Hphi_dielectric]
+  [Hphi_dielectric]
     type = TM0Cylindrical
     variable = Hphi_dielectric
     block = 1
-  [../]
-  [./Hphi_vacuum]
+  []
+  [Hphi_vacuum]
     type = TM0Cylindrical
     variable = Hphi_vacuum
     block = 0
-  [../]
-  [./Ez_dielectric_kern]
+  []
+  [Ez_dielectric_kern]
     type = TM0CylindricalEz
     variable = Ez_dielectric
     block = 1
     Hphi = Hphi_dielectric
-  [../]
-  [./Ez_vacuum_kern]
+  []
+  [Ez_vacuum_kern]
     type = TM0CylindricalEz
     variable = Ez_vacuum
     block = 0
     Hphi = Hphi_vacuum
-  [../]
-  [./Er_dielectric]
+  []
+  [Er_dielectric]
     type = TM0CylindricalEr
     variable = Er_dielectric
     Hphi = Hphi_dielectric
     block = 1
-  [../]
-  [./Er_vacuum]
+  []
+  [Er_vacuum]
     type = TM0CylindricalEr
     variable = Er_vacuum
     Hphi = Hphi_vacuum
     block = 0
-  [../]
+  []
 []
 
 [BCs]
-  [./launcher]
+  [launcher]
     type = TM0AntennaVertBC
     boundary = Antenna
     variable = Hphi_vacuum
-  [../]
-  [./vert_wall]
+  []
+  [vert_wall]
     type = TM0PECVertBC
     variable = Hphi_vacuum
     boundary = vert_pec
-  [../]
-  [./axis]
+  []
+  [axis]
     type = DirichletBC
     variable = Hphi_dielectric
     boundary = Axis
     value = 0
-  [../]
-  [./H_phi_interface]
+  []
+  [H_phi_interface]
     type = MatchedValueBC
     variable = Hphi_vacuum
     v = Hphi_dielectric
     boundary = interface
-  [../]
-  # [./Ez_interface]
+  []
+  # [Ez_interface]
   #   type = MatchedValueBC
   #   variable = Ez_dielectric
   #   v = Ez_vacuum
   #   boundary = interface
-  # [../]
+  # []
 []
 
 [InterfaceKernels]
-  [./Ez_continuous]
+  [Ez_continuous]
     type = HphiRadialInterface
     variable = Hphi_dielectric
     neighbor_var = Hphi_vacuum
     boundary = interface_dielectric
-  [../]
+  []
 []
 
 
 [Materials]
-   [./dielectric]
+   [dielectric]
      type = ADGenericConstantMaterial
      prop_names = 'eps_r'
      prop_values = '3.8'
      block = 1
-   [../]
-   [./vacuum]
+   []
+   [vacuum]
      type = ADGenericConstantMaterial
      prop_names = 'eps_r'
      prop_values = '1'
      block = 0
-   [../]
+   []
 []
 
 
 # [AuxVariables]
-#   [./Hphi_mag]
-#   [../]
-#   [./Er]
+#   [Hphi_mag]
+#   []
+#   [Er]
 #     order = FIRST
 #     family = MONOMIAL
-#   [../]
-#   # [./Electric_z]
+#   []
+#   # [Electric_z]
 #   #   order = FIRST
 #   #   family = MONOMIAL
-#   # [../]
+#   # []
 # []
 
 # [AuxKernels]
-#   [./Hphi_mag]
+#   [Hphi_mag]
 #     type = AbsValueAux
 #     u = Hphi
 #     variable = Hphi_mag
-#   [../]
-#   [./Er_dielectric]
+#   []
+#   [Er_dielectric]
 #     type = TM0CylindricalEr
 #     Hphi = Hphi
 #     variable = Er
 #     block = 1
 #     eps_r = 16
-#   [../]
-#   [./Er_vacuum]
+#   []
+#   [Er_vacuum]
 #     type = TM0CylindricalEr
 #     Hphi = Hphi
 #     block = 0
 #     eps_r = 1
 #     variable = Er
-#   [../]
-#   # [./Electric_z_dielectric]
+#   []
+#   # [Electric_z_dielectric]
 #   #   type = TM0CylindricalEz
 #   #   Hphi = Hphi
 #   #   variable = Electric_z
 #   #   block = 1
 #   #   eps_r = 16
-#   # [../]
-#   # [./Electric_z_vacuum]
+#   # []
+#   # [Electric_z_vacuum]
 #   #   type = TM0CylindricalEz
 #   #   Hphi = Hphi
 #   #   variable = Electric_z
 #   #   block = 0
 #   #   eps_r = 1
-#   # [../]
+#   # []
 # []
 
 # [VectorPostprocessors]
-#   [./line0]
+#   [line0]
 #     type = LineValueSampler
 #     start_point = '0 .045 0'
 #     end_point = '.015 .045 0'
@@ -223,8 +223,8 @@
 #     sort_by = x
 #     variable = Hphi
 #     outputs = csv
-#   [../]
-#   [./line1]
+#   []
+#   [line1]
 #     type = LineValueSampler
 #     start_point = '0 .045 0'
 #     end_point = '.015 .045 0'
@@ -232,8 +232,8 @@
 #     sort_by = x
 #     variable = Elec_z
 #     outputs = csv
-#   [../]
-#   [./line2]
+#   []
+#   [line2]
 #     type = LineValueSampler
 #     start_point = '0 .045 0'
 #     end_point = '.015 .045 0'
@@ -241,5 +241,5 @@
 #     sort_by = x
 #     variable = Er
 #     outputs = csv
-#   [../]
+#   []
 # []

--- a/test/tests/TM10_circular_wg/tests
+++ b/test/tests/TM10_circular_wg/tests
@@ -1,14 +1,14 @@
 [Tests]
-  [./test_vacuum]
+  [test_vacuum]
     type = 'Exodiff'
     input = 'TM_steady.i'
     exodiff = 'TM_steady_out.e'
-  [../]
-  [./test_vac_dielectric]
+  []
+  [test_vac_dielectric]
     type = 'Exodiff'
     input = 'TM_steady_dieletric.i'
     exodiff = 'TM_steady_dieletric_out.e'
     min_parallel = 4
     heavy = true
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Averaging_acceleration.i
+++ b/test/tests/accelerations/Acceleration_By_Averaging_acceleration.i
@@ -1,20 +1,20 @@
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -22,111 +22,111 @@
 []
 
 [Variables]
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 []
 
 [AuxVariables]
-  [./em]
-  [../]
-  [./Ar+]
-  [../]
-  [./mean_en]
-  [../]
-  [./potential]
-  [../]
-  [./Ar*S]
-  [../]
-  [./Ar*T]
-  [../]
+  [em]
+  []
+  [Ar+]
+  []
+  [mean_en]
+  []
+  [potential]
+  []
+  [Ar*S]
+  []
+  [Ar*T]
+  []
 []
 
 [Kernels]
-  [./Ar*_AcclerationByAveraging]
+  [Ar*_AcclerationByAveraging]
     type = AccelerationByAveraging
     variable = Ar*
     density_at_start_cycle = Ar*S
     density_at_end_cycle = Ar*T
     time_of_averaging = 73.74631268e-9
     time_of_acceleration = 2e-6
-  [../]
+  []
 []
 
 [BCs]
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 []
 
 #MultiApp used to calculate the non-accelerated density for 1RF cycle.
 #This is used to get A*T (density at end of cycle)
 [MultiApps]
-  [./Sub]
+  [Sub]
     type = FullSolveMultiApp
     input_files = 'Acceleration_By_Averaging_acceleration_sub.i'
-  [../]
+  []
 []
 
 [Transfers]
-  [./em_to_sub]
+  [em_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = Sub
     source_variable = em
     variable = em
-  [../]
-  [./Ar+_to_sub]
+  []
+  [Ar+_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = Sub
     source_variable = Ar+
     variable = Ar+
-  [../]
-  [./mean_en_to_sub]
+  []
+  [mean_en_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = Sub
     source_variable = mean_en
     variable = mean_en
-  [../]
-  [./potential_to_sub]
+  []
+  [potential_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = Sub
     source_variable = potential
     variable = potential
-  [../]
-  [./Ar*_to_sub]
+  []
+  [Ar*_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = Sub
     source_variable = Ar*
     variable = Ar*
-  [../]
+  []
 
-  [./Ar*T_from_sub]
+  [Ar*T_from_sub]
     type = MultiAppCopyTransfer
     from_multi_app = Sub
     source_variable = Ar*
     variable = Ar*T
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -139,7 +139,7 @@
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Averaging_acceleration_sub.i
+++ b/test/tests/accelerations/Acceleration_By_Averaging_acceleration_sub.i
@@ -6,22 +6,22 @@ dom0Scale = 25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -29,44 +29,44 @@ dom0Scale = 25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
 #Electron Equations
 #Time Derivative term of electron
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
-  [../]
+  []
 #Advection term of electron
-  [./em_advection]
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 #Diffusion term of electrons
-  [./em_diffusion]
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     position_units = ${dom0Scale}
-  [../]
+  []
 #Net electron production from ionization
-  [./em_ionization]
+  [em_ionization]
     type = EEDFReactionLog
     variable = em
     electrons = em
@@ -74,9 +74,9 @@ dom0Scale = 25.4e-3
     target = Ar
     reaction = 'em + Ar -> em + em + Ar+'
     coefficient = 1
-  [../]
+  []
 #Net electron production from step - wise ionization
-  [./em_stepwise_ionization]
+  [em_stepwise_ionization]
     type = EEDFReactionLog
     variable = em
     electrons = em
@@ -84,37 +84,37 @@ dom0Scale = 25.4e-3
     target = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
     coefficient = 1
-  [../]
+  []
 #Net electron production from metastable pooling
-  [./em_pooling]
+  [em_pooling]
     type = ReactionSecondOrderLog
     variable = em
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     coefficient = 1
-  [../]
+  []
 
 #Argon Ion Equations
 #Time Derivative term of the ions
-  [./Ar+_time_deriv]
+  [Ar+_time_deriv]
     type = ElectronTimeDerivative
     variable = Ar+
-  [../]
+  []
 #Advection term of ions
-  [./Ar+_advection]
+  [Ar+_advection]
     type = EFieldAdvection
     variable = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_diffusion]
+  []
+  [Ar+_diffusion]
     type = CoeffDiffusion
     variable = Ar+
     position_units = ${dom0Scale}
-  [../]
+  []
 #Net ion production from ionization
-  [./Ar+_ionization]
+  [Ar+_ionization]
     type = EEDFReactionLog
     variable = Ar+
     electrons = em
@@ -122,9 +122,9 @@ dom0Scale = 25.4e-3
     target = Ar
     reaction = 'em + Ar -> em + em + Ar+'
     coefficient = 1
-  [../]
+  []
 #Net ion production from step - wise ionization
-  [./Ar+_stepwise_ionization]
+  [Ar+_stepwise_ionization]
     type = EEDFReactionLog
     variable = Ar+
     electrons = em
@@ -132,31 +132,31 @@ dom0Scale = 25.4e-3
     target = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
     coefficient = 1
-  [../]
+  []
 #Net ion production from metastable pooling
-  [./Ar+_pooling]
+  [Ar+_pooling]
     type = ReactionSecondOrderLog
     variable = Ar+
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     coefficient = 1
-  [../]
+  []
 
 #Argon Excited Equations
 #Time Derivative term of excited Argon
-  [./Ar*_time_deriv]
+  [Ar*_time_deriv]
     type = ElectronTimeDerivative
     variable = Ar*
-  [../]
+  []
 #Diffusion term of excited Argon
-  [./Ar*_diffusion]
+  [Ar*_diffusion]
     type = CoeffDiffusion
     variable = Ar*
     position_units = ${dom0Scale}
-  [../]
+  []
 #Net excited Argon production from excitation
-  [./Ar*_excitation]
+  [Ar*_excitation]
     type = EEDFReactionLog
     variable = Ar*
     electrons = em
@@ -164,9 +164,9 @@ dom0Scale = 25.4e-3
     mean_energy = mean_en
     reaction = 'em + Ar -> em + Ar*'
     coefficient = 1
-  [../]
+  []
 #Net excited Argon loss from step - wise ionization
-  [./Ar*_stepwise_ionization]
+  [Ar*_stepwise_ionization]
     type = EEDFReactionLog
     variable = Ar*
     electrons = em
@@ -174,9 +174,9 @@ dom0Scale = 25.4e-3
     mean_energy = mean_en
     reaction = 'em + Ar* -> em + em + Ar+'
     coefficient = -1
-  [../]
+  []
 #Net excited Argon loss from superelastic collisions
-  [./Ar*_collisions]
+  [Ar*_collisions]
     type = EEDFReactionLog
     variable = Ar*
     electrons = em
@@ -184,9 +184,9 @@ dom0Scale = 25.4e-3
     mean_energy = mean_en
     reaction = 'em + Ar* -> em + Ar'
     coefficient = -1
-  [../]
+  []
 #Net excited Argon loss from quenching to resonant
-  [./Ar*_quenching]
+  [Ar*_quenching]
     type = EEDFReactionLog
     variable = Ar*
     electrons = em
@@ -194,9 +194,9 @@ dom0Scale = 25.4e-3
     mean_energy = mean_en
     reaction = 'em + Ar* -> em + Ar_r'
     coefficient = -1
-  [../]
+  []
 #Net excited Argon loss from metastable pooling
-  [./Ar*_pooling]
+  [Ar*_pooling]
     type = ReactionSecondOrderLog
     variable = Ar*
     v = Ar*
@@ -205,9 +205,9 @@ dom0Scale = 25.4e-3
     coefficient = -2
     _v_eq_u = true
     _w_eq_u = true
-  [../]
+  []
 #Net excited Argon loss from two - body quenching
-  [./Ar*_2B_quenching]
+  [Ar*_2B_quenching]
     type = ReactionSecondOrderLog
     variable = Ar*
     v = Ar*
@@ -215,9 +215,9 @@ dom0Scale = 25.4e-3
     reaction = 'Ar* + Ar -> Ar + Ar'
     coefficient = -1
     _v_eq_u = true
-  [../]
+  []
 #Net excited Argon loss from three - body quenching
-  [./Ar*_3B_quenching]
+  [Ar*_3B_quenching]
     type = ReactionThirdOrderLog
     variable = Ar*
     v = Ar*
@@ -226,126 +226,126 @@ dom0Scale = 25.4e-3
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     coefficient = -1
     _v_eq_u = true
-  [../]
+  []
 #Voltage Equations
 #Voltage term in Poissons Eqaution
-  [./potential_diffusion_dom0]
+  [potential_diffusion_dom0]
     type = CoeffDiffusionLin
     variable = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 #Ion term in Poissons Equation
-  [./Ar+_charge_source]
+  [Ar+_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Ar+
-  [../]
+  []
 #Electron term in Poissons Equation
-  [./em_charge_source]
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
-  [../]
+  []
 
 #Electron Energy Equations
 #Time Derivative term of electron energy
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
-  [../]
+  []
 #Advection term of electron energy
-  [./mean_en_advection]
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 #Diffusion term of electrons energy
-  [./mean_en_diffusion]
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     position_units = ${dom0Scale}
-  [../]
+  []
 #Joule Heating term
-  [./mean_en_joule_heating]
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     position_units = ${dom0Scale}
-  [../]
+  []
 #Energy loss from ionization
-  [./Ionization_Loss]
+  [Ionization_Loss]
     type = EEDFEnergyLog
     variable = mean_en
     electrons = em
     target = Ar
     reaction = 'em + Ar -> em + em + Ar+'
     threshold_energy = -15.7
-  [../]
+  []
 #Energy loss from excitation
-  [./Excitation_Loss]
+  [Excitation_Loss]
     type = EEDFEnergyLog
     variable = mean_en
     electrons = em
     target = Ar
     reaction = 'em + Ar -> em + Ar*'
     threshold_energy = -11.56
-  [../]
+  []
 #Energy loss from step - wise ionization
-  [./Stepwise_Ionization_Loss]
+  [Stepwise_Ionization_Loss]
     type = EEDFEnergyLog
     variable = mean_en
     electrons = em
     target = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
     threshold_energy = -4.14
-  [../]
+  []
 #Energy gain from superelastic collisions
-  [./Collisions_Loss]
+  [Collisions_Loss]
     type = EEDFEnergyLog
     variable = mean_en
     electrons = em
     target = Ar*
     reaction = 'em + Ar* -> em + Ar'
     threshold_energy = 11.56
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./Ar]
-  [../]
+  [Ar]
+  []
 []
 
 [AuxKernels]
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     #value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 []
 
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -356,8 +356,8 @@ dom0Scale = 25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -368,64 +368,64 @@ dom0Scale = 25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions Metastable
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 
 #Boundary conditions for electron mean energy
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*pi*13.56e6*t)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -437,107 +437,107 @@ dom0Scale = 25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + Ar*.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + em + Ar+.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + Ar.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + em + Ar+.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-43
     reaction_rate_value = 39890.9324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -555,7 +555,7 @@ dom0Scale = 25.4e-3
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Averaging_main.i
+++ b/test/tests/accelerations/Acceleration_By_Averaging_main.i
@@ -9,22 +9,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -32,44 +32,44 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
   #Electron Equations
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -77,9 +77,9 @@ dom0Scale=25.4e-3
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -87,37 +87,37 @@ dom0Scale=25.4e-3
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -125,9 +125,9 @@ dom0Scale=25.4e-3
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -135,31 +135,31 @@ dom0Scale=25.4e-3
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -167,9 +167,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -177,9 +177,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -187,9 +187,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -197,9 +197,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -208,9 +208,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -218,9 +218,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -229,292 +229,292 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Electron Energy Equations
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -522,8 +522,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -531,29 +531,29 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -564,8 +564,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -576,96 +576,96 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for metastables
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 
 #Boundary conditions for electron mean energy
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*pi*13.56e6*t)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e14)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log((3./2.) * ((1e14)/6.022e23))'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -677,154 +677,154 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + Ar*.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + em + Ar+.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + Ar.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + em + Ar+.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-43
     reaction_rate_value = 39890.9324
-  [../]
+  []
 []
 
 [MultiApps]
   #MultiApp of Acceleration by Averaging
-  [./Averaging_Acceleration]
+  [Averaging_Acceleration]
     type = FullSolveMultiApp
     input_files = 'Acceleration_By_Averaging_acceleration.i'
     execute_on = 'TIMESTEP_END'
     enable = false
-  [../]
+  []
 []
 
 [Transfers]
   #MultiApp Transfers for Acceleration by Averaging
-  [./em_to_Averaging]
+  [em_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = em
     variable = em
     enable = false
-  [../]
-  [./Ar+_to_Averaging]
+  []
+  [Ar+_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = Ar+
     variable = Ar+
     enable = false
-  [../]
-  [./mean_en_to_Averaging]
+  []
+  [mean_en_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = mean_en
     variable = mean_en
     enable = false
-  [../]
-  [./potential_to_Averaging]
+  []
+  [potential_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = potential
     variable = potential
     enable = false
-  [../]
-  [./Ar*_to_Averaging]
+  []
+  [Ar*_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = Ar*
     variable = Ar*
     enable = false
-  [../]
-  [./Ar*S_to_Averaging]
+  []
+  [Ar*S_to_Averaging]
     type = MultiAppCopyTransfer
     to_multi_app = Averaging_Acceleration
     source_variable = Ar*
     variable = Ar*S
     enable = false
-  [../]
+  []
 
 
-  [./Ar*New_from_Averaging]
+  [Ar*New_from_Averaging]
     type = MultiAppCopyTransfer
     from_multi_app = Averaging_Acceleration
     source_variable = Ar*
     variable = Ar*
     enable = false
-  [../]
+  []
 []
 
 #The Action the add the TimePeriod Controls to turn off and on the MultiApps
 [PeriodicControllers]
-  [./Averaging_Acceleration]
+  [Averaging_Acceleration]
     Enable_at_cycle_start = 'MultiApps::Averaging_Acceleration
                               Transfers::em_to_Averaging *::Ar+_to_Averaging *::mean_en_to_Averaging
                               *::potential_to_Averaging *::Ar*_to_Averaging *::Ar*S_to_Averaging
@@ -834,30 +834,30 @@ dom0Scale=25.4e-3
     cycles_between_controls = 10
     num_controller_set = 15
     name = Averaging_Acceleration
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -878,7 +878,7 @@ dom0Scale=25.4e-3
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Shooting_Method.i
+++ b/test/tests/accelerations/Acceleration_By_Shooting_Method.i
@@ -17,49 +17,49 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
+  [em]
     initial_from_file_var = em
-  [../]
+  []
 
-  [./Ar+]
+  [Ar+]
     initial_from_file_var = Ar+
-  [../]
+  []
 
-  [./Ar*]
+  [Ar*]
     initial_from_file_var = Ar*
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     initial_from_file_var = mean_en
-  [../]
+  []
 
-  [./potential]
+  [potential]
     initial_from_file_var = potential
-  [../]
+  []
 []
 
 [Kernels]
   #Electron Equations
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -67,9 +67,9 @@ dom0Scale=25.4e-3
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = EEDFReactionLog
       variable = em
       electrons = em
@@ -77,37 +77,37 @@ dom0Scale=25.4e-3
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -115,9 +115,9 @@ dom0Scale=25.4e-3
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = EEDFReactionLog
       variable = Ar+
       electrons = em
@@ -125,31 +125,31 @@ dom0Scale=25.4e-3
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -157,9 +157,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -167,9 +167,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -177,9 +177,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = EEDFReactionLog
         variable = Ar*
         electrons = em
@@ -187,9 +187,9 @@ dom0Scale=25.4e-3
         mean_energy = mean_en
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -198,9 +198,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -208,9 +208,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -219,292 +219,292 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Electron Energy Equations
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = EEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./emRate]
+  [emRate]
     type = ProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -512,8 +512,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -521,29 +521,29 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -554,8 +554,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -566,64 +566,64 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for metastables
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 
 #Boundary conditions for electron mean energy
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*pi*13.56e6*t)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -635,153 +635,153 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + Ar*.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + em + Ar+.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + Ar.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + em + Ar+.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = GenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = GenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = GenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = GenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-43
     reaction_rate_value = 39890.9324
-  [../]
+  []
 []
 
 [MultiApps]
   #MultiApp of Acceleration by Shooting Method
-  [./Shooting]
+  [Shooting]
     type = FullSolveMultiApp
     input_files = 'Acceleration_By_Shooting_Method_Shooting.i'
     execute_on = 'TIMESTEP_END'
     enable = false
-  [../]
+  []
 []
 
 [Transfers]
   #MultiApp Transfers for Acceleration by Shooting Method
-  [./em_to_Shooting]
+  [em_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = em
     variable = em
     enable = false
-  [../]
-  [./Ar+_to_Shooting]
+  []
+  [Ar+_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = Ar+
     variable = Ar+
     enable = false
-  [../]
-  [./mean_en_to_Shooting]
+  []
+  [mean_en_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = mean_en
     variable = mean_en
     enable = false
-  [../]
-  [./potential_to_Shooting]
+  []
+  [potential_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = potential
     variable = potential
     enable = false
-  [../]
-  [./Ar*_to_Shooting]
+  []
+  [Ar*_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = Ar*
     variable = Ar*
     enable = false
-  [../]
-  [./Ar*S_to_Shooting]
+  []
+  [Ar*S_to_Shooting]
     type = MultiAppCopyTransfer
     to_multi_app = Shooting
     source_variable = Ar*
     variable = Ar*S
     enable = false
-  [../]
+  []
 
-  [./Ar*New_from_Shooting]
+  [Ar*New_from_Shooting]
     type = MultiAppCopyTransfer
     from_multi_app = Shooting
     source_variable = Ar*
     variable = Ar*
     enable = false
-  [../]
+  []
 []
 
 #The Action the add the TimePeriod Controls to turn off and on the MultiApps
 [PeriodicControllers]
-  [./Shooting]
+  [Shooting]
     Enable_at_cycle_start = 'MultiApps::Shooting
                               Transfers::em_to_Shooting *::Ar+_to_Shooting *::mean_en_to_Shooting
                               *::potential_to_Shooting *::Ar*_to_Shooting *::Ar*S_to_Shooting
@@ -791,31 +791,31 @@ dom0Scale=25.4e-3
     cycles_between_controls = 30
     num_controller_set = 2000
     name = Shooting
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -837,7 +837,7 @@ dom0Scale=25.4e-3
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
+++ b/test/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
@@ -6,22 +6,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -29,169 +29,169 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./SMDeriv]
-  [../]
+  [SMDeriv]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net electron production from ionization
-    [./em_ionization]
+    [em_ionization]
       type = ADEEDFReactionLog
       variable = em
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from step-wise ionization
-    [./em_stepwise_ionization]
+    [em_stepwise_ionization]
       type = ADEEDFReactionLog
       variable = em
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net electron production from metastable pooling
-    [./em_pooling]
+    [em_pooling]
       type = ADReactionSecondOrderLog
       variable = em
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
     #Net ion production from ionization
-    [./Ar+_ionization]
+    [Ar+_ionization]
       type = ADEEDFReactionLog
       variable = Ar+
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from step-wise ionization
-    [./Ar+_stepwise_ionization]
+    [Ar+_stepwise_ionization]
       type = ADEEDFReactionLog
       variable = Ar+
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       coefficient = 1
-    [../]
+    []
     #Net ion production from metastable pooling
-    [./Ar+_pooling]
+    [Ar+_pooling]
       type = ADReactionSecondOrderLog
       variable = Ar+
       v = Ar*
       w = Ar*
       reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
       coefficient = 1
-    [../]
+    []
 
     #Argon Excited Equations (Same as in paper)
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
       #Net excited Argon production from excitation
-      [./Ar*_excitation]
+      [Ar*_excitation]
         type = ADEEDFReactionLog
         variable = Ar*
         electrons = em
         target = Ar
         reaction = 'em + Ar -> em + Ar*'
         coefficient = 1
-      [../]
+      []
       #Net excited Argon loss from step-wise ionization
-      [./Ar*_stepwise_ionization]
+      [Ar*_stepwise_ionization]
         type = ADEEDFReactionLog
         variable = Ar*
         electrons = em
         target = Ar*
         reaction = 'em + Ar* -> em + em + Ar+'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from superelastic collisions
-      [./Ar*_collisions]
+      [Ar*_collisions]
         type = ADEEDFReactionLog
         variable = Ar*
         electrons = em
         target = Ar*
         reaction = 'em + Ar* -> em + Ar'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from quenching to resonant
-      [./Ar*_quenching]
+      [Ar*_quenching]
         type = ADEEDFReactionLog
         variable = Ar*
         electrons = em
         target = Ar*
         reaction = 'em + Ar* -> em + Ar_r'
         coefficient = -1
-      [../]
+      []
       #Net excited Argon loss from  metastable pooling
-      [./Ar*_pooling]
+      [Ar*_pooling]
         type = ADReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -200,9 +200,9 @@ dom0Scale=25.4e-3
         coefficient = -2
         _v_eq_u = true
         _w_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from two-body quenching
-      [./Ar*_2B_quenching]
+      [Ar*_2B_quenching]
         type = ADReactionSecondOrderLog
         variable = Ar*
         v = Ar*
@@ -210,9 +210,9 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar -> Ar + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
       #Net excited Argon loss from three-body quenching
-      [./Ar*_3B_quenching]
+      [Ar*_3B_quenching]
         type = ADReactionThirdOrderLog
         variable = Ar*
         v = Ar*
@@ -221,109 +221,109 @@ dom0Scale=25.4e-3
         reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
         coefficient = -1
         _v_eq_u = true
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
     #Energy loss from ionization
-    [./Ionization_Loss]
+    [Ionization_Loss]
       type = ADEEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + em + Ar+'
       threshold_energy = -15.7
-    [../]
+    []
     #Energy loss from excitation
-    [./Excitation_Loss]
+    [Excitation_Loss]
       type = ADEEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar
       reaction = 'em + Ar -> em + Ar*'
       threshold_energy = -11.56
-    [../]
+    []
     #Energy loss from step-wise ionization
-    [./Stepwise_Ionization_Loss]
+    [Stepwise_Ionization_Loss]
       type = ADEEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + em + Ar+'
       threshold_energy = -4.14
-    [../]
+    []
     #Energy gain from superelastic collisions
-    [./Collisions_Loss]
+    [Collisions_Loss]
       type = ADEEDFEnergyLog
       variable = mean_en
       electrons = em
       target = Ar*
       reaction = 'em + Ar* -> em + Ar'
       threshold_energy = 11.56
-    [../]
+    []
 
   #Argon Excited Equations For Shooting Method
   #Time Derivative term of excited Argon
-  [./SM_Ar*_time_deriv]
+  [SM_Ar*_time_deriv]
     type = TimeDerivative
     variable = SMDeriv
-  [../]
+  []
   #Diffusion term of excited Argon
-  [./SM_Ar*_diffusion]
+  [SM_Ar*_diffusion]
     type = CoeffDiffusionForShootMethod
     variable = SMDeriv
     density = Ar*
     position_units = ${dom0Scale}
-  [../]
+  []
   #Net excited Argon loss from step-wise ionization
-  [./SM_Ar*_stepwise_ionization]
+  [SM_Ar*_stepwise_ionization]
     type = EEDFReactionLogForShootMethod
     variable = SMDeriv
     density = Ar*
@@ -331,9 +331,9 @@ dom0Scale=25.4e-3
     energy = mean_en
     reaction = 'em + Ar* -> em + em + Ar+'
     coefficient = -1
-  [../]
+  []
   #Net excited Argon loss from superelastic collisions
-  [./SM_Ar*_collisions]
+  [SM_Ar*_collisions]
     type = EEDFReactionLogForShootMethod
     variable = SMDeriv
     density = Ar*
@@ -341,36 +341,36 @@ dom0Scale=25.4e-3
     energy = mean_en
     reaction = 'em + Ar* -> em + Ar'
     coefficient = -1
-  [../]
+  []
   #Net excited Argon loss from quenching to resonant
-  [./SM_Ar*_quenching]
+  [SM_Ar*_quenching]
     type = ReactionSecondOrderLogForShootMethod
     variable = SMDeriv
     density = Ar*
     v = em
     reaction = 'em + Ar* -> em + Ar_r'
     coefficient = -1
-  [../]
+  []
   #Net excited Argon loss from  metastable pooling
-  [./SM_Ar*_pooling]
+  [SM_Ar*_pooling]
     type = ReactionSecondOrderLogForShootMethod
     variable = SMDeriv
     density = Ar*
     v = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     coefficient = -2
-  [../]
+  []
   #Net excited Argon loss from two-body quenching
-  [./SM_Ar*_2B_quenching]
+  [SM_Ar*_2B_quenching]
     type = ReactionSecondOrderLogForShootMethod
     variable = SMDeriv
     density = Ar*
     v = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
     coefficient = -1
-  [../]
+  []
   #Net excited Argon loss from three-body quenching
-  [./SM_Ar*_3B_quenching]
+  [SM_Ar*_3B_quenching]
     type = ReactionThirdOrderLogForShootMethod
     variable = SMDeriv
     density = Ar*
@@ -378,246 +378,246 @@ dom0Scale=25.4e-3
     w = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     coefficient = -1
-  [../]
+  []
 []
 
 
 [AuxVariables]
-  [./emDeBug]
-  [../]
-  [./Ar+_DeBug]
-  [../]
-  [./Ar*_DeBug]
-  [../]
-  [./mean_enDeBug]
-  [../]
+  [emDeBug]
+  []
+  [Ar+_DeBug]
+  []
+  [Ar*_DeBug]
+  []
+  [mean_enDeBug]
+  []
 
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emRate]
+  []
+  [emRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./exRate]
+  []
+  [exRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./swRate]
+  []
+  [swRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./quRate]
+  []
+  [quRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./emDeBug]
+  [emDeBug]
     type = DebugResidualAux
     variable = emDeBug
     debug_variable = em
     #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  [../]
-  [./Ar+_DeBug]
+  []
+  [Ar+_DeBug]
     type = DebugResidualAux
     variable = Ar+_DeBug
     debug_variable = Ar+
     #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  [../]
-  [./mean_enDeBug]
+  []
+  [mean_enDeBug]
     type = DebugResidualAux
     variable = mean_enDeBug
     debug_variable = mean_en
     #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  [../]
-  [./Ar*_DeBug]
+  []
+  [Ar*_DeBug]
     type = DebugResidualAux
     variable = Ar*_DeBug
     debug_variable = Ar*
     #execute_on = 'LINEAR NONLINEAR TIMESTEP_BEGIN'
-  [../]
+  []
 
-  [./emRate]
+  [emRate]
     type = ADProcRateForRateCoeff
     variable = emRate
     v = em
     w = Ar
     reaction = 'em + Ar -> em + em + Ar+'
-  [../]
-  [./exRate]
+  []
+  [exRate]
     type = ADProcRateForRateCoeff
     variable = exRate
     v = em
     w = Ar*
     reaction = 'em + Ar -> em + Ar*'
-  [../]
-  [./swRate]
+  []
+  [swRate]
     type = ADProcRateForRateCoeff
     variable = swRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + em + Ar+'
-  [../]
-  [./deexRate]
+  []
+  [deexRate]
     type = ADProcRateForRateCoeff
     variable = deexRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar'
-  [../]
-  [./quRate]
+  []
+  [quRate]
     type = ADProcRateForRateCoeff
     variable = quRate
     v = em
     w = Ar*
     reaction = 'em + Ar* -> em + Ar_r'
-  [../]
-  [./poolRate]
+  []
+  [poolRate]
     type = ADProcRateForRateCoeff
     variable = poolRate
     v = Ar*
     w = Ar*
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
-  [../]
-  [./TwoBRate]
+  []
+  [TwoBRate]
     type = ADProcRateForRateCoeff
     variable = TwoBRate
     v = Ar*
     w = Ar
     reaction = 'Ar* + Ar -> Ar + Ar'
-  [../]
-  [./ThreeBRate]
+  []
+  [ThreeBRate]
     type = ADProcRateForRateCoeffThreeBody
     variable = ThreeBRate
     v = Ar*
     w = Ar
     vv = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
-  [../]
-  [./Te]
+  []
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -625,8 +625,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -634,29 +634,29 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -667,8 +667,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -679,66 +679,66 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*pi*13.56e6*t)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -750,108 +750,108 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = Argon_reactions_paper_RateCoefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
-  [./reaction_0]
+  []
+  [reaction_0]
     type = ADZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + Ar*.txt'
     reaction = 'em + Ar -> em + Ar*'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_1]
+  []
+  [reaction_1]
     type = ADZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar -> em + em + Ar+.txt'
     reaction = 'em + Ar -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_2]
+  []
+  [reaction_2]
     type = ADZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + Ar.txt'
     reaction = 'em + Ar* -> em + Ar'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_3]
+  []
+  [reaction_3]
     type = ADZapdosEEDFRateConstant
     mean_energy = mean_en
     property_file = 'Argon_reactions_paper_RateCoefficients/reaction_em + Ar* -> em + em + Ar+.txt'
     reaction = 'em + Ar* -> em + em + Ar+'
     file_location = ''
     electrons = em
-  [../]
-  [./reaction_4]
+  []
+  [reaction_4]
     type = ADGenericRateConstant
     reaction = 'em + Ar* -> em + Ar_r'
     #reaction_rate_value = 2e-13
     reaction_rate_value = 1.2044e11
-  [../]
-  [./reaction_5]
+  []
+  [reaction_5]
     type = ADGenericRateConstant
     reaction = 'Ar* + Ar* -> Ar+ + Ar + em'
     #reaction_rate_value = 6.2e-16
     reaction_rate_value = 373364000
-  [../]
-  [./reaction_6]
+  []
+  [reaction_6]
     type = ADGenericRateConstant
     reaction = 'Ar* + Ar -> Ar + Ar'
     #reaction_rate_value = 3e-21
     reaction_rate_value = 1806.6
-  [../]
-  [./reaction_7]
+  []
+  [reaction_7]
     type = ADGenericRateConstant
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
     #reaction_rate_value = 1.1e-43
     reaction_rate_value = 39890.9324
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -873,7 +873,7 @@ dom0Scale=25.4e-3
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/Acceleration_By_Shooting_Method_Shooting.i
+++ b/test/tests/accelerations/Acceleration_By_Shooting_Method_Shooting.i
@@ -1,20 +1,20 @@
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -22,131 +22,131 @@
 []
 
 [Variables]
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 []
 
 [AuxVariables]
-  [./em]
-  [../]
-  [./Ar+]
-  [../]
-  [./mean_en]
-  [../]
-  [./potential]
-  [../]
-  [./Ar*S]
-  [../]
+  [em]
+  []
+  [Ar+]
+  []
+  [mean_en]
+  []
+  [potential]
+  []
+  [Ar*S]
+  []
 
-  [./Ar*T]
-  [../]
-  [./SMDeriv]
-  [../]
+  [Ar*T]
+  []
+  [SMDeriv]
+  []
 
-  [./SMDerivReset]
+  [SMDerivReset]
     initial_condition = 1.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./Shoot_Method]
+  [Shoot_Method]
     type = ShootMethodLog
     variable = Ar*
     density_at_start_cycle = Ar*S
     density_at_end_cycle = Ar*T
     sensitivity_variable = SMDeriv
     growth_limit = 100.0
-  [../]
+  []
 []
 
 [BCs]
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 1e-5
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 1e-5
-  [../]
+  []
 []
 
 #MultiApp used to calculate the non-accelerated density for 1RF cycle.
 #This is used to get A*T (density at end of cycle) and
 ##the sensitivity variable needed for the shoot method.
 [MultiApps]
-  [./SensitivityMatrix]
+  [SensitivityMatrix]
     type = FullSolveMultiApp
     input_files = 'Acceleration_By_Shooting_Method_SensitivityMatrix.i'
-  [../]
+  []
 []
 
 [Transfers]
-  [./em_to_sub]
+  [em_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = em
     variable = em
-  [../]
-  [./Ar+_to_sub]
+  []
+  [Ar+_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = Ar+
     variable = Ar+
-  [../]
-  [./mean_en_to_sub]
+  []
+  [mean_en_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = mean_en
     variable = mean_en
-  [../]
-  [./potential_to_sub]
+  []
+  [potential_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = potential
     variable = potential
-  [../]
-  [./Ar*_to_sub]
+  []
+  [Ar*_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = Ar*
     variable = Ar*
-  [../]
-  [./Deriv_to_sub]
+  []
+  [Deriv_to_sub]
     type = MultiAppCopyTransfer
     to_multi_app = SensitivityMatrix
     source_variable = SMDerivReset
     variable = SMDeriv
-  [../]
+  []
 
-  [./Ar*T_from_sub]
+  [Ar*T_from_sub]
     type = MultiAppCopyTransfer
     from_multi_app = SensitivityMatrix
     source_variable = Ar*
     variable = Ar*T
-  [../]
-  [./Deriv_from_sub]
+  []
+  [Deriv_from_sub]
     type = MultiAppCopyTransfer
     from_multi_app = SensitivityMatrix
     source_variable = SMDeriv
     variable = SMDeriv
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -160,7 +160,7 @@
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/test/tests/accelerations/tests
+++ b/test/tests/accelerations/tests
@@ -1,12 +1,12 @@
 [Tests]
-  [./Acceleration_By_Averaging]
+  [Acceleration_By_Averaging]
     type = 'Exodiff'
     input = 'Acceleration_By_Averaging_main.i'
     exodiff = 'Acceleration_By_Averaging_main_out.e Acceleration_By_Averaging_main_out_Averaging_Acceleration0_out.e Acceleration_By_Averaging_main_out_Averaging_Acceleration0_Sub0_out.e'
-  [../]
-  [./Acceleration_By_Shooting_Method]
+  []
+  [Acceleration_By_Shooting_Method]
     type = 'Exodiff'
     input = 'Acceleration_By_Shooting_Method.i'
     exodiff = 'Acceleration_By_Shooting_Method_out.e Acceleration_By_Shooting_Method_out_Shooting0_out.e Acceleration_By_Shooting_Method_out_Shooting0_SensitivityMatrix0_out.e'
-  [../]
+  []
 []

--- a/test/tests/automatic_differentiation/ad_argon.i
+++ b/test/tests/automatic_differentiation/ad_argon.i
@@ -7,22 +7,22 @@ dom0Scale=1e-3
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'ad_argon.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -30,10 +30,10 @@ dom0Scale=1e-3
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -50,320 +50,320 @@ dom0Scale=1e-3
   nl_abs_tol = 1e-10
   dtmin = 1e-18
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
     optimal_iterations = 30
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
+  []
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [Kernels]
-  [./Arex_time_deriv]
+  [Arex_time_deriv]
     type = TimeDerivativeLog
     variable = Ar*
     block = 0
-  [../]
-  [./Arex_diffusion]
+  []
+  [Arex_diffusion]
     type = CoeffDiffusion
     variable = Ar*
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arex_log_stabilization]
+  []
+  [Arex_log_stabilization]
     type = LogStabilizationMoles
     variable = Ar*
     block = 0
     #offset = 25
-  [../]
+  []
 
 
-  [./em_time_deriv]
+  [em_time_deriv]
     type = TimeDerivativeLog
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_log_stabilization]
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
+  []
 
-  [./potential_diffusion_dom1]
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./Ar2p_charge_source]
+  []
+  [Ar2p_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Ar2p
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = TimeDerivativeLog
     variable = Arp
     block = 0
-  [../]
-  [./Arp_advection]
+  []
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Arp_diffusion]
+  []
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Arp_log_stabilization]
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./Ar2p_time_deriv]
+  [Ar2p_time_deriv]
     #type = ElectronTimeDerivative
     type = TimeDerivativeLog
     variable = Ar2p
     block = 0
-  [../]
-  [./Ar2p_advection]
+  []
+  [Ar2p_advection]
     type = EFieldAdvection
     variable = Ar2p
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Ar2p_diffusion]
+  []
+  [Ar2p_diffusion]
     type = CoeffDiffusion
     variable = Ar2p
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Ar2p_log_stabilization]
+  [Ar2p_log_stabilization]
     type = LogStabilizationMoles
     variable = Ar2p
     block = 0
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = TimeDerivativeLog
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./em]
+  [em]
     initial_condition = -24
     block = 0
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     initial_condition = -24.69314718056
     block = 0
-  [../]
+  []
 
-  [./Ar*]
+  [Ar*]
     initial_condition = -26
     block = 0
-  [../]
+  []
 
-  [./Ar2p]
+  [Ar2p]
     initial_condition = -24.69314718056
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
     initial_condition = -24
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./Arex_lin]
+  [Arex_lin]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Ar2p_lin]
+  []
+  [Ar2p_lin]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Ar]
+  []
+  [Ar]
     block = 0
     order = CONSTANT
     family = MONOMIAL
     initial_condition = 3.70109
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x]
+  []
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./em_lin]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Arp_lin]
+  []
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Efield]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Current_em]
+  []
+  [Arp_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Arp]
+  []
+  [Efield]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_Ar2p]
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_gas_current]
+  []
+  [Current_Ar2p]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./PowerDep_em]
+  []
+  [DiffusiveFlux_em]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./Arex_lin]
+  [Arex_lin]
     type = DensityMoles
     variable = Arex_lin
     density_log = Ar*
     block = 0
-  [../]
-  [./Ar2p_lin]
+  []
+  [Ar2p_lin]
     type = DensityMoles
     variable = Ar2p_lin
     density_log = Ar2p
     block = 0
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -372,8 +372,8 @@ dom0Scale=1e-3
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -382,63 +382,63 @@ dom0Scale=1e-3
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_lin Arp_lin Ar2p_lin'
     function = 'Arp_lin + Ar2p_lin - em_lin'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp Current_Ar2p'
     function = 'Current_em + Current_Arp + Current_Ar2p'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
     block = 0
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = DensityMoles
     variable = Arp_lin
     density_log = Arp
     block = 0
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -446,8 +446,8 @@ dom0Scale=1e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -455,8 +455,8 @@ dom0Scale=1e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar2p]
+  []
+  [Current_Ar2p]
     type = ADCurrent
     potential = potential
     density_log = Ar2p
@@ -464,26 +464,26 @@ dom0Scale=1e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'right'
@@ -491,8 +491,8 @@ dom0Scale=1e-3
     em = em
     r = 0.0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -500,8 +500,8 @@ dom0Scale=1e-3
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -510,9 +510,9 @@ dom0Scale=1e-3
     ip = 'Arp Ar2p'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -523,15 +523,15 @@ dom0Scale=1e-3
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
     preset = false
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'right'
@@ -539,39 +539,39 @@ dom0Scale=1e-3
     mean_en = mean_en
     r = 0.0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'right'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'right'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Ar2p_physical_right_diffusion]
+  []
+  [Ar2p_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Ar2p
     boundary = 'right'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Ar2p_physical_right_advection]
+  []
+  [Ar2p_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Ar2p
     boundary = 'right'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -579,8 +579,8 @@ dom0Scale=1e-3
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -589,116 +589,116 @@ dom0Scale=1e-3
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Ar2p_physical_left_diffusion]
+  []
+  [Ar2p_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Ar2p
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Ar2p_physical_left_advection]
+  []
+  [Ar2p_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Ar2p
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = -0.8
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-0.8 * (1 - x)'
-  [../]
+  []
 []
 
 [Materials]
-  [./electron_moments]
+  [electron_moments]
     type = ADGasElectronMoments
     block = 0
     em = em
     mean_en = mean_en
     property_tables_file = 'argon_chemistry_rates/electron_moments.txt'
-  [../]
+  []
 
-  [./gas_constants]
+  [gas_constants]
     type = GenericConstantMaterial
     block = 0
     prop_names = ' e         N_A     k_boltz  eps       T_gas massem   p_gas  n_gas    se_coeff se_energy'
     prop_values = '1.6e-19 6.022e23  1.38e-23 8.854e-12 300   9.11e-31 1.01e5 40.4915  0.05     3.'
-  [../]
+  []
   [ad_gas_constants]
     type = ADGenericConstantMaterial
     block = 0
     prop_names = 'diffpotential'
     prop_values = '8.85e-12'
   []
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Arp
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     block = 0
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar2p
     heavy_species_mass = 1.328e-25
     heavy_species_charge = 1.0
     block = 0
-  [../]
+  []
 
-  [./gas_species_2]
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     block = 0
-  [../]
+  []
 
-  [./gas_species_3]
+  [gas_species_3]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     block = 0
-  [../]
+  []
 []
 
 [Reactions]
   # This argon reaction network based on a ZDPlasKin example:
   # zdplaskin.laplace.univ-tlse.fr
   # Example: "Micro-cathode sustained discharged in Ar"
-  [./Argon]
+  [Argon]
     species = 'em Arp Ar2p Ar*'
     aux_species = 'Ar'
     reaction_coefficient_format = 'townsend'
@@ -740,5 +740,5 @@ dom0Scale=1e-3
                  Arp + em + em -> Ar + em         : {3.17314235e9*(e_temp/11600)^(-4.5)}
                  Ar* + Ar + Ar -> Ar + Ar + Ar    : 5077.02776
                  Arp + Ar + Ar -> Ar2p + Ar       : {81595.089*(Tgas/300)^(-0.4)}'
-  [../]
+  []
 []

--- a/test/tests/automatic_differentiation/tests
+++ b/test/tests/automatic_differentiation/tests
@@ -1,11 +1,11 @@
 [Tests]
-  [./ad_test]
+  [ad_test]
     type = 'Exodiff'
     input = 'ad_argon.i'
     exodiff = 'ad_argon_out.e'
     group = 'automatic_differentiation'
-  [../]
-  [./jacobian_testing]
+  []
+  [jacobian_testing]
     type = 'PetscJacobianTester'
     input = 'ad_argon.i'
     cli_args = 'Outputs/exodus=false Executioner/num_steps=1'
@@ -13,5 +13,5 @@
     ratio_tol = 5e-6
     difference_tol = 1e-1
     group = 'automatic_differentiation'
-  [../]
+  []
 []

--- a/test/tests/crane_action/rate_units.i
+++ b/test/tests/crane_action/rate_units.i
@@ -8,22 +8,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./geo]
+  [geo]
     type = FileMeshGenerator
     file = 'rate_units.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -31,230 +31,230 @@ dom0Scale=25.4e-3
 []
 
 [Variables]
-  [./em]
-  [../]
+  [em]
+  []
 
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 
-  [./Ar*]
-  [../]
+  [Ar*]
+  []
 
-  [./mean_en]
-  [../]
+  [mean_en]
+  []
 
-  [./potential]
-  [../]
+  [potential]
+  []
 []
 
 [Kernels]
   #Electron Equations (Same as in paper)
     #Time Derivative term of electron
-    [./em_time_deriv]
+    [em_time_deriv]
       type = ElectronTimeDerivative
       variable = em
-    [../]
+    []
     #Advection term of electron
-    [./em_advection]
+    [em_advection]
       type = EFieldAdvection
       variable = em
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons
-    [./em_diffusion]
+    [em_diffusion]
       type = CoeffDiffusion
       variable = em
       position_units = ${dom0Scale}
-    [../]
+    []
 
   #Argon Ion Equations (Same as in paper)
     #Time Derivative term of the ions
-    [./Ar+_time_deriv]
+    [Ar+_time_deriv]
       type = ElectronTimeDerivative
       variable = Ar+
-    [../]
+    []
     #Advection term of ions
-    [./Ar+_advection]
+    [Ar+_advection]
       type = EFieldAdvection
       variable = Ar+
       potential = potential
       position_units = ${dom0Scale}
-    [../]
-    [./Ar+_diffusion]
+    []
+    [Ar+_diffusion]
       type = CoeffDiffusion
       variable = Ar+
       position_units = ${dom0Scale}
-    [../]
+    []
       #Time Derivative term of excited Argon
-      [./Ar*_time_deriv]
+      [Ar*_time_deriv]
         type = ElectronTimeDerivative
         variable = Ar*
-      [../]
+      []
       #Diffusion term of excited Argon
-      [./Ar*_diffusion]
+      [Ar*_diffusion]
         type = CoeffDiffusion
         variable = Ar*
         position_units = ${dom0Scale}
-      [../]
+      []
 
   #Voltage Equations (Same as in paper)
     #Voltage term in Poissons Eqaution
-    [./potential_diffusion_dom0]
+    [potential_diffusion_dom0]
       type = CoeffDiffusionLin
       variable = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Ion term in Poissons Equation
-    [./Ar+_charge_source]
+    [Ar+_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = Ar+
-    [../]
+    []
     #Electron term in Poissons Equation
-    [./em_charge_source]
+    [em_charge_source]
       type = ChargeSourceMoles_KV
       variable = potential
       charged = em
-    [../]
+    []
 
 
   #Since the paper uses electron temperature as a variable, the energy equation is in
   #a different form but should be the same physics
     #Time Derivative term of electron energy
-    [./mean_en_time_deriv]
+    [mean_en_time_deriv]
       type = ElectronTimeDerivative
       variable = mean_en
-    [../]
+    []
     #Advection term of electron energy
-    [./mean_en_advection]
+    [mean_en_advection]
       type = EFieldAdvection
       variable = mean_en
       potential = potential
       position_units = ${dom0Scale}
-    [../]
+    []
     #Diffusion term of electrons energy
-    [./mean_en_diffusion]
+    [mean_en_diffusion]
       type = CoeffDiffusion
       variable = mean_en
       position_units = ${dom0Scale}
-    [../]
+    []
     #Joule Heating term
-    [./mean_en_joule_heating]
+    [mean_en_joule_heating]
       type = JouleHeating
       variable = mean_en
       potential = potential
       em = em
       position_units = ${dom0Scale}
-    [../]
+    []
   []
 
 
 [AuxVariables]
-  [./Te]
+  [Te]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./rho]
+  [rho]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar+_lin]
+  [Ar+_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar*_lin]
+  [Ar*_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 
-  [./Efield]
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./Current_em]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./Current_Ar]
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
+  []
+  [Current_Ar]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
 []
 
 [AuxKernels]
-  [./Te]
+  [Te]
     type = ElectronTemperature
     variable = Te
     electron_density = em
     mean_en = mean_en
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_lin]
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
-  [../]
-  [./Ar+_lin]
+  []
+  [Ar+_lin]
     type = DensityMoles
     variable = Ar+_lin
     density_log = Ar+
-  [../]
-  [./Ar*_lin]
+  []
+  [Ar*_lin]
     type = DensityMoles
     variable = Ar*_lin
     density_log = Ar*
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = ConstantAux
     variable = Ar
     # value = 3.22e22
     value = -2.928623
     execute_on = INITIAL
-  [../]
+  []
 
-  [./Efield_calc]
+  [Efield_calc]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -262,8 +262,8 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_Ar]
+  []
+  [Current_Ar]
     type = ADCurrent
     potential = potential
     density_log = Ar+
@@ -271,29 +271,29 @@ dom0Scale=25.4e-3
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition, same as in paper
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #New Boundary conditions for electons, same as in paper
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -304,8 +304,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -316,108 +316,108 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #New Boundary conditions for ions, should be the same as in paper
 #(except the metastables are not set to zero, since Zapdos uses log form)
-  [./Ar*_physical_right_diffusion]
+  [Ar*_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'right'
     value = 100
-  [../]
-  [./Ar*_physical_left_diffusion]
+  []
+  [Ar*_physical_left_diffusion]
     type = LogDensityDirichletBC
     variable = Ar*
     boundary = 'left'
     value = 100
-  [../]
+  []
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./Ar*_ic]
+  []
+  [Ar*_ic]
     type = FunctionIC
     variable = Ar*
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -429,52 +429,52 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = rate_coefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_1]
+  []
+  [gas_species_1]
     type = ADHeavySpecies
     heavy_species_name = Ar*
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     diffusivity = 7.515528e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
+  []
 []
 
 #New postprocessor that calculates the inverse of the plasma frequency
 [Postprocessors]
-  [./InversePlasmaFreq]
+  [InversePlasmaFreq]
     type = PlasmaFrequencyInverse
     variable = em
     use_moles = true
     execute_on = 'INITIAL TIMESTEP_BEGIN'
-  [../]
+  []
 []
 
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -492,22 +492,22 @@ dom0Scale=25.4e-3
   l_max_its = 20
 
   #Time steps based on the inverse of the plasma frequency
-  [./TimeStepper]
+  [TimeStepper]
     type = PostprocessorDT
     postprocessor = InversePlasmaFreq
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
+  []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     species = 'Ar* em Ar+'
     aux_species = 'Ar'
     reaction_coefficient_format = 'rate'
@@ -528,5 +528,5 @@ dom0Scale=25.4e-3
                  Ar* + Ar* -> Ar+ + Ar + em : 373364000
                  Ar* + Ar -> Ar + Ar        : 1806.6
                  Ar* + Ar + Ar -> Ar_2 + Ar : 398909.324'
-  [../]
+  []
 []

--- a/test/tests/crane_action/tests
+++ b/test/tests/crane_action/tests
@@ -1,15 +1,15 @@
 [Tests]
-  [./crane_rate_coefficients]
+  [crane_rate_coefficients]
     type = 'Exodiff'
     input = 'rate_units.i'
     exodiff = 'rate_units_out.e'
     group = 'crane_action'
-  [../]
-  [./crane_townsend_coefficients]
+  []
+  [crane_townsend_coefficients]
     type = 'Exodiff'
     input = 'townsend_units.i'
     exodiff = 'townsend_units_out.e'
     group = 'crane_action'
     custom_cmp = 'townsend_units_out.cmp'
-  [../]
+  []
 []

--- a/test/tests/crane_action/townsend_units.i
+++ b/test/tests/crane_action/townsend_units.i
@@ -10,36 +10,36 @@ dom1Scale=1e-7
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'townsend_units.msh'
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'master0_interface'
     input = file
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'master1_interface'
     input = interface
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -47,10 +47,10 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -64,24 +64,24 @@ dom1Scale=1e-7
   nl_abs_tol = 7.6e-5
   dtmin = 1e-15
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
     optimal_iterations = 30
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
-  #[./dof_map]
+  []
+  #[dof_map]
   #  type = DOFMap
-  #[../]
+  #[]
 []
 
 [Debug]
@@ -89,352 +89,352 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [Kernels]
-  [./em_time_deriv]
+  [em_time_deriv]
     type = ElectronTimeDerivative
     variable = em
     block = 0
-  [../]
-  [./em_advection]
+  []
+  [em_advection]
     type = EFieldAdvection
     variable = em
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = CoeffDiffusion
     variable = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_log_stabilization]
+  [em_log_stabilization]
     type = LogStabilizationMoles
     variable = em
     block = 0
-  [../]
+  []
 
-  [./emliq_time_deriv]
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
     block = 1
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 
-  [./emliq_log_stabilization]
+  [emliq_log_stabilization]
     type = LogStabilizationMoles
     variable = emliq
     block = 1
-  [../]
+  []
 
-  [./potential_diffusion_dom1]
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom2]
+  []
+  [potential_diffusion_dom2]
     type = CoeffDiffusionLin
     variable = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Arp_charge_source]
+  []
+  [Arp_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = Arp
     block = 0
-  [../]
-  [./em_charge_source]
+  []
+  [em_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = em
     block = 0
-  [../]
-  [./emliq_charge_source]
+  []
+  [emliq_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = emliq
     block = 1
-  [../]
-  [./OHm_charge_source]
+  []
+  [OHm_charge_source]
     type = ChargeSourceMoles_KV
     variable = potential
     charged = OHm
     block = 1
-  [../]
+  []
 
-  [./Arp_time_deriv]
+  [Arp_time_deriv]
     type = ElectronTimeDerivative
     variable = Arp
     block = 0
-  [../]
-  [./Arp_advection]
+  []
+  [Arp_advection]
     type = EFieldAdvection
     variable = Arp
     potential = potential
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Arp_diffusion]
+  []
+  [Arp_diffusion]
     type = CoeffDiffusion
     variable = Arp
     block = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Arp_log_stabilization]
+  [Arp_log_stabilization]
     type = LogStabilizationMoles
     variable = Arp
     block = 0
-  [../]
+  []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
     block = 1
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_log_stabilization]
+  []
+  [OHm_log_stabilization]
     type = LogStabilizationMoles
     variable = OHm
     block = 1
-  [../]
+  []
 
-  [./mean_en_time_deriv]
+  [mean_en_time_deriv]
     type = ElectronTimeDerivative
     variable = mean_en
     block = 0
-  [../]
-  [./mean_en_advection]
+  []
+  [mean_en_advection]
     type = EFieldAdvection
     variable = mean_en
     potential = potential
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_diffusion]
+  []
+  [mean_en_diffusion]
     type = CoeffDiffusion
     variable = mean_en
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_joule_heating]
+  []
+  [mean_en_joule_heating]
     type = JouleHeating
     variable = mean_en
     potential = potential
     em = em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_log_stabilization]
+  []
+  [mean_en_log_stabilization]
     type = LogStabilizationMoles
     variable = mean_en
     block = 0
     offset = 15
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
+  [potential]
+  []
 
-  [./em]
+  [em]
     block = 0
-  [../]
+  []
 
-  [./emliq]
+  [emliq]
     block = 1
-  [../]
+  []
 
-  [./Arp]
+  [Arp]
     block = 0
-  [../]
+  []
 
-  [./mean_en]
+  [mean_en]
     block = 0
-  [../]
+  []
 
-  [./OHm]
+  [OHm]
     block = 1
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./H2O]
+  [H2O]
     order = CONSTANT
     family = MONOMIAL
     initial_condition = 10.92252
     block = 1
-  [../]
-  [./Ar]
+  []
+  [Ar]
     block = 0
     order = CONSTANT
     family = MONOMIAL
     initial_condition = 3.70109
-  [../]
-  [./e_temp]
+  []
+  [e_temp]
     block = 0
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x]
+  []
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./rho]
-    order = CONSTANT
-    family = MONOMIAL
-    block = 0
-  [../]
-  [./rholiq]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./em_lin]
+  []
+  [x_node]
+  []
+  [rho]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [rholiq]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [em_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [emliq_lin]
+    order = CONSTANT
+    family = MONOMIAL
     block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Efield]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./Current_em]
+  []
+  [Arp_lin]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_emliq]
+  []
+  [OHm_lin]
+    block = 1
     order = CONSTANT
     family = MONOMIAL
-    block = 1
-  [../]
-  [./Current_Arp]
+  []
+  [Efield]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [Current_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./Current_OHm]
-    block = 1
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_gas_current]
+    block = 1
+  []
+  [Current_Arp]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [Current_OHm]
     block = 1
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
-    block = 1
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [tot_gas_current]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [tot_liq_current]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [tot_flux_OHm]
+    block = 1
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [EFieldAdvAux_em]
     order = CONSTANT
     family = MONOMIAL
     block = 0
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [DiffusiveFlux_em]
+    order = CONSTANT
+    family = MONOMIAL
+    block = 0
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
     block = 1
-  [../]
-  [./PowerDep_em]
+  []
+  [PowerDep_em]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
    order = CONSTANT
    family = MONOMIAL
    block = 0
-  [../]
-  #[./ProcRate_el]
+  []
+  #[ProcRate_el]
   # order = CONSTANT
   # family = MONOMIAL
   # block = 0
-  #[../]
-  #[./ProcRate_ex]
+  #[]
+  #[ProcRate_ex]
   # order = CONSTANT
   # family = MONOMIAL
   # block = 0
-  #[../]
-  #[./ProcRate_iz]
+  #[]
+  #[ProcRate_iz]
   # order = CONSTANT
   # family = MONOMIAL
   # block = 0
-  #[../]
+  #[]
 []
 
 [AuxKernels]
-  [./PowerDep_em]
+  [PowerDep_em]
     type = ADPowerDep
     density_log = em
     potential = potential
@@ -443,8 +443,8 @@ dom1Scale=1e-7
     variable = PowerDep_em
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./PowerDep_Arp]
+  []
+  [PowerDep_Arp]
     type = ADPowerDep
     density_log = Arp
     potential = potential
@@ -453,8 +453,8 @@ dom1Scale=1e-7
     variable = PowerDep_Arp
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  #[./ProcRate_el]
+  []
+  #[ProcRate_el]
   #  type = ProcRate
   #  em = em
   #  potential = potential
@@ -462,8 +462,8 @@ dom1Scale=1e-7
   #  variable = ProcRate_el
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./ProcRate_ex]
+  #[]
+  #[ProcRate_ex]
   #  type = ProcRate
   #  em = em
   #  potential = potential
@@ -471,8 +471,8 @@ dom1Scale=1e-7
   #  variable = ProcRate_ex
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./ProcRate_iz]
+  #[]
+  #[ProcRate_iz]
   #  type = ProcRate
   #  em = em
   #  potential = potential
@@ -480,111 +480,111 @@ dom1Scale=1e-7
   #  variable = ProcRate_iz
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  [./e_temp]
+  #[]
+  [e_temp]
     type = ElectronTemperature
     variable = e_temp
     electron_density = em
     mean_en = mean_en
     block = 0
-  [../]
-  [./x_g]
+  []
+  [x_g]
     type = Position
     variable = x
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_l]
+  []
+  [x_l]
     type = Position
     variable = x
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./x_ng]
+  []
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./rho]
+  []
+  [rho]
     type = ParsedAux
     variable = rho
     args = 'em_lin Arp_lin'
     function = 'Arp_lin - em_lin'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./rholiq]
+  []
+  [rholiq]
     type = ParsedAux
     variable = rholiq
     args = 'emliq_lin OHm_lin' # H3Op_lin OHm_lin'
     function = '-emliq_lin - OHm_lin' # 'H3Op_lin - em_lin - OHm_lin'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./tot_gas_current]
+  []
+  [tot_gas_current]
     type = ParsedAux
     variable = tot_gas_current
     args = 'Current_em Current_Arp'
     function = 'Current_em + Current_Arp'
     execute_on = 'timestep_end'
     block = 0
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm' # Current_H3Op Current_OHm'
     function = 'Current_emliq + Current_OHm' # + Current_H3Op + Current_OHm'
     execute_on = 'timestep_end'
     block = 1
-  [../]
-  [./em_lin]
+  []
+  [em_lin]
     type = DensityMoles
     variable = em_lin
     density_log = em
     block = 0
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = DensityMoles
     variable = emliq_lin
     density_log = emliq
     block = 1
-  [../]
-  [./Arp_lin]
+  []
+  [Arp_lin]
     type = DensityMoles
     variable = Arp_lin
     density_log = Arp
     block = 0
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = DensityMoles
     variable = OHm_lin
     density_log = OHm
     block = 1
-  [../]
-  [./Efield_g]
+  []
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom1Scale}
     block = 1
-  [../]
-  [./Current_em]
+  []
+  [Current_em]
     type = ADCurrent
     potential = potential
     density_log = em
@@ -592,8 +592,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
@@ -601,8 +601,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./Current_Arp]
+  []
+  [Current_Arp]
     type = ADCurrent
     potential = potential
     density_log = Arp
@@ -610,8 +610,8 @@ dom1Scale=1e-7
     art_diff = false
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     block = 1
     type = ADCurrent
     potential = potential
@@ -619,48 +619,48 @@ dom1Scale=1e-7
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     block = 1
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_em]
+  []
+  [EFieldAdvAux_em]
     type = ADEFieldAdvAux
     potential = potential
     density_log = em
     variable = EFieldAdvAux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./DiffusiveFlux_em]
+  []
+  [DiffusiveFlux_em]
     type = ADDiffusiveFlux
     density_log = em
     variable = DiffusiveFlux_em
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -669,8 +669,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -678,11 +678,11 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -691,8 +691,8 @@ dom1Scale=1e-7
     r = 0.99
     #r = 0.0
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -700,8 +700,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -710,9 +710,9 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -723,14 +723,14 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./em_physical_right]
+  []
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -739,24 +739,24 @@ dom1Scale=1e-7
     r = 0.99
     #r = 0.0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_advection]
+  []
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -764,8 +764,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -774,97 +774,97 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_diffusion]
+  []
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./emliq_right]
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
- [./water_block]
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 
- [./test]
+ [test]
    type = GasElectronMoments
    interp_trans_coeffs = true
    interp_elastic_coeff = true
@@ -876,34 +876,34 @@ dom1Scale=1e-7
    mean_en = mean_en
    block = 0
    property_tables_file = 'townsend_coefficients/moments.txt'
- [../]
+ []
 
- [./test_block1]
+ [test_block1]
    type = GenericConstantMaterial
    block = 1
    prop_names = 'T_gas p_gas'
    prop_values = '300 1.01e5'
- [../]
+ []
 
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Arp
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     block = 0
-  [../]
+  []
 
-  [./gas_species_2]
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
     block = 0
-  [../]
+  []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     species = 'em Arp'
     aux_species = 'Ar'
     reaction_coefficient_format = 'townsend'
@@ -922,9 +922,9 @@ dom1Scale=1e-7
     reactions = 'em + Ar -> em + Ar               : EEDF [elastic] (reaction1)
                  em + Ar -> em + Ar*              : EEDF [-11.5] (reaction2)
                  em + Ar -> em + em + Arp         : EEDF [-15.76] (reaction3)'
-  [../]
+  []
 
-  [./Water]
+  [Water]
     species = 'emliq OHm'
     reaction_coefficient_format = 'rate'
     use_log = true
@@ -933,5 +933,5 @@ dom1Scale=1e-7
     block = 1
     reactions = 'emliq -> H + OHm : 1064
                  emliq + emliq -> H2 + OHm + OHm : 3.136e8'
-  [../]
+  []
 []

--- a/test/tests/current_carrying_wire/current_carrying_wire.i
+++ b/test/tests/current_carrying_wire/current_carrying_wire.i
@@ -1,29 +1,29 @@
 [Mesh]
-  [./generated]
+  [generated]
     type = GeneratedMeshGenerator
     dim = 1
     nx = 20
     xmax = 2
     xmin = 0
-  [../]
-  [./vacuum]
+  []
+  [vacuum]
     type = SubdomainBoundingBoxGenerator
     bottom_left = '1 0 0'
     top_right = '2 0 0'
     block_id = 1
     input = generated
-  [../]
+  []
 []
 
 [Problem]
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
     ksp_norm = none
-  [../]
+  []
 []
 
 [Executioner]
@@ -36,34 +36,34 @@
 [Outputs]
   perf_graph = true
   print_linear_residuals = false
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []
 
 [Kernels]
-  [./curl_z]
+  [curl_z]
     type = AxisymmetricCurlZ
     variable = Bphi
-  [../]
-  [./source]
+  []
+  [source]
     type = UserSource
     variable = Bphi
     source_magnitude = 1
     block = 0
-  [../]
+  []
 []
 
 [Variables]
-  [./Bphi]
-  [../]
+  [Bphi]
+  []
 []
 
 [BCs]
-  [./center_of_wire]
+  [center_of_wire]
     type = DirichletBC
     boundary = left
     variable = Bphi
     value = 0
-  [../]
+  []
 []

--- a/test/tests/current_carrying_wire/tests
+++ b/test/tests/current_carrying_wire/tests
@@ -1,7 +1,7 @@
 [Tests]
-  [./current_carrying_wire]
+  [current_carrying_wire]
     type = 'Exodiff'
     input = 'current_carrying_wire.i'
     exodiff = 'current_carrying_wire_out.e'
-  [../]
+  []
 []

--- a/test/tests/field_emission/field_emission.i
+++ b/test/tests/field_emission/field_emission.i
@@ -10,22 +10,22 @@ vhigh=-0.15 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'micro_fe.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,10 +34,10 @@ vhigh=-0.15 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -51,22 +51,22 @@ vhigh=-0.15 #kV
         nl_abs_tol = 7.6e-5
         dtmin = 1e-15
         dtmax = 0.01E-7
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-12
                 growth_factor = 1.2
                 optimal_iterations = 15
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
                 #       execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -74,36 +74,36 @@ vhigh=-0.15 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e6
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -111,58 +111,58 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 block = 0
-        [../]
-        # [./em_advection_stabilization]
+        []
+        # [em_advection_stabilization]
         #               type = EFieldArtDiff
         #               variable = em
         #               potential = potential
         #               block = 0
-        # [../]
+        # []
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -170,186 +170,186 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_log_stabilization]
+        []
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 block = 0
-        [../]
-        # [./Arp_advection_stabilization]
+        []
+        # [Arp_advection_stabilization]
         #               type = EFieldArtDiff
         #               variable = Arp
         #               potential = potential
         #               block = 0
-        # [../]
+        # []
 
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 15
-        [../]
-        # [./mean_en_advection_stabilization]
+        []
+        # [mean_en_advection_stabilization]
         #               type = EFieldArtDiff
         #               variable = mean_en
         #               potential = potential
         #               block = 0
-        # [../]
+        # []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = PowerDep
                 density_log = em
                 potential = potential
@@ -358,8 +358,8 @@ vhigh=-0.15 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = PowerDep
                 density_log = Arp
                 potential = potential
@@ -368,8 +368,8 @@ vhigh=-0.15 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ProcRate
                 em = em
                 potential = potential
@@ -377,8 +377,8 @@ vhigh=-0.15 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ProcRate
                 em = em
                 potential = potential
@@ -386,8 +386,8 @@ vhigh=-0.15 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ProcRate
                 em = em
                 potential = potential
@@ -395,65 +395,65 @@ vhigh=-0.15 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = Current
                 potential = potential
                 density_log = em
@@ -461,8 +461,8 @@ vhigh=-0.15 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = Current
                 potential = potential
                 density_log = Arp
@@ -470,26 +470,26 @@ vhigh=-0.15 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = EFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = DiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -500,14 +500,14 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./potential_dirichlet_right]
+        []
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
-        [./em_physical_right]
+        []
+        [em_physical_right]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = right
@@ -515,24 +515,24 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 r = 0.99
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_physical_right]
+        []
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -541,8 +541,8 @@ vhigh=-0.15 #kV
                 ip = Arp
                 r = 0.99
                 position_units = ${dom0Scale}
-        [../]
-        [./em_physical_left]
+        []
+        [em_physical_left]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = 'left'
@@ -550,8 +550,8 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./sec_electrons_left]
+        []
+#       [sec_electrons_left]
 #               type = SecondaryElectronBC
 #               variable = em
 #               boundary = 'left'
@@ -560,8 +560,8 @@ vhigh=-0.15 #kV
 #               mean_en = mean_en
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
-        [./FieldEmission_left]
+#       []
+        [FieldEmission_left]
                 type = FieldEmissionBC
                 variable = em
                 boundary = 'left'
@@ -570,23 +570,23 @@ vhigh=-0.15 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_diffusion]
+        []
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_physical_left]
+        []
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -595,57 +595,57 @@ vhigh=-0.15 #kV
                 ip = Arp
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -21
                 block = 0
-        [../]
-        [./Arp_ic]
+        []
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -21
                 block = 0
-        [../]
-        [./mean_en_ic]
+        []
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -20
                 block = 0
-        [../]
+        []
 
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
-        # [./em_ic]
+        []
+        # [em_ic]
         #               type = RandomIC
         #               variable = em
         #               block = 0
-        # [../]
-        # [./Arp_ic]
+        # []
+        # [Arp_ic]
         #               type = RandomIC
         #               variable = Arp
         #               block = 0
-        # [../]
-        # [./mean_en_ic]
+        # []
+        # [mean_en_ic]
         #               type = RandomIC
         #               variable = mean_en
         #               block = 0
-        # [../]
-        # [./potential_ic]
+        # []
+        # [potential_ic]
         #               type = RandomIC
         #               variable = potential
-        # [../]
+        # []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'period dutyCycle riseTime VHigh VLow'
                 vals = '3E-6 0.1 5E-7 ${vhigh} -0.001')
@@ -654,19 +654,19 @@ vhigh=-0.15 #kV
                                  if((t % period) < period - riseTime          , VLow                                                                                                                               ,
                                  if((t % period) < period                                         , ((VHigh - VLow)/riseTime) * ((t % period) - period) + VHigh            ,
                                         0))))'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
-        [./cathode_temperature]
+        []
+        [cathode_temperature]
                 type = ParsedFunction
                 value = 1500
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -680,5 +680,5 @@ vhigh=-0.15 #kV
                 user_field_enhancement = 55
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/kernels/simple_diffusion/simple_diffusion.i
+++ b/test/tests/kernels/simple_diffusion/simple_diffusion.i
@@ -1,37 +1,37 @@
 [Mesh]
-  [./generated]
+  [generated]
     type = GeneratedMeshGenerator
     dim = 2
     nx = 10
     ny = 10
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = right
     value = 1
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/kernels/simple_diffusion/tests
+++ b/test/tests/kernels/simple_diffusion/tests
@@ -1,7 +1,7 @@
 [Tests]
-  [./test]
+  [test]
     type = 'Exodiff'
     input = 'simple_diffusion.i'
     exodiff = 'simple_diffusion_out.e'
-  [../]
+  []
 []

--- a/test/tests/reflections/Schottky/Input.i
+++ b/test/tests/reflections/Schottky/Input.i
@@ -9,22 +9,22 @@ vhigh = -150E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -33,10 +33,10 @@ vhigh = -150E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -55,22 +55,22 @@ vhigh = -150E-3 #kV
         dtmin = 1e-16
         dtmax = 0.1E-7
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.9
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -78,34 +78,34 @@ vhigh = -150E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e6
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -113,53 +113,53 @@ vhigh = -150E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 40
                 block = 0
-        [../]
+        []
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -167,178 +167,178 @@ vhigh = -150E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_log_stabilization]
+        []
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 40
                 block = 0
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 30
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -347,8 +347,8 @@ vhigh = -150E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -357,8 +357,8 @@ vhigh = -150E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -366,8 +366,8 @@ vhigh = -150E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -375,8 +375,8 @@ vhigh = -150E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -384,65 +384,65 @@ vhigh = -150E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -450,8 +450,8 @@ vhigh = -150E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -459,27 +459,27 @@ vhigh = -150E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -490,17 +490,17 @@ vhigh = -150E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -510,9 +510,9 @@ vhigh = -150E-3 #kV
                 mean_en = mean_en
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -520,9 +520,9 @@ vhigh = -150E-3 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = right
@@ -530,43 +530,43 @@ vhigh = -150E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -574,9 +574,9 @@ vhigh = -150E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -584,53 +584,53 @@ vhigh = -150E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -42
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -45
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -36
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -646,5 +646,5 @@ vhigh = -150E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/Schottky/tests
+++ b/test/tests/reflections/Schottky/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/reflections/Schottky_300_V_5_um/Input.i
+++ b/test/tests/reflections/Schottky_300_V_5_um/Input.i
@@ -9,22 +9,22 @@ vhigh = -400E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -33,10 +33,10 @@ vhigh = -400E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -58,22 +58,22 @@ vhigh = -400E-3 #kV
         dtmin = 1e-16
         dtmax = 0.1E-7
         nl_max_its = 100
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.4
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -81,60 +81,60 @@ vhigh = -400E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e0
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 45
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 45
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 45
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -142,48 +142,48 @@ vhigh = -400E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -191,160 +191,160 @@ vhigh = -400E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -353,8 +353,8 @@ vhigh = -400E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -363,8 +363,8 @@ vhigh = -400E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -372,8 +372,8 @@ vhigh = -400E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -381,8 +381,8 @@ vhigh = -400E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -390,65 +390,65 @@ vhigh = -400E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -456,8 +456,8 @@ vhigh = -400E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -465,27 +465,27 @@ vhigh = -400E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -496,17 +496,17 @@ vhigh = -400E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -518,9 +518,9 @@ vhigh = -400E-3 #kV
                 position_units = ${dom0Scale}
                 tau = 100E-9
                 relax = true
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -528,52 +528,52 @@ vhigh = -400E-3 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-#       [./Arp_physical_left_diffusion]
+#       [Arp_physical_left_diffusion]
 #               type = HagelaarIonDiffusionBC
 #               variable = Arp
 #               boundary = 'left'
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
-        [./Arp_physical_left_advection]
+#       []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-#       [./Arp_physical_right_diffusion]
+#       [Arp_physical_right_diffusion]
 #               type = HagelaarIonDiffusionBC
 #               variable = Arp
 #               boundary = right
 #               r = 0
 #               position_units = ${dom0Scale}
-#       [../]
-        [./Arp_physical_right_advection]
+#       []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyAdvectionBC
                 variable = mean_en
                 boundary = 'left'
@@ -581,9 +581,9 @@ vhigh = -400E-3 #kV
                 ip = Arp
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -591,53 +591,53 @@ vhigh = -400E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -42
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -45
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -36
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -653,5 +653,5 @@ vhigh = -400E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/Schottky_300_V_5_um/tests
+++ b/test/tests/reflections/Schottky_300_V_5_um/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/reflections/Schottky_400_V_10_um/Input.i
+++ b/test/tests/reflections/Schottky_400_V_10_um/Input.i
@@ -9,22 +9,22 @@ vhigh = -175E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -33,10 +33,10 @@ vhigh = -175E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -55,22 +55,22 @@ vhigh = -175E-3 #kV
         dtmin = 1e-30
         dtmax = 0.1E-7
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.9
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -78,60 +78,60 @@ vhigh = -175E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e3
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
 ## Stabilization
-        [./Arp_log_stabilization]
+        [Arp_log_stabilization]
                 type = LogStabilizationMoles
                 variable = Arp
                 offset = 45
                 block = 0
-        [../]
-        [./em_log_stabilization]
+        []
+        [em_log_stabilization]
                 type = LogStabilizationMoles
                 variable = em
                 offset = 45
                 block = 0
-        [../]
-        [./mean_en_log_stabilization]
+        []
+        [mean_en_log_stabilization]
                 type = LogStabilizationMoles
                 variable = mean_en
                 block = 0
                 offset = 45
-        [../]
-#       [./mean_en_advection_stabilization]
+        []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -139,48 +139,48 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -188,160 +188,160 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -350,8 +350,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -360,8 +360,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -369,8 +369,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -378,8 +378,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -387,65 +387,65 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -453,8 +453,8 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -462,27 +462,27 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -493,17 +493,17 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SchottkyEmissionBC
 #               type = SecondaryElectronBC
                 variable = em
@@ -513,9 +513,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        # [./em_physical_left]
+        # [em_physical_left]
         #       type = HagelaarElectronBC
         #       variable = em
         #       boundary = 'left'
@@ -523,52 +523,52 @@ vhigh = -175E-3 #kV
         #       mean_en = mean_en
         #       r = 0
         #       position_units = ${dom0Scale}
-        # [../]
+        # []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronAdvectionBC
                 variable = em
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -576,9 +576,9 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -586,53 +586,53 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -42
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -45
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -36
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -648,5 +648,5 @@ vhigh = -175E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/Schottky_400_V_10_um/tests
+++ b/test/tests/reflections/Schottky_400_V_10_um/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/reflections/base/Input.i
+++ b/test/tests/reflections/base/Input.i
@@ -10,22 +10,22 @@ vhigh = -175E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,10 +34,10 @@ vhigh = -175E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -54,22 +54,22 @@ vhigh = -175E-3 #kV
         steady_state_start_time = 1E-6
         dtmin = 1e-18
         dtmax = 0.1E-7
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.9
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -77,34 +77,34 @@ vhigh = -175E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e6
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -112,52 +112,52 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./em_log_stabilization]
+        []
+#       [em_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = em
 #               block = 0
-#       [../]
+#       []
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -165,177 +165,177 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./Arp_log_stabilization]
+        []
+#       [Arp_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = Arp
 #               block = 0
-#       [../]
+#       []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./mean_en_log_stabilization]
+        []
+#       [mean_en_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = mean_en
 #               block = 0
 #               offset = 15
-#       [../]
-#       [./mean_en_advection_stabilization]
+#       []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -344,8 +344,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -354,8 +354,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -363,8 +363,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -372,8 +372,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -381,65 +381,65 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -447,8 +447,8 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -456,27 +456,27 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -487,17 +487,17 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SecondaryElectronBC
                 variable = em
                 boundary = 'left'
@@ -506,9 +506,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_left]
+        [em_physical_left]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = 'left'
@@ -516,9 +516,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = right
@@ -526,43 +526,43 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -570,9 +570,9 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -580,53 +580,53 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -35
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -35
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -35
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -642,5 +642,5 @@ vhigh = -175E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/base/tests
+++ b/test/tests/reflections/base/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/reflections/high_initial/Input.i
+++ b/test/tests/reflections/high_initial/Input.i
@@ -10,22 +10,22 @@ vhigh = -175E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,10 +34,10 @@ vhigh = -175E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -56,22 +56,22 @@ vhigh = -175E-3 #kV
         dtmin = 1e-18
         dtmax = 0.1E-7
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.9
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -79,34 +79,34 @@ vhigh = -175E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e6
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -114,52 +114,52 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./em_log_stabilization]
+        []
+#       [em_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = em
 #               block = 0
-#       [../]
+#       []
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -167,177 +167,177 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./Arp_log_stabilization]
+        []
+#       [Arp_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = Arp
 #               block = 0
-#       [../]
+#       []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./mean_en_log_stabilization]
+        []
+#       [mean_en_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = mean_en
 #               block = 0
 #               offset = 15
-#       [../]
-#       [./mean_en_advection_stabilization]
+#       []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -346,8 +346,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -356,8 +356,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -365,8 +365,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -374,8 +374,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -383,65 +383,65 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -449,8 +449,8 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -458,27 +458,27 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -489,17 +489,17 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SecondaryElectronBC
                 variable = em
                 boundary = 'left'
@@ -508,9 +508,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_left]
+        [em_physical_left]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = 'left'
@@ -518,9 +518,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = right
@@ -528,43 +528,43 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -572,9 +572,9 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -582,53 +582,53 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -30
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -30
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -644,5 +644,5 @@ vhigh = -175E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/high_initial/tests
+++ b/test/tests/reflections/high_initial/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/reflections/low_initial/Input.i
+++ b/test/tests/reflections/low_initial/Input.i
@@ -10,22 +10,22 @@ vhigh = -175E-3 #kV
 []
 
 [Mesh]
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'Geometry.msh'
-  [../]
-  [./add_left]
+  []
+  [add_left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = file
-  [../]
-  [./add_right]
+  []
+  [add_right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = add_left
-  [../]
+  []
 []
 
 [Problem]
@@ -34,10 +34,10 @@ vhigh = -175E-3 #kV
 []
 
 [Preconditioning]
-        [./smp]
+        [smp]
                 type = SMP
                 full = true
-        [../]
+        []
 []
 
 [Executioner]
@@ -56,22 +56,22 @@ vhigh = -175E-3 #kV
         dtmin = 1e-18
         dtmax = 0.1E-7
         nl_max_its = 200
-        [./TimeStepper]
+        [TimeStepper]
                 type = IterationAdaptiveDT
                 cutback_factor = 0.9
                 dt = 1e-13
                 growth_factor = 1.2
                 optimal_iterations = 100
-        [../]
+        []
 []
 
 [Outputs]
         perf_graph = true
         print_linear_residuals = false
-        [./out]
+        [out]
                 type = Exodus
 #               execute_on = 'final'
-        [../]
+        []
 []
 
 [Debug]
@@ -79,34 +79,34 @@ vhigh = -175E-3 #kV
 []
 
 [UserObjects]
-        [./data_provider]
+        [data_provider]
                 type = ProvideMobility
                 electrode_area = 5.02e-7 # Formerly 3.14e-6
                 ballast_resist = 1e6
                 e = 1.6e-19
-        [../]
+        []
 []
 
 [Kernels]
-        [./em_time_deriv]
+        [em_time_deriv]
                 type = ElectronTimeDerivative
                 variable = em
                 block = 0
-        [../]
-        [./em_advection]
+        []
+        [em_advection]
                 type = EFieldAdvection
                 variable = em
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_diffusion]
+        []
+        [em_diffusion]
                 type = CoeffDiffusion
                 variable = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./em_ionization]
+        []
+        [em_ionization]
                 type = ElectronsFromIonization
     em = em
                 variable = em
@@ -114,52 +114,52 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./em_log_stabilization]
+        []
+#       [em_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = em
 #               block = 0
-#       [../]
+#       []
 
-        [./potential_diffusion_dom1]
+        [potential_diffusion_dom1]
                 type = CoeffDiffusionLin
                 variable = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_charge_source]
+        [Arp_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = Arp
                 block = 0
-        [../]
-        [./em_charge_source]
+        []
+        [em_charge_source]
                 type = ChargeSourceMoles_KV
                 variable = potential
                 charged = em
                 block = 0
-        [../]
+        []
 
-        [./Arp_time_deriv]
+        [Arp_time_deriv]
                 type = ElectronTimeDerivative
                 variable = Arp
                 block = 0
-        [../]
-        [./Arp_advection]
+        []
+        [Arp_advection]
                 type = EFieldAdvection
                 variable = Arp
                 potential = potential
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Arp_diffusion]
+        []
+        [Arp_diffusion]
                 type = CoeffDiffusion
                 variable = Arp
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_ionization]
+        []
+        [Arp_ionization]
                 type = IonsFromIonization
                 variable = Arp
                 potential = potential
@@ -167,177 +167,177 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./Arp_log_stabilization]
+        []
+#       [Arp_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = Arp
 #               block = 0
-#       [../]
+#       []
 
-        [./mean_en_time_deriv]
+        [mean_en_time_deriv]
                 type = ElectronTimeDerivative
                 variable = mean_en
                 block = 0
-        [../]
-        [./mean_en_advection]
+        []
+        [mean_en_advection]
                 type = EFieldAdvection
                 variable = mean_en
                 potential = potential
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_diffusion]
+        []
+        [mean_en_diffusion]
                 type = CoeffDiffusion
                 variable = mean_en
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_joule_heating]
+        []
+        [mean_en_joule_heating]
                 type = JouleHeating
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_ionization]
+        []
+        [mean_en_ionization]
                 type = ElectronEnergyLossFromIonization
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_elastic]
+        []
+        [mean_en_elastic]
                 type = ElectronEnergyLossFromElastic
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./mean_en_excitation]
+        []
+        [mean_en_excitation]
                 type = ElectronEnergyLossFromExcitation
                 variable = mean_en
                 potential = potential
                 em = em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-#       [./mean_en_log_stabilization]
+        []
+#       [mean_en_log_stabilization]
 #               type = LogStabilizationMoles
 #               variable = mean_en
 #               block = 0
 #               offset = 15
-#       [../]
-#       [./mean_en_advection_stabilization]
+#       []
+#       [mean_en_advection_stabilization]
 #               type = EFieldArtDiff
 #               variable = mean_en
 #               potential = potential
 #               block = 0
-#       [../]
+#       []
 []
 
 [Variables]
-        [./potential]
-        [../]
-        [./em]
+        [potential]
+        []
+        [em]
                 block = 0
-        [../]
-        [./Arp]
+        []
+        [Arp]
                 block = 0
-        [../]
-        [./mean_en]
+        []
+        [mean_en]
                 block = 0
-        [../]
+        []
 
 []
 
 [AuxVariables]
-        [./e_temp]
+        [e_temp]
                 block = 0
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x]
+        []
+        [x]
                 order = CONSTANT
                 family = MONOMIAL
-        [../]
-        [./x_node]
-        [../]
-        [./rho]
-                order = CONSTANT
-                family = MONOMIAL
-                block = 0
-        [../]
-        [./em_lin]
+        []
+        [x_node]
+        []
+        [rho]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [em_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Efield]
-                order = CONSTANT
-                family = MONOMIAL
-        [../]
-        [./Current_em]
+        []
+        [Arp_lin]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./Current_Arp]
+        []
+        [Efield]
+                order = CONSTANT
+                family = MONOMIAL
+        []
+        [Current_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [Current_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [tot_gas_current]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [EFieldAdvAux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_em]
+        []
+        [DiffusiveFlux_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_em]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [PowerDep_Arp]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_el]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_ex]
                 order = CONSTANT
                 family = MONOMIAL
                 block = 0
-        [../]
+        []
+        [ProcRate_iz]
+                order = CONSTANT
+                family = MONOMIAL
+                block = 0
+        []
 []
 
 [AuxKernels]
-        [./PowerDep_em]
+        [PowerDep_em]
                 type = ADPowerDep
                 density_log = em
                 potential = potential
@@ -346,8 +346,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_em
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./PowerDep_Arp]
+        []
+        [PowerDep_Arp]
                 type = ADPowerDep
                 density_log = Arp
                 potential = potential
@@ -356,8 +356,8 @@ vhigh = -175E-3 #kV
                 variable = PowerDep_Arp
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_el]
+        []
+        [ProcRate_el]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -365,8 +365,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_el
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_ex]
+        []
+        [ProcRate_ex]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -374,8 +374,8 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_ex
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./ProcRate_iz]
+        []
+        [ProcRate_iz]
                 type = ADProcRate
                 em = em
                 potential = potential
@@ -383,65 +383,65 @@ vhigh = -175E-3 #kV
                 variable = ProcRate_iz
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./e_temp]
+        []
+        [e_temp]
                 type = ElectronTemperature
                 variable = e_temp
                 electron_density = em
                 mean_en = mean_en
                 block = 0
-        [../]
-        [./x_g]
+        []
+        [x_g]
                 type = Position
                 variable = x
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./x_ng]
+        []
+        [x_ng]
                 type = Position
                 variable = x_node
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./rho]
+        []
+        [rho]
                 type = ParsedAux
                 variable = rho
                 args = 'em_lin Arp_lin'
                 function = 'Arp_lin - em_lin'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./tot_gas_current]
+        []
+        [tot_gas_current]
                 type = ParsedAux
                 variable = tot_gas_current
                 args = 'Current_em Current_Arp'
                 function = 'Current_em + Current_Arp'
                 execute_on = 'timestep_end'
                 block = 0
-        [../]
-        [./em_lin]
+        []
+        [em_lin]
                 type = Density
 #               convert_moles = true
                 variable = em_lin
                 density_log = em
                 block = 0
-        [../]
-        [./Arp_lin]
+        []
+        [Arp_lin]
                 type = Density
 #               convert_moles = true
                 variable = Arp_lin
                 density_log = Arp
                 block = 0
-        [../]
-        [./Efield_g]
+        []
+        [Efield_g]
                 type = Efield
                 component = 0
                 potential = potential
                 variable = Efield
                 position_units = ${dom0Scale}
                 block = 0
-        [../]
-        [./Current_em]
+        []
+        [Current_em]
                 type = ADCurrent
                 potential = potential
                 density_log = em
@@ -449,8 +449,8 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Current_Arp]
+        []
+        [Current_Arp]
                 type = ADCurrent
                 potential = potential
                 density_log = Arp
@@ -458,27 +458,27 @@ vhigh = -175E-3 #kV
                 art_diff = false
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./EFieldAdvAux_em]
+        []
+        [EFieldAdvAux_em]
                 type = ADEFieldAdvAux
                 potential = potential
                 density_log = em
                 variable = EFieldAdvAux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./DiffusiveFlux_em]
+        []
+        [DiffusiveFlux_em]
                 type = ADDiffusiveFlux
                 density_log = em
                 variable = DiffusiveFlux_em
                 block = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [BCs]
 ## Potential boundary conditions ##
-        [./potential_left]
+        [potential_left]
                 type = NeumannCircuitVoltageMoles_KV
                 variable = potential
                 boundary = left
@@ -489,17 +489,17 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./potential_dirichlet_right]
+        [potential_dirichlet_right]
                 type = DirichletBC
                 variable = potential
                 boundary = right
                 value = 0
-        [../]
+        []
 
 ## Electron boundary conditions ##
-        [./Emission_left]
+        [Emission_left]
                 type = SecondaryElectronBC
                 variable = em
                 boundary = 'left'
@@ -508,9 +508,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 1
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_left]
+        [em_physical_left]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = 'left'
@@ -518,9 +518,9 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./em_physical_right]
+        [em_physical_right]
                 type = HagelaarElectronBC
                 variable = em
                 boundary = right
@@ -528,43 +528,43 @@ vhigh = -175E-3 #kV
                 mean_en = mean_en
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Argon boundary conditions ##
-        [./Arp_physical_left_diffusion]
+        [Arp_physical_left_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = 'left'
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_left_advection]
+        []
+        [Arp_physical_left_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = 'left'
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./Arp_physical_right_diffusion]
+        [Arp_physical_right_diffusion]
                 type = HagelaarIonDiffusionBC
                 variable = Arp
                 boundary = right
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
-        [./Arp_physical_right_advection]
+        []
+        [Arp_physical_right_advection]
                 type = HagelaarIonAdvectionBC
                 variable = Arp
                 boundary = right
                 potential = potential
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
 ## Mean energy boundary conditions ##
-        [./mean_en_physical_left]
+        [mean_en_physical_left]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = 'left'
@@ -572,9 +572,9 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 
-        [./mean_en_physical_right]
+        [mean_en_physical_right]
                 type = HagelaarEnergyBC
                 variable = mean_en
                 boundary = right
@@ -582,53 +582,53 @@ vhigh = -175E-3 #kV
                 em = em
                 r = 0
                 position_units = ${dom0Scale}
-        [../]
+        []
 []
 
 [ICs]
-        [./potential_ic]
+        [potential_ic]
                 type = FunctionIC
                 variable = potential
                 function = potential_ic_func
-        [../]
+        []
 
-        [./em_ic]
+        [em_ic]
                 type = ConstantIC
                 variable = em
                 value = -36
                 block = 0
-        [../]
+        []
 
-        [./Arp_ic]
+        [Arp_ic]
                 type = ConstantIC
                 variable = Arp
                 value = -36
                 block = 0
-        [../]
+        []
 
-        [./mean_en_ic]
+        [mean_en_ic]
                 type = ConstantIC
                 variable = mean_en
                 value = -36
                 block = 0
-        [../]
+        []
 []
 
 [Functions]
-        [./potential_bc_func]
+        [potential_bc_func]
                 type = ParsedFunction
                 vars = 'VHigh'
                 vals = '${vhigh}'
                 value = 'VHigh'
-        [../]
-        [./potential_ic_func]
+        []
+        [potential_ic_func]
                 type = ParsedFunction
                 value = '-${vhigh} * (${dom0Size} - x) / ${dom0Size}'
-        [../]
+        []
 []
 
 [Materials]
-        [./gas_block]
+        [gas_block]
                 type = Gas
                 interp_trans_coeffs = true
                 interp_elastic_coeff = true
@@ -644,5 +644,5 @@ vhigh = -175E-3 #kV
                 user_cathode_temperature = 1273
                 property_tables_file = td_argon_mean_en.txt
                 block = 0
-        [../]
+        []
 []

--- a/test/tests/reflections/low_initial/tests
+++ b/test/tests/reflections/low_initial/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = 'Input.i'
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/surface_charge/dbd_test.i
+++ b/test/tests/surface_charge/dbd_test.i
@@ -35,38 +35,38 @@ dom1Scale=1e-4
   #
   # Block 0 = plasma region
   # Block 1 = dielectric
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'dbd_mesh.msh'
-  [../]
-  [./plasma_right]
+  []
+  [plasma_right]
     # plasma master
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'plasma_right'
     input = file
-  [../]
-  [./dielectric_left]
+  []
+  [dielectric_left]
     # left dielectric master
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'dielectric_left'
     input = plasma_right
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = dielectric_left
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -74,10 +74,10 @@ dom1Scale=1e-4
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -100,22 +100,22 @@ dom1Scale=1e-4
   dtmin = 1e-22
   dtmax = 1e-6
   #dt = 1e-8
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-9
     growth_factor = 1.2
    optimal_iterations = 30
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     output_material_properties = true
     show_material_properties = 'surface_charge'
-  [../]
+  []
 []
 
 [AuxVariables]
@@ -177,31 +177,31 @@ dom1Scale=1e-4
     execute_on = 'initial timestep_end'
     block = 1
   []
-  [./Efield_g]
+  [Efield_g]
     type = Efield
     component = 0
     potential = potential_dom0
     variable = Efield
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential_dom1
     variable = Efield
     position_units = ${dom1Scale}
     block = 1
-  [../]
+  []
 []
 
 [Variables]
-  [./potential_dom0]
+  [potential_dom0]
     block = 0
-  [../]
-  [./potential_dom1]
+  []
+  [potential_dom1]
     block = 1
-  [../]
+  []
 
   [neg]
     block = 0
@@ -218,128 +218,128 @@ dom1Scale=1e-4
 []
 
 [Kernels]
-  [./potential_diffusion_dom0]
+  [potential_diffusion_dom0]
     type = CoeffDiffusionLin
     variable = potential_dom0
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom1]
+  []
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential_dom1
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 
   # Potential source terms
-  #[./em_source]
+  #[em_source]
   #  type = ChargeSourceMoles_KV
   #  variable = potential_dom0
   #  charged = em
   #  block = 0
-  #[../]
-  #[./Arp_source]
+  #[]
+  #[Arp_source]
   #  type = ChargeSourceMoles_KV
   #  variable = potential_dom0
   #  charged = Arp
   #  block = 0
-  #[../]
+  #[]
   #
   # Electrons
-  #[./d_em_dt]
+  #[d_em_dt]
   #  type = TimeDerivativeLog
   #  variable = em
   #  block = 0
-  #[../]
-  [./neg_advection]
+  #[]
+  [neg_advection]
     type = EFieldAdvection
     variable = neg
     potential = potential_dom0
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./neg_diffusion]
+  []
+  [neg_diffusion]
     type = CoeffDiffusion
     variable = neg
     position_units = ${dom0Scale}
     block = 0
-  [../]
+  []
 
-  [./pos_advection]
+  [pos_advection]
     type = EFieldAdvection
     variable = pos
     potential = potential_dom0
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  [./pos_diffusion]
+  []
+  [pos_diffusion]
     type = CoeffDiffusion
     variable = pos
     position_units = ${dom0Scale}
     block = 0
-  [../]
-  #[./em_offset]
+  []
+  #[em_offset]
   #  type = LogStabilizationMoles
   #  variable = em
   #  block = 0
-  #[../]
+  #[]
   #
-  #[./d_mean_en_dt]
+  #[d_mean_en_dt]
   #  type = TimeDerivativeLog
   #  variable = mean_en
   #  block = 0
-  #[../]
-  #[./mean_en_advection]
+  #[]
+  #[mean_en_advection]
   #  type = ADEFieldAdvection
   #  em = em
   #  variable = mean_en
   #  potential = potential_dom0
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./mean_en_diffusion]
+  #[]
+  #[mean_en_diffusion]
   #  type = ADCoeffDiffusion
   #  variable = mean_en
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./mean_en_joule_heating]
+  #[]
+  #[mean_en_joule_heating]
   #  type = ADJouleHeating
   #  variable = mean_en
   #  em = em
   #  potential = potential_dom0
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./mean_en_offset]
+  #[]
+  #[mean_en_offset]
   #  type = LogStabilizationMoles
   #  variable = mean_en
   #  block = 0
-  #[../]
+  #[]
   #
-  #[./d_Arp_dt]
+  #[d_Arp_dt]
   #  type = TimeDerivativeLog
   #  variable = Arp
   #  block = 0
-  #[../]
-  #[./Arp_advection]
+  #[]
+  #[Arp_advection]
   #  type = ADEFieldAdvection
   #  variable = Arp
   #  potential = potential_dom0
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./Arp_diffusion]
+  #[]
+  #[Arp_diffusion]
   #  type = ADCoeffDiffusion
   #  variable = Arp
   #  position_units = ${dom0Scale}
   #  block = 0
-  #[../]
-  #[./Arp_offset]
+  #[]
+  #[Arp_offset]
   #  type = LogStabilizationMoles
   #  variable = Arp
   #  block = 0
-  #[../]
+  #[]
 []
 
 [InterfaceKernels]
@@ -365,29 +365,29 @@ dom1Scale=1e-4
 
 [BCs]
   # Interface BCs:
-  [./match_potential]
+  [match_potential]
     type = MatchedValueBC
     variable = potential_dom1
     v = potential_dom0
     boundary = 'dielectric_left'
-  [../]
+  []
 
   # Electrode and ground BCs:
   # Electrode is at x = 0, named 'left'
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential_dom0
     function = potential_input
     boundary = 'left'
-  [../]
+  []
 
   # Ground is at x = 0.3 mm, named 'right'
-  [./potential_dirichlet_right]
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential_dom1
     boundary = right
     value = 0
-  [../]
+  []
 
   # Both charged species will have a specified dirichlet BC on the driven electrode
   # and a diffusion BC on the right side.
@@ -424,29 +424,29 @@ dom1Scale=1e-4
 []
 
 [ICs]
-  [./potential_dom0_ic]
+  [potential_dom0_ic]
     type = FunctionIC
     variable = potential_dom0
     function = potential_ic_func
-  [../]
-  [./potential_dom1_ic]
+  []
+  [potential_dom1_ic]
     type = FunctionIC
     variable = potential_dom1
     function = potential_ic_func
-  [../]
+  []
 
-  [./neg_ic]
+  [neg_ic]
     type = ConstantIC
     variable = neg
     value = -10
     block = 0
-  [../]
-  [./pos_ic]
+  []
+  [pos_ic]
     type = ConstantIC
     variable = pos
     value = -10
     block = 0
-  [../]
+  []
 []
 
 [Functions]
@@ -455,20 +455,20 @@ dom1Scale=1e-4
   # (Note that here the amplitude is set to 0.2. Potential units are
   # typically included as kV, not V. This option is set in the
   # GlobalParams block.)
-  [./potential_input]
+  [potential_input]
     type = ParsedFunction
     vars = 'f0'
     vals = '50e3'
     value = '-0.2*sin(2*3.1415926*f0*t)'
-  [../]
+  []
 
   # Set the initial condition to a line from -10 V on the left and
   # 0 on the right.
   # (Poisson solver tends to struggle with a uniformly zero potential IC.)
-  [./potential_ic_func]
+  [potential_ic_func]
     type = ParsedFunction
     value = '-0.001 * (2.000e-4 - x)'
-  [../]
+  []
 []
 
 [Materials]
@@ -486,26 +486,26 @@ dom1Scale=1e-4
   []
 
   # This just defines some constants that Zapdos needs to run.
-  [./gas_constants]
+  [gas_constants]
     type = GenericConstantMaterial
     block = 0
     prop_names = ' e       N_A      k_boltz  eps         se_energy T_gas  massem   p_gas'
     prop_values = '1.6e-19 6.022e23 1.38e-23 8.854e-12   1.        400    9.11e-31 1.01e5'
-  [../]
+  []
 
   #
-  [./dielectric_left_side]
+  [dielectric_left_side]
     type = ADGenericConstantMaterial
     prop_names = 'diffpotential_dom0'
     prop_values = '8.85e-12'
     block = 0
-  [../]
-  [./gas_phase]
+  []
+  [gas_phase]
     type = ADGenericConstantMaterial
     prop_names = 'diffpotential_dom1'
     prop_values = '8.85e-12'
     block = 1
-  [../]
+  []
 
   ######
   # HeavySpeciesMaterial defines charge, mass, transport coefficients, and
@@ -516,20 +516,20 @@ dom1Scale=1e-4
   # implementations may include mixture-averaged diffusion coefficients and
   # effective ion temperatures with nonlinear dependence on other variables.
   ######
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = neg
     heavy_species_mass = 6.64e-26
     heavy_species_charge = -1.0
     diffusivity = 1.6897e-5
     block = 0
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = pos
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     diffusivity = 1.6897e-5
     block = 0
-  [../]
+  []
 []

--- a/test/tests/surface_charge/interface_test.i
+++ b/test/tests/surface_charge/interface_test.i
@@ -17,38 +17,38 @@ dom1Scale=1e-4
   # Block 0 = left dielectric
   # Block 1 = plasma region
   # Block 2 = right dielectric
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'interface_mesh.msh'
-  [../]
-  [./plasma_right]
+  []
+  [plasma_right]
     # plasma master
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '0'
     paired_block = '1'
     new_boundary = 'plasma_right'
     input = file
-  [../]
-  [./dielectric_left]
+  []
+  [dielectric_left]
     # left dielectric master
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1'
     paired_block = '0'
     new_boundary = 'dielectric_left'
     input = plasma_right
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = dielectric_left
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -56,10 +56,10 @@ dom1Scale=1e-4
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -71,33 +71,33 @@ dom1Scale=1e-4
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []
 
 [Variables]
-  [./potential_dom0]
+  [potential_dom0]
     block = 0
-  [../]
-  [./potential_dom1]
+  []
+  [potential_dom1]
     block = 1
-  [../]
+  []
 []
 
 [Kernels]
-  [./potential_diffusion_dom0]
+  [potential_diffusion_dom0]
     type = CoeffDiffusionLin
     variable = potential_dom0
     block = 0
     position_units = ${dom0Scale}
-  [../]
-  [./potential_diffusion_dom1]
+  []
+  [potential_diffusion_dom1]
     type = CoeffDiffusionLin
     variable = potential_dom1
     block = 1
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [InterfaceKernels]
@@ -107,55 +107,55 @@ dom1Scale=1e-4
   # The potential requires two different boundary conditions on each side:
   #    (1) An InterfaceKernel to provide the Neumann boundary condition
   #    (2) A MatchedValueBC to ensure that the potential remains continuous
-  [./potential_left]
+  [potential_left]
     type = PotentialSurfaceCharge
     neighbor_var = potential_dom1
     variable = potential_dom0
     position_units = ${dom0Scale}
     neighbor_position_units = ${dom1Scale}
     boundary = plasma_right
-  [../]
+  []
 
 []
 
 [BCs]
   # Interface BCs:
-  [./match_potential]
+  [match_potential]
     type = MatchedValueBC
     variable = potential_dom1
     v = potential_dom0
     boundary = 'dielectric_left'
-  [../]
+  []
 
   # Electrode and ground BCs:
   # Electrode is at x = 0, named 'left'
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential_dom0
     function = potential_input
     boundary = 'left'
-  [../]
+  []
 
   # Ground is at x = 0.3 mm, named 'right'
-  [./potential_dirichlet_right]
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential_dom1
     boundary = right
     value = 0
-  [../]
+  []
 []
 
 [ICs]
-  [./potential_dom0_ic]
+  [potential_dom0_ic]
     type = FunctionIC
     variable = potential_dom0
     function = potential_ic_func
-  [../]
-  [./potential_dom1_ic]
+  []
+  [potential_dom1_ic]
     type = FunctionIC
     variable = potential_dom1
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
@@ -164,21 +164,21 @@ dom1Scale=1e-4
   # (Note that here the amplitude is set to 0.75. Potential units are
   # typically included as kV, not V. This option is set in the
   # GlobalParams block.)
-  [./potential_input]
+  [potential_input]
     type = ParsedFunction
     vars = 'f0'
     vals = '50e3'
     #value = '-0.75*sin(2*3.1415926*f0*t)'
     value = '-0.75'
-  [../]
+  []
 
   # Set the initial condition to a line from -10 V on the left and
   # 0 on the right.
   # (Poisson solver tends to struggle with a uniformly zero potential IC.)
-  [./potential_ic_func]
+  [potential_ic_func]
     type = ParsedFunction
     value = '-0.75 * (2.0001e-4 - x)'
-  [../]
+  []
 []
 
 [Materials]
@@ -186,19 +186,19 @@ dom1Scale=1e-4
   # Define secondary electron emission coefficients on the left and right
   # dielectrics.
   #########
-  [./se_left]
+  [se_left]
     type = GenericConstantMaterial
     boundary = 'plasma_right'
     prop_names = 'se_coeff'
     prop_values = '0.01'
-  [../]
+  []
 
-  [./gas_constants]
+  [gas_constants]
     type = GenericConstantMaterial
     block = 1
     prop_names = ' e       N_A      k_boltz  eps         se_energy T_gas  massem   p_gas'
     prop_values = '1.6e-19 6.022e23 1.38e-23 8.854e-12   1.        400    9.11e-31 1.01e5'
-  [../]
+  []
 
 
   # Create a constant surface charge on the boundary named 'plasma_side'
@@ -209,16 +209,16 @@ dom1Scale=1e-4
     prop_values = '-1e-6'
   []
 
-  [./dielectric_left_side]
+  [dielectric_left_side]
     type = ADGenericConstantMaterial
     prop_names = 'diffpotential_dom0'
     prop_values = '8.85e-12'
     block = 0
-  [../]
-  [./gas_phase]
+  []
+  [gas_phase]
     type = ADGenericConstantMaterial
     prop_names = 'diffpotential_dom1'
     prop_values = '8.85e-11'
     block = 1
-  [../]
+  []
 []

--- a/test/tests/thesis_example/tests
+++ b/test/tests/thesis_example/tests
@@ -1,7 +1,7 @@
 [Tests]
-  [./test]
+  [test]
     type = Exodiff
     input = 'thesis_example.i'
     exodiff = 'thesis_example_out.e'
-  [../]
+  []
 []

--- a/test/tests/thesis_example/thesis_example.i
+++ b/test/tests/thesis_example/thesis_example.i
@@ -15,10 +15,10 @@
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -32,38 +32,38 @@
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []
 
 [Variables]
-  [./coffee_creamer]
-  [../]
+  [coffee_creamer]
+  []
 []
 
 [Kernels]
-  [./time]
+  [time]
     type = TimeDerivative
     variable = coffee_creamer
-  [../]
-  [./diffusion]
+  []
+  [diffusion]
     type = Diffusion
     variable = coffee_creamer
-  [../]
+  []
 []
 
 [ICs]
-  [./func_ic]
+  [func_ic]
     type = FunctionIC
     variable = coffee_creamer
     function = gauss
-  [../]
+  []
 []
 
 [Functions]
-  [./gauss]
+  [gauss]
     type = ParsedFunction
     value = 'exp(-x^2 / 0.2^2) * exp(-y^2 / 0.2^2)'
-  [../]
+  []
 []

--- a/test/tests/water_only/tests
+++ b/test/tests/water_only/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./test]
+  [test]
     type = RunApp
     input = water_only.i
     check_input = True
     method = opt
-  [../]
+  []
 []

--- a/test/tests/water_only/water_only.i
+++ b/test/tests/water_only/water_only.i
@@ -17,10 +17,10 @@ dom1Scale=1e-7
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -35,20 +35,20 @@ dom1Scale=1e-7
   dtmin = 1e-12
   l_max_its = 20
   nl_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
     optimal_iterations = 15
-  [../]
+  []
 []
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []
 
 [Debug]
@@ -56,259 +56,259 @@ dom1Scale=1e-7
 []
 
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [Kernels]
-  [./emliq_time_deriv]
+  [emliq_time_deriv]
     type = ElectronTimeDerivative
     variable = emliq
-  [../]
-  [./emliq_advection]
+  []
+  [emliq_advection]
     type = EFieldAdvection
     variable = emliq
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_diffusion]
+  []
+  [emliq_diffusion]
     type = CoeffDiffusion
     variable = emliq
     position_units = ${dom1Scale}
-  [../]
-  [./emliq_reactant_first_order_rxn]
+  []
+  [emliq_reactant_first_order_rxn]
     type = ReactantFirstOrderRxn
     variable = emliq
-  [../]
-  [./emliq_water_bi_sink]
+  []
+  [emliq_water_bi_sink]
     type = ReactantAARxn
     variable = emliq
-  [../]
+  []
 
-  [./potential_diffusion]
+  [potential_diffusion]
     type = CoeffDiffusionLin
     variable = potential
     position_units = ${dom1Scale}
-  [../]
-  # [./emliq_charge_source]
+  []
+  # [emliq_charge_source]
   #   type = ChargeSourceMoles_KV
   #   variable = potential
   #   charged = emliq
-  # [../]
-  # [./OHm_charge_source]
+  # []
+  # [OHm_charge_source]
   #   type = ChargeSourceMoles_KV
   #   variable = potential
   #   charged = OHm
-  # [../]
+  # []
 
-  [./OHm_time_deriv]
+  [OHm_time_deriv]
     type = ElectronTimeDerivative
     variable = OHm
-  [../]
-  [./OHm_advection]
+  []
+  [OHm_advection]
     type = EFieldAdvection
     variable = OHm
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_diffusion]
+  []
+  [OHm_diffusion]
     type = CoeffDiffusion
     variable = OHm
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_product_first_order_rxn]
+  []
+  [OHm_product_first_order_rxn]
     type = ProductFirstOrderRxn
     variable = OHm
     v = emliq
-  [../]
-  [./OHm_product_aabb_rxn]
+  []
+  [OHm_product_aabb_rxn]
     type = ProductAABBRxn
     variable = OHm
     v = emliq
-  [../]
+  []
 []
 
 [Variables]
-  [./potential]
-  [../]
-  [./emliq]
-  [../]
-  [./OHm]
-  [../]
+  [potential]
+  []
+  [emliq]
+  []
+  [OHm]
+  []
 []
 
 [AuxVariables]
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./x_node]
-  [../]
-  [./emliq_lin]
+  []
+  [x_node]
+  []
+  [emliq_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Efield]
+  []
+  [Efield]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./x_l]
+  [x_l]
     type = Position
     variable = x
     position_units = ${dom1Scale}
-  [../]
-  [./x_nl]
+  []
+  [x_nl]
     type = Position
     variable = x_node
     position_units = ${dom1Scale}
-  [../]
-  [./tot_liq_current]
+  []
+  [tot_liq_current]
     type = ParsedAux
     variable = tot_liq_current
     args = 'Current_emliq Current_OHm'
     function = 'Current_emliq + Current_OHm'
     execute_on = 'timestep_end'
-  [../]
-  [./emliq_lin]
+  []
+  [emliq_lin]
     type = DensityMoles
     variable = emliq_lin
     density_log = emliq
-  [../]
-  [./OHm_lin]
+  []
+  [OHm_lin]
     type = DensityMoles
     variable = OHm_lin
     density_log = OHm
-  [../]
-  [./Efield_l]
+  []
+  [Efield_l]
     type = Efield
     component = 0
     potential = potential
     variable = Efield
     position_units = ${dom1Scale}
-  [../]
-  [./Current_emliq]
+  []
+  [Current_emliq]
     type = ADCurrent
     potential = potential
     density_log = emliq
     variable = Current_emliq
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./Current_OHm]
+  []
+  [Current_OHm]
     type = ADCurrent
     potential = potential
     density_log = OHm
     variable = Current_OHm
     art_diff = false
     position_units = ${dom1Scale}
-  [../]
-  [./tot_flux_OHm]
+  []
+  [tot_flux_OHm]
     type = ADTotalFlux
     potential = potential
     density_log = OHm
     variable = tot_flux_OHm
-  [../]
-  [./EFieldAdvAux_emliq]
+  []
+  [EFieldAdvAux_emliq]
     type = ADEFieldAdvAux
     potential = potential
     density_log = emliq
     variable = EFieldAdvAux_emliq
     position_units = ${dom1Scale}
-  [../]
-  [./DiffusiveFlux_emliq]
+  []
+  [DiffusiveFlux_emliq]
     type = ADDiffusiveFlux
     density_log = emliq
     variable = DiffusiveFlux_emliq
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [BCs]
-  [./potential_left]
+  [potential_left]
     type = DirichletBC
     value = -6.5e-5
     variable = potential
     boundary = left
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
-  [./emliq_left]
+  []
+  [emliq_left]
     type = NeumannBC
     value = 300
     variable = emliq
     boundary = left
-  [../]
-  [./emliq_right]
+  []
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = right
     potential = potential
     position_units = ${dom1Scale}
-  [../]
-  [./OHm_physical]
+  []
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 [ICs]
-  [./emliq_ic]
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
-  [../]
+  []
 []
 
 [Materials]
- [./water_block]
+ [water_block]
    type = Water
    potential = potential
- [../]
+ []
 []

--- a/tutorial/tutorial01-Diffusion/diffusion-only.i
+++ b/tutorial/tutorial01-Diffusion/diffusion-only.i
@@ -17,27 +17,27 @@ dom0Scale=1.0
 
 [Mesh]
   #Sets up a 1D mesh from 0 to 0.5m with 1000 element
-  [./geo]
+  [geo]
     type = GeneratedMeshGenerator
     xmin = 0
     xmax = 0.5
     nx = 1000
     dim = 1
-  [../]
+  []
   #Renames all sides with the specified normal
   #For 1D, this is used to rename the end points of the mesh
-  [./left]
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0' #Outward facing normal
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right' #Outward facing normal
     input = left
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -50,20 +50,20 @@ dom0Scale=1.0
 # such as family of shape function and variable order
 # (the default family/order is Lagrange/First)
 [Variables]
-  [./Ar+]
-  [../]
+  [Ar+]
+  []
 []
 
 [Kernels]
   #Adds the diffusion for the variable
-  [./Ar+_diffusion]
+  [Ar+_diffusion]
     type = CoeffDiffusion
     variable = Ar+
     position_units = ${dom0Scale}
-  [../]
+  []
   #Adds the source term for the variable.
   #In this case, adds a first order reaction of k*Ar+
-  [./Ar+_source]
+  [Ar+_source]
     type = ReactionFirstOrderLog
     variable = Ar+
     # v is a constant density of 1e16 #/m^3 in mole-log form
@@ -72,78 +72,78 @@ dom0Scale=1.0
     _v_eq_u = false
     coefficient = 1
     reaction = FirstOrder
-  [../]
+  []
 []
 
 #User defined name for the auxvariables.
 #Other variable properties are defined here,
 # such as family of shape function and variable order
 [AuxVariables]
-  [./x]
+  [x]
     #Monomial is a family set for elemental variables
     #(variable that are solve for the elements vs the nodes)
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
   #The auxvariable used to converts the mole-log form of the density to #/m^3
-  [./Ar+_density]
+  [Ar+_density]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
   #The auxvariable for the known solution for this diffusion problem
-  [./Solution]
-  [../]
+  [Solution]
+  []
 []
 
 [AuxKernels]
   #Add a scaled position units used for plotting other element AuxVariables
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
   #Converts the mole-log form of the density to #/m^3
-  [./Ar+_density]
+  [Ar+_density]
     type = DensityMoles
     variable = Ar+_density
     density_log = Ar+
     execute_on = 'LINEAR TIMESTEP_END'
-  [../]
+  []
   #The know solution for this diffusion problem
-  [./Solution]
+  [Solution]
     type = FunctionAux
     variable = Solution
     function = '1e16 * 9.8696 / 8. * (1 - (2*x)^2.)'
-  [../]
+  []
 []
 
 #Initial conditions for variables.
 #If left undefine, the IC is zero
 [ICs]
-  [./Ar+_ic]
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = 'log(1e16/6.022e23)'
-  [../]
+  []
 []
 
 [BCs]
 #Dirichlet boundary conditions for mole-log density
 #Value is in #/m^3
-  [./Ar+_physical_right_diffusion]
+  [Ar+_physical_right_diffusion]
     type = LogDensityDirichletBC
     variable = Ar+
     boundary = 'right'
     value = 100
-  [../]
+  []
 []
 
 [Materials]
   #The material properties for electrons.
   #Also hold universal constant, such as Avogadro's number, elementary charge, etc.
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -151,38 +151,38 @@ dom0Scale=1.0
     user_p_gas = 133.3322
     user_electron_diffusion_coeff = 1.0
     property_tables_file = rate_coefficients/electron_moments.txt
-  [../]
+  []
   #The material properties of the ion
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     diffusivity = 1
     #diffusivity = 2
-  [../]
+  []
   #The rate constant for the first order reaction of the source term
-  [./FirstOrder_Reaction]
+  [FirstOrder_Reaction]
     type = GenericRateConstant
     reaction = FirstOrder
     reaction_rate_value = 9.8696
     #reaction_rate_value = 4.9348
-  [../]
+  []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -203,7 +203,7 @@ dom0Scale=1.0
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial01-Diffusion/tests
+++ b/tutorial/tutorial01-Diffusion/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial01-Diffusion_syntax]
+  [tutorial01-Diffusion_syntax]
     type = RunApp
     input = 'diffusion-only.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []

--- a/tutorial/tutorial02-ReactionNetwork/tests
+++ b/tutorial/tutorial02-ReactionNetwork/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial02-ReactionNetwork_syntax]
+  [tutorial02-ReactionNetwork_syntax]
     type = RunApp
     input = 'transient-kinetics.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []

--- a/tutorial/tutorial02-ReactionNetwork/transient-kinetics.i
+++ b/tutorial/tutorial02-ReactionNetwork/transient-kinetics.i
@@ -3,11 +3,11 @@
 
 [Mesh]
   #Sets up a 0D mesh with 1 element
-  [./geo]
+  [geo]
     type = GeneratedMeshGenerator
     nx = 1
     dim = 1
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -20,33 +20,33 @@
 # such as family of shape function and variable order
 # (the default family/order is Lagrange/First)
 [Variables]
-  [./nA]
-  [../]
-  [./nB]
-  [../]
-  [./nC]
-  [../]
+  [nA]
+  []
+  [nB]
+  []
+  [nC]
+  []
 []
 
 [Kernels]
   #Adds the time derivative for the variables
-  [./nA_time_derv]
+  [nA_time_derv]
     type = TimeDerivative
     variable = nA
-  [../]
-  [./nB_time_derv]
+  []
+  [nB_time_derv]
     type = TimeDerivative
     variable = nB
-  [../]
-  [./nC_time_derv]
+  []
+  [nC_time_derv]
     type = TimeDerivative
     variable = nC
-  [../]
+  []
 []
 
 #CRANE's Reactions Action that inputs the reactions as source terms for the variables
 [Reactions]
-  [./Gas]
+  [Gas]
     #Name of each variable on the reactant side
     species = 'nA nB nC'
     #Define type of coefficient (rate or townsend)
@@ -61,7 +61,7 @@
     #Define reactions and coefficients
     reactions = 'nA -> nB  : 1
                  nB -> nC  : 5'
-  [../]
+  []
 []
 
 #User defined name for the auxvariables.
@@ -69,56 +69,56 @@
 # such as family of shape function and variable order
 [AuxVariables]
   #The auxvariable for the known solution for this diffusion problem
-  [./Solution_nA]
-  [../]
-  [./Solution_nB]
-  [../]
-  [./Solution_nC]
-  [../]
+  [Solution_nA]
+  []
+  [Solution_nB]
+  []
+  [Solution_nC]
+  []
 []
 
 [AuxKernels]
   #The know solution for this diffusion problem
-  [./Solution_nA]
+  [Solution_nA]
     type = FunctionAux
     variable = Solution_nA
     function = '1.0 * exp(-1.0*t)'
-  [../]
-  [./Solution_nB]
+  []
+  [Solution_nB]
     type = FunctionAux
     variable = Solution_nB
     function = '1.0 * 1.0 / (5. - 1.) * (exp(-1.0*t) - exp(-5.0*t))'
-  [../]
-  [./Solution_nC]
+  []
+  [Solution_nC]
     type = FunctionAux
     variable = Solution_nC
     function = '1.0 * (1.0 + 1.0 / (1. - 5.) * (5.*exp(-1.0*t) - 1.*exp(-5.0*t)))'
-  [../]
+  []
 []
 
 #Initial conditions for variables.
 #If left undefine, the IC is zero
 [ICs]
-  [./nA_ic]
+  [nA_ic]
     type = FunctionIC
     variable = nA
     function = '1.0'
-  [../]
+  []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -143,7 +143,7 @@
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial03-PotentialWithIonLoss/ion-loss-for-IonOnlyPlasma.i
+++ b/tutorial/tutorial03-PotentialWithIonLoss/ion-loss-for-IonOnlyPlasma.i
@@ -16,27 +16,27 @@ dom0Scale=1.0
 
 [Mesh]
   #Sets up a 1D mesh from 0 to 10cm with 100 points
-  [./geo]
+  [geo]
     type = GeneratedMeshGenerator
     xmin = 0
     xmax = 0.10
     nx = 100
     dim = 1
-  [../]
+  []
   #Renames all sides with the specified normal
   #For 1D, this is used to rename the end points of the mesh
-  [./left]
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -47,7 +47,7 @@ dom0Scale=1.0
 #Zapdos's Drift-Diffusion Action that inputs the continuity equations for
 # species and electon mean energy, and poisson's equation for potential
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     #User define name for ions
     charged_particle = Ar+
     #User define name for potential (usually 'potential')
@@ -56,74 +56,74 @@ dom0Scale=1.0
     Is_potential_unique = true
     #The position scaling for the mesh, define at top of input file
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [AuxVariables]
   #Add a scaled position units used for plotting other Variables
-  [./x_node]
-  [../]
+  [x_node]
+  []
 []
 
 [AuxKernels]
   #Add at scaled position units used for plotting other Variables
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = DirichletBC
     variable = potential
     boundary = 'left right'
     value = 0
     preset = false
-  [../]
+  []
 
   #Boundary conditions for ions
-  [./Arp_physical_left_diffusion]
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Ar+
     boundary = 'right left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Ar+
     boundary = 'right left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 
 #Initial conditions for variables.
 #If left undefine, the IC is zero
 [ICs]
-  [./Ar+_ic]
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = 'log(1e16/6.022e23)'
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = '0.5 * (1e16 * 1.6e-19) / 8.85e-12 * ((0.10/2)^2. - (x-0.10/2)^2.)'
-  [../]
+  []
 []
 
 [Materials]
   #The material properties for electrons.
   #Also hold universal constant, such as Avogadro's number, elementary charge, etc.
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -132,29 +132,29 @@ dom0Scale=1.0
     #user_p_gas = 1.33322
     potential = potential
     property_tables_file = rate_coefficients/electron_moments.txt
-  [../]
+  []
   #The material properties of the ion
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
-  [../]
+  []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -175,7 +175,7 @@ dom0Scale=1.0
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial03-PotentialWithIonLoss/tests
+++ b/tutorial/tutorial03-PotentialWithIonLoss/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial03-PotentialWithIonLoss_syntax]
+  [tutorial03-PotentialWithIonLoss_syntax]
     type = RunApp
     input = 'ion-loss-for-IonOnlyPlasma.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []

--- a/tutorial/tutorial04-PressureVsTe/RF_Plasma_WithOut_Metastables-1Torr.i
+++ b/tutorial/tutorial04-PressureVsTe/RF_Plasma_WithOut_Metastables-1Torr.i
@@ -18,25 +18,25 @@ dom0Scale=1.0
 
 [Mesh]
   #Mesh is define by a previous output file
-  [./geo]
+  [geo]
     type = FileMeshGenerator
     file = 'RF_Plasma_WithOut_Metastables_IC.e'
     use_for_exodus_restart = true
-  [../]
+  []
   #Renames all sides with the specified normal
   #For 1D, this is used to rename the end points of the mesh
-  [./left]
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -47,23 +47,23 @@ dom0Scale=1.0
 #Defining IC from previous output file
 # (The ICs block is not used in this case)
 [Variables]
-  [./em]
+  [em]
     initial_from_file_var = em
-  [../]
-  [./potential]
+  []
+  [potential]
     initial_from_file_var = potential
-  [../]
-  [./Ar+]
+  []
+  [Ar+]
     initial_from_file_var = Ar+
-  [../]
-  [./mean_en]
+  []
+  [mean_en]
     initial_from_file_var = mean_en
-  [../]
+  []
 []
 
 
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     #User define name for electrons (usually 'em')
     electrons = em
     #User define name for ions
@@ -78,11 +78,11 @@ dom0Scale=1.0
     position_units = ${dom0Scale}
     #Additional outputs, such as ElectronTemperature, Current, and EField.
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
+  []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     #Name of reactant species that are variables
     species = 'em Ar+'
     #Name of reactant species that are auxvariables
@@ -114,44 +114,44 @@ dom0Scale=1.0
     #     em + Ar -> em + Ar*        : EEDF [-11.56] (reaction1)
     reactions = 'em + Ar -> em + Ar*        : EEDF [-11.56] (reaction1)
                  em + Ar -> em + em + Ar+   : EEDF [-15.7] (reaction2)'
-  [../]
+  []
 []
 
 [AuxVariables]
   #Add a scaled position units used for plotting other element AuxVariables
-  [./x]
+  [x]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
   #Background gas (e.g Ar)
-  [./Ar]
-  [../]
+  [Ar]
+  []
 []
 
 [AuxKernels]
   #Add at scaled position units used for plotting other element AuxVariables
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Background gas number density (e.g. for 1Torr)
-  [./Ar_val]
+  [Ar_val]
     type = FunctionAux
     variable = Ar
     function = 'log(3.22e22/6.022e23)'
     execute_on = INITIAL
-  [../]
+  []
 []
 
 #Define function used throughout the input file (e.g. BCs)
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
+  []
 []
 
 #Currently there is no Action for BC (but one is currently in development)
@@ -159,30 +159,30 @@ dom0Scale=1.0
 #(For other BC example, please look at Tutorial 05 and Tutorial 06)
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-[./em_physical_diffusion]
+[em_physical_diffusion]
   type = SakiyamaElectronDiffusionBC
   variable = em
   mean_en = mean_en
   boundary = 'left right'
   position_units = ${dom0Scale}
-[../]
-[./em_Ar+_second_emissions]
+[]
+[em_Ar+_second_emissions]
   type = SakiyamaSecondaryElectronBC
   variable = em
   potential = potential
@@ -190,27 +190,27 @@ dom0Scale=1.0
   users_gamma = 0.01
   boundary = 'left right'
   position_units = ${dom0Scale}
-[../]
+[]
 
 #Boundary conditions for ions
-  [./Ar+_physical_advection]
+  [Ar+_physical_advection]
     type = SakiyamaIonAdvectionBC
     variable = Ar+
     potential = potential
     boundary = 'left right'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 
 #New Boundary conditions for mean energy, should be the same as in paper
-  [./mean_en_physical_diffusion]
+  [mean_en_physical_diffusion]
     type = SakiyamaEnergyDiffusionBC
     variable = mean_en
     em = em
     boundary = 'left right'
     position_units = ${dom0Scale}
-  [../]
-  [./mean_en_Ar+_second_emissions]
+  []
+  [mean_en_Ar+_second_emissions]
     type = SakiyamaEnergySecondaryElectronBC
     variable = mean_en
     em = em
@@ -221,13 +221,13 @@ dom0Scale=1.0
     se_coeff = 0.01
     boundary = 'left right'
     position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 [Materials]
   #The material properties for electrons.
   #Also hold universal constant, such as Avogadro's number, elementary charge, etc.
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     #True means variable electron coeff, defined by user
     interp_trans_coeffs = true
@@ -249,43 +249,43 @@ dom0Scale=1.0
     property_tables_file = rate_coefficients/electron_moments.txt
   []
   #The material properties of the ion
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
+  []
   #The material properties of the background gas
-  [./gas_species_2]
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./ElectronTemp_Average]
+  [ElectronTemp_Average]
     type = ElementAverageValue
     variable = e_temp
-  [../]
+  []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -311,7 +311,7 @@ dom0Scale=1.0
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial04-PressureVsTe/tests
+++ b/tutorial/tutorial04-PressureVsTe/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial04-PressureVsTe_syntax]
+  [tutorial04-PressureVsTe_syntax]
     type = RunApp
     input = 'RF_Plasma_WithOut_Metastables-1Torr.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []

--- a/tutorial/tutorial05-PlasmaWaterInterface/DC_argon-With-Water.i
+++ b/tutorial/tutorial05-PlasmaWaterInterface/DC_argon-With-Water.i
@@ -18,12 +18,12 @@ dom1Scale=1e-7
 
 [Mesh]
   #Mesh is define by a Gmsh file
-  [./file]
+  [file]
     type = FileMeshGenerator
     file = 'plasmaliquid.msh'
-  [../]
+  []
 
-  [./interface]
+  [interface]
     # interface allows for one directional fluxes
     # interface going from air to water
     type = SideSetsBetweenSubdomainsGenerator
@@ -31,29 +31,29 @@ dom1Scale=1e-7
     paired_block = '1' # block where the flux is going to
     new_boundary = 'master0_interface'
     input = file # first input is where the msh is coming and it is then named air_to_water
-  [../]
-  [./interface_again]
+  []
+  [interface_again]
     # interface going from water to air
     type = SideSetsBetweenSubdomainsGenerator
     primary_block = '1' # block where the flux is coming from
     paired_block = '0' # block where the flux is going to
     new_boundary = 'master1_interface'
     input = interface
-  [../]
+  []
   #Renames all sides with the specified normal
   #For 1D, this is used to rename the end points of the mesh
-  [./left]
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = interface_again
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -65,12 +65,12 @@ dom1Scale=1e-7
 #since it is present in both Blocks
 #Declare any variable that is present in mulitple blocks in the variables section
 [Variables]
-    [./potential]
-    [../]
+    [potential]
+    []
 []
 
 [DriftDiffusionAction]
-    [./Plasma]
+    [Plasma]
       #User define name for electrons (usually 'em')
       electrons = em
       #User define name for ions
@@ -89,9 +89,9 @@ dom1Scale=1e-7
       block = 0
       #Additional outputs, such as ElectronTemperature, Current, and EField.
       Additional_Outputs = 'ElectronTemperature Current EField'
-    [../]
+    []
     # treats water as a dense plasma
-    [./Water]
+    [Water]
       charged_particle = 'emliq OHm'
       potential = potential
       Is_potential_unique = false
@@ -100,11 +100,11 @@ dom1Scale=1e-7
       #Name of material block for water
       block = 1
       Additional_Outputs = 'Current EField'
-    [../]
+    []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     #Name of reactant species that are variables
     species = 'em Arp'
     #Name of reactant species that are auxvariables
@@ -137,9 +137,9 @@ dom1Scale=1e-7
     reactions = 'em + Ar -> em + Ar               : EEDF [elastic] (reaction1)
                  em + Ar -> em + Ar*              : EEDF [-11.5] (reaction2)
                  em + Ar -> em + em + Arp         : EEDF [-15.76] (reaction3)'
-  [../]
+  []
 
-  [./Water]
+  [Water]
     species = 'emliq OHm'
     reaction_coefficient_format = 'rate'
     use_log = true
@@ -148,31 +148,31 @@ dom1Scale=1e-7
     block = 1
     reactions = 'emliq -> H + OHm : 1064
                  emliq + emliq -> H2 + OHm + OHm : 3.136e8'
-  [../]
+  []
 []
 
 [AuxVariables]
   #Background fluid in water
-  [./H2O]
+  [H2O]
     order = CONSTANT
     family = MONOMIAL
     initial_condition = 10.92252
     block = 1
-  [../]
+  []
   #Background gas in plasma
-  [./Ar]
+  [Ar]
     block = 0
     order = CONSTANT
     family = MONOMIAL
     initial_condition = 3.70109
-  [../]
+  []
 []
 
 [InterfaceKernels]
   # interface conditions allow one this to go another
   # These account for electrons going into the water
   # if you want to account for electrons going out of the water into the air then you would need there to be interface conditions for master interface 0
-  [./em_advection]
+  [em_advection]
     type = InterfaceAdvection
     mean_en_neighbor = mean_en
     potential_neighbor = potential
@@ -184,8 +184,8 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
-  [./em_diffusion]
+  []
+  [em_diffusion]
     type = InterfaceLogDiffusionElectrons
     mean_en_neighbor = mean_en
     neighbor_var = em
@@ -193,22 +193,22 @@ dom1Scale=1e-7
     boundary = master1_interface
     position_units = ${dom1Scale}
     neighbor_position_units = ${dom0Scale}
-  [../]
+  []
 []
 
 #Electrode data needed for 1D BC of 'NeumannCircuitVoltageMoles_KV'
 [UserObjects]
-  [./data_provider]
+  [data_provider]
     type = ProvideMobility
     electrode_area = 5.02e-7 # Formerly 3.14e-6
     ballast_resist = 1e6
     e = 1.6e-19
-  [../]
+  []
 []
 
 [BCs]
   #DC BC on the air electrode
-  [./potential_left]
+  [potential_left]
     type = NeumannCircuitVoltageMoles_KV
     variable = potential
     boundary = left
@@ -219,17 +219,17 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
   #Ground electrode under the water
-  [./potential_dirichlet_right]
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = right
     value = 0
-  [../]
+  []
 
   #Electrons on the powered electrode
-  [./em_physical_left]
+  [em_physical_left]
     type = HagelaarElectronBC
     variable = em
     boundary = 'left'
@@ -237,8 +237,8 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./sec_electrons_left]
+  []
+  [sec_electrons_left]
     type = SecondaryElectronBC
     variable = em
     boundary = 'left'
@@ -247,10 +247,10 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Mean electron energy on the powered electrode
-  [./mean_en_physical_left]
+  [mean_en_physical_left]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -258,8 +258,8 @@ dom1Scale=1e-7
     em = em
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./secondary_energy_left]
+  []
+  [secondary_energy_left]
     type = SecondaryElectronEnergyBC
     variable = mean_en
     boundary = 'left'
@@ -268,27 +268,27 @@ dom1Scale=1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Argon ions on the powered electrode
-  [./Arp_physical_left_diffusion]
+  [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'left'
     r = 0
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_left_advection]
+  []
+  [Arp_physical_left_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'left'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Electrons on the plasma-liquid interface
-  [./em_physical_right]
+  [em_physical_right]
     type = HagelaarElectronBC
     variable = em
     boundary = 'master0_interface'
@@ -296,17 +296,17 @@ dom1Scale=1e-7
     mean_en = mean_en
     r = 0.00
     position_units = ${dom0Scale}
-  [../]
-  [./Arp_physical_right_diffusion]
+  []
+  [Arp_physical_right_diffusion]
     type = HagelaarIonDiffusionBC
     variable = Arp
     boundary = 'master0_interface'
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Mean electron energy on the plasma-liquid interface
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = HagelaarEnergyBC
     variable = mean_en
     boundary = 'master0_interface'
@@ -314,100 +314,100 @@ dom1Scale=1e-7
     em = em
     r = 0.00
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Argon ions on the plasma-liquid interface
-  [./Arp_physical_right_advection]
+  [Arp_physical_right_advection]
     type = HagelaarIonAdvectionBC
     variable = Arp
     boundary = 'master0_interface'
     potential = potential
     r = 0
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Electrons on the electrode
-  [./emliq_right]
+  [emliq_right]
     type = DCIonBC
     variable = emliq
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
   #OH- on the ground electrode
-  [./OHm_physical]
+  [OHm_physical]
     type = DCIonBC
     variable = OHm
     boundary = 'right'
     potential = potential
     position_units = ${dom1Scale}
-  [../]
+  []
 []
 
 #Initial conditions for variables.
 #If left undefine, the IC is zero
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = ConstantIC
     variable = em
     value = -21
     block = 0
-  [../]
-  [./emliq_ic]
+  []
+  [emliq_ic]
     type = ConstantIC
     variable = emliq
     value = -21
     block = 1
-  [../]
-  [./Arp_ic]
+  []
+  [Arp_ic]
     type = ConstantIC
     variable = Arp
     value = -21
     block = 0
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = ConstantIC
     variable = mean_en
     value = -20
     block = 0
-  [../]
-  [./OHm_ic]
+  []
+  [OHm_ic]
     type = ConstantIC
     variable = OHm
     value = -15.6
     block = 1
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 #Define function used throughout the input file (e.g. BCs and ICs)
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     # value = '1.25*tanh(1e6*t)'
     value = -1.25
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '-1.25 * (1.0001e-3 - x)'
-  [../]
+  []
 []
 
 [Materials]
  #The material properties for electrons and ions in water
- [./water_block]
+ [water_block]
    type = Water
    block = 1
    potential = potential
- [../]
+ []
 
  #The material properties for electrons in plasma
  #Also hold universal constant, such as Avogadro's number, elementary charge, etc.
- [./electrons_in_plasma]
+ [electrons_in_plasma]
    type = GasElectronMoments
    interp_trans_coeffs = true
    interp_elastic_coeff = true
@@ -419,42 +419,42 @@ dom1Scale=1e-7
    mean_en = mean_en
    block = 0
    property_tables_file = 'townsend_coefficients/moments.txt'
- [../]
+ []
 
  #Sets the pressure and temperature in the water
- [./water_block1]
+ [water_block1]
    type = GenericConstantMaterial
    block = 1
    prop_names = 'T_gas p_gas'
    prop_values = '300 1.01e5'
- [../]
+ []
 
  #The material properties of the argon ion
- [./gas_species_0]
+ [gas_species_0]
    type = ADHeavySpecies
    heavy_species_name = Arp
    heavy_species_mass = 6.64e-26
    heavy_species_charge = 1.0
    block = 0
- [../]
+ []
 
  #The material properties of the background argon gas
- [./gas_species_2]
+ [gas_species_2]
    type = ADHeavySpecies
    heavy_species_name = Ar
    heavy_species_mass = 6.64e-26
    heavy_species_charge = 0.0
    block = 0
- [../]
+ []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -471,20 +471,20 @@ dom1Scale=1e-7
   nl_abs_tol = 7.6e-5
   dtmin = 1e-15
   l_max_its = 20
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.4
     dt = 1e-11
     growth_factor = 1.2
     optimal_iterations = 30
-  [../]
+  []
 []
 
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
     execute_on = 'final'
-  [../]
+  []
 []

--- a/tutorial/tutorial05-PlasmaWaterInterface/tests
+++ b/tutorial/tutorial05-PlasmaWaterInterface/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial05-PlasmaWaterInterface_syntax]
+  [tutorial05-PlasmaWaterInterface_syntax]
     type = RunApp
     input = 'DC_argon-With-Water.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []

--- a/tutorial/tutorial06-Building-InputFile/RF_Plasma_Blank.i
+++ b/tutorial/tutorial06-Building-InputFile/RF_Plasma_Blank.i
@@ -18,24 +18,24 @@ dom0Scale=25.4e-3
 
 [Mesh]
   #Mesh is define by a Gmsh file
-  [./geo]
+  [geo]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
+  []
   #Renames all sides with the specified normal
   #For 1D, this is used to rename the end points of the mesh
-  [./left]
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 #Defines the problem type, such as FE, eigen value problem, etc.
@@ -44,7 +44,7 @@ dom0Scale=25.4e-3
 []
 
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     #User define name for electrons (usually 'em')
     electrons =
     #User define name for ions
@@ -59,11 +59,11 @@ dom0Scale=25.4e-3
     position_units = ${dom0Scale}
     #Additional outputs, such as ElectronTemperature, Current, and EField.
     Additional_Outputs =
-  [../]
+  []
 []
 
 [Reactions]
-  [./Gas]
+  [Gas]
     #Name of reactant species that are variables
     species =
     #Name of reactant species that are auxvariables
@@ -94,34 +94,34 @@ dom0Scale=25.4e-3
     #e.g. Reaction : Constant or EEDF dependent [Threshold Energy] (Text file name)
     #     em + Ar -> em + Ar*        : EEDF [-11.56] (reaction1)
     reactions =
-  [../]
+  []
 []
 
 [AuxVariables]
   #Add a scaled position units used for plotting other element AuxVariables
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
   #Background gas (e.g Ar)
-  [./Ar]
-  [../]
+  [Ar]
+  []
 []
 
 [AuxKernels]
   #Add at scaled position units used for plotting other element AuxVariables
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
   #Background gas number density (e.g. for 1Torr)
-  [./Ar_val]
+  [Ar_val]
     type = FunctionAux
     variable = Ar
     function = 'log(3.22e22/6.022e23)'
     execute_on = INITIAL
-  [../]
+  []
 []
 
 #Currently there is no Action for BC (but one is currently in development)
@@ -129,23 +129,23 @@ dom0Scale=25.4e-3
 #(For other BC example, please look at Tutorial 04 and Tutorial 06)
 [BCs]
 #Voltage Boundary Condition Ffor a Power-Ground RF Discharge
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right left'
@@ -154,76 +154,76 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for mean energy
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5 #Electron Temperature in eV
     boundary = 'right left'
-  [../]
+  []
 []
 
 #Initial conditions for variables.
 #If left undefine, the IC is zero
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
-  [./mean_en_ic]
+  []
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
-  [./potential_ic]
+  []
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 #Define function used throughout the input file (e.g. BCs and ICs)
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
   #The material properties for electrons.
   #Also hold universal constant, such as Avogadro's number, elementary charge, etc.
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     #False means constant electron coeff, defined by user
     interp_trans_coeffs = false
@@ -245,38 +245,38 @@ dom0Scale=25.4e-3
     user_electron_diffusion_coeff = 119.8757763975
     #Name of text file with electron properties
     property_tables_file = rate_coefficients/electron_moments.txt
-  [../]
+  []
   #The material properties of the ion
-  [./gas_species_0]
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
+  []
   #The material properties of the background gas
-  [./gas_species_2]
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
+  []
 []
 
 #Preconditioning options
 #Learn more at: https://mooseframework.inl.gov/syntax/Preconditioning/index.html
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 #How to execute the problem.
@@ -301,7 +301,7 @@ dom0Scale=25.4e-3
 #Defines the output type of the file (multiple output files can be define per run)
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial06-Building-InputFile/RF_Plasma_WithOut_Metastables.i
+++ b/tutorial/tutorial06-Building-InputFile/RF_Plasma_WithOut_Metastables.i
@@ -6,22 +6,22 @@ dom0Scale=25.4e-3
 []
 
 [Mesh]
-  [./geo]
+  [geo]
     type = FileMeshGenerator
     file = 'Lymberopoulos_paper.msh'
-  [../]
-  [./left]
+  []
+  [left]
     type = SideSetsFromNormalsGenerator
     normals = '-1 0 0'
     new_boundary = 'left'
     input = geo
-  [../]
-  [./right]
+  []
+  [right]
     type = SideSetsFromNormalsGenerator
     normals = '1 0 0'
     new_boundary = 'right'
     input = left
-  [../]
+  []
 []
 
 [Problem]
@@ -29,7 +29,7 @@ dom0Scale=25.4e-3
 []
 
 [DriftDiffusionAction]
-  [./Plasma]
+  [Plasma]
     electrons = em
     charged_particle = Ar+
     potential = potential
@@ -37,11 +37,11 @@ dom0Scale=25.4e-3
     mean_energy = mean_en
     position_units = ${dom0Scale}
     Additional_Outputs = 'ElectronTemperature Current EField'
-  [../]
+  []
 []
 
 [Reactions]
-  [./Argon]
+  [Argon]
     species = 'em Ar+'
     aux_species = 'Ar'
     reaction_coefficient_format = 'rate'
@@ -57,52 +57,52 @@ dom0Scale=25.4e-3
     block = 0
     reactions = 'em + Ar -> em + Ar*        : EEDF [-11.56] (reaction1)
                  em + Ar -> em + em + Ar+   : EEDF [-15.7] (reaction2)'
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./x_node]
-  [../]
+  [x_node]
+  []
 
-  [./Ar]
-  [../]
+  [Ar]
+  []
 []
 
 [AuxKernels]
-  [./x_ng]
+  [x_ng]
     type = Position
     variable = x_node
     position_units = ${dom0Scale}
-  [../]
+  []
 
-  [./Ar_val]
+  [Ar_val]
     type = FunctionAux
     variable = Ar
     function = 'log(3.22e22/6.022e23)'
     execute_on = INITIAL
-  [../]
+  []
 []
 
 
 [BCs]
 #Voltage Boundary Condition
-  [./potential_left]
+  [potential_left]
     type = FunctionDirichletBC
     variable = potential
     boundary = 'left'
     function = potential_bc_func
     preset = false
-  [../]
-  [./potential_dirichlet_right]
+  []
+  [potential_dirichlet_right]
     type = DirichletBC
     variable = potential
     boundary = 'right'
     value = 0
     preset = false
-  [../]
+  []
 
 #Boundary conditions for electons
-  [./em_physical_right]
+  [em_physical_right]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'right'
@@ -111,8 +111,8 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
-  [./em_physical_left]
+  []
+  [em_physical_left]
     type = LymberopoulosElectronBC
     variable = em
     boundary = 'left'
@@ -121,89 +121,89 @@ dom0Scale=25.4e-3
     ion = Ar+
     potential = potential
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for ions
-  [./Ar+_physical_right_advection]
+  [Ar+_physical_right_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'right'
     position_units = ${dom0Scale}
-  [../]
-  [./Ar+_physical_left_advection]
+  []
+  [Ar+_physical_left_advection]
     type = LymberopoulosIonBC
     variable = Ar+
     potential = potential
     boundary = 'left'
     position_units = ${dom0Scale}
-  [../]
+  []
 
 #Boundary conditions for mean energy
-  [./mean_en_physical_right]
+  [mean_en_physical_right]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'right'
-  [../]
-  [./mean_en_physical_left]
+  []
+  [mean_en_physical_left]
     type = ElectronTemperatureDirichletBC
     variable = mean_en
     em = em
     value = 0.5
     boundary = 'left'
-  [../]
+  []
 
 []
 
 
 [ICs]
-  [./em_ic]
+  [em_ic]
     type = FunctionIC
     variable = em
     function = density_ic_func
-  [../]
-  [./Ar+_ic]
+  []
+  [Ar+_ic]
     type = FunctionIC
     variable = Ar+
     function = density_ic_func
-  [../]
+  []
 
-  [./mean_en_ic]
+  [mean_en_ic]
     type = FunctionIC
     variable = mean_en
     function = energy_density_ic_func
-  [../]
+  []
 
-  [./potential_ic]
+  [potential_ic]
     type = FunctionIC
     variable = potential
     function = potential_ic_func
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_bc_func]
+  [potential_bc_func]
     type = ParsedFunction
     value = '0.100*sin(2*3.1415926*13.56e6*t)'
-  [../]
-  [./potential_ic_func]
+  []
+  [potential_ic_func]
     type = ParsedFunction
     value = '0.100 * (25.4e-3 - x)'
-  [../]
-  [./density_ic_func]
+  []
+  [density_ic_func]
     type = ParsedFunction
     value = 'log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
-  [./energy_density_ic_func]
+  []
+  [energy_density_ic_func]
     type = ParsedFunction
     value = 'log(3./2.) + log((1e13 + 1e15 * (1-x/1)^2 * (x/1)^2)/6.022e23)'
-  [../]
+  []
 []
 
 [Materials]
-  [./GasBasics]
+  [GasBasics]
     type = GasElectronMoments
     interp_trans_coeffs = false
     interp_elastic_coeff = false
@@ -215,34 +215,34 @@ dom0Scale=25.4e-3
     user_electron_mobility = 30.0
     user_electron_diffusion_coeff = 119.8757763975
     property_tables_file = rate_coefficients/electron_moments.txt
-  [../]
-  [./gas_species_0]
+  []
+  [gas_species_0]
     type = ADHeavySpecies
     heavy_species_name = Ar+
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 1.0
     mobility = 0.144409938
     diffusivity = 6.428571e-3
-  [../]
-  [./gas_species_2]
+  []
+  [gas_species_2]
     type = ADHeavySpecies
     heavy_species_name = Ar
     heavy_species_mass = 6.64e-26
     heavy_species_charge = 0.0
-  [../]
+  []
 []
 
 [Preconditioning]
   active = 'smp'
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 
-  [./fdp]
+  [fdp]
     type = FDP
     full = true
-  [../]
+  []
 []
 
 
@@ -264,7 +264,7 @@ dom0Scale=25.4e-3
 
 [Outputs]
   perf_graph = true
-  [./out]
+  [out]
     type = Exodus
-  [../]
+  []
 []

--- a/tutorial/tutorial06-Building-InputFile/tests
+++ b/tutorial/tutorial06-Building-InputFile/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./tutorial06-Building-InputFile_syntax]
+  [tutorial06-Building-InputFile_syntax]
     type = RunApp
     input = 'RF_Plasma_WithOut_Metastables.i'
     check_input = True
     method = opt
     group = 'tutorial'
-  [../]
+  []
 []


### PR DESCRIPTION
This PR: 

- Removes old legacy flags and adds one to disable legacy material output in `ZapdosApp.C`. Zapdos no longer displays a legacy material output warning during simulations and will output material properties on INITIAL by default, which is the current MOOSE standard.
- Removes `./` and `../` syntax in all input files and input example snippets in Zapdos. This syntax has been deprecated and should no longer be used. 
- Updates the `fixup_headers.py` script to be in line with that within MOOSE by:
  - updating to python 3 compatibility (Closes #154) and
  - adding the ability to detect `#ifdef` directives and switching to `#pragma once` in C++ source.
- Adds new features to `fixup_headers.py` by adding the ability to ignore particular files during the check.

EDIT: This also adds an extra reset step to the website action....the clean-up step wasn't adequate to reset the state of the doxygen dummy page added in #165. See [the most recent website build failure](https://github.com/shannon-lab/zapdos/actions/runs/3826669342).