### PR TITLE
Improvements to the docker build script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
         day: "saturday"
         time: "01:00"
     directory: "/"
+    allow:
+      # Allow updates for crane and squirrel....moose is updated through CIVET
+      - dependency-name: "crane"
+      - dependency-name: "squirrel"
   # Maintain dependencies for GitHub Actions once a month
   - package-ecosystem: "github-actions"
     schedule:

--- a/doc/content/development/zapdos_developer_info.md
+++ b/doc/content/development/zapdos_developer_info.md
@@ -7,13 +7,10 @@ is desired, please refer to the [moose_developer_info.md] page.
 ## Update and Build a New Docker Container
 
 !style halign=left
-The Zapdos docker container image should be updated whenever Zapdos source code or submodules (CRANE,
-Squirrel, or MOOSE) are updated and those changes are merged into the master branch. Whenever the
-MOOSE submodule is updated, in particular, the submodule git commit hash must be copied and entered
-into the `Dockerfile` so that the proper MOOSE docker image can be used with the Zapdos image.
-
-To build a new docker container, first fetch the most up-to-date version of the Zapdos master branch.
-Assuming that Zapdos is stored in `~/projects/` and that your `upstream` remote is referencing
+The Zapdos docker container image should be updated whenever Zapdos source code or that of submodules
+(CRANE, Squirrel, or MOOSE) are updated and those changes are merged into the master branch. To build
+a new docker container, first fetch the most up-to-date version of the Zapdos master branch. Assuming
+that Zapdos is stored in `~/projects/` and that your `upstream` remote is referencing
 [shannon-lab/zapdos](https://github.com/shannon-lab/zapdos.git):
 
 ```bash
@@ -68,7 +65,3 @@ INFO: Push to Docker Hub disabled. If desired in the future, run this script
       docker push shannonlab/zapdos:2c4a214d4d55106ac6c8c9058e3b224a46ba416d
       docker push shannonlab/zapdos:latest
 ```
-
-
-
-

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
-# DON'T FORGET: Modify this hash to be consistent with the MOOSE submodule!
-FROM idaholab/moose:5e60aeb38c948f5db9e98b2080724b87188f5ee2
+# Template variable is replaced with hash when build_docker.sh is run!
+FROM idaholab/moose:{{MOOSE_HASH}}
 
 WORKDIR /opt
 


### PR DESCRIPTION
With these changes the Dockerfile doesn't need to be updated manually. This is in preparation for a staged move to 

1. Automating MOOSE submodule updates from CIVET instead of dependabot, and then
2. Automating the Docker build process through Docker Hub directly now that `shannonlab` is a proper Docker Team. 

This PR also moves the Dockerfile to the `scripts` directory. It's not necessary to keep it in the root directory, so let's place it beside the script that actually uses it. 

Refs #155 