### PR TITLE
Update website action and publication list

### DIFF
--- a/doc/content/bib/zapdos_journal_articles.bib
+++ b/doc/content/bib/zapdos_journal_articles.bib
@@ -34,3 +34,14 @@
   title = {Multiphase modeling of the DC plasma–water interface: application to hydrogen peroxide generation with experimental validation},
   journal = {Plasma Sources Science and Technology}
 }
+
+@article{dechant2023psst,
+  author = {Corey DeChant and Casey Icenhour and Shane Keniley and Alexander Lindsay and Grayson Gall and Kimberly Clein Hizon and Davide Curreli and Steven Shannon},
+  title = {Verification Methods for Drift-Diffusion Reaction Models for Plasma Simulations},
+  year = {2023},
+  volume = {32},
+  number = {4},
+  pages = {044006},
+  journal = {Plasma Sources Science and Technology},
+  doi = {10.1088/1361-6595/acce65}
+}

--- a/scripts/conda_environment.yml
+++ b/scripts/conda_environment.yml
@@ -4,5 +4,4 @@ channels:
   - https://conda.software.inl.gov/public
 dependencies:
   - python=3.10
-  - moose-libmesh
-  - moose-tools
+  - moose-dev


### PR DESCRIPTION
Changes website action to use the new `moose-dev` package. @csdechant You might be interested to know that this one package now gives you all that `moose-libmesh` and `moose-tools` used to give. The main moose installation instructions should be updated to reflect.

This also adds the PSST paper to the publications page, now that it has a full citation. 