### PR TITLE
Add const-ness to getValue methods in postprocessors

### DIFF
--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -44,6 +44,8 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./doc/site
+        # This populates the gh-pages branch with only this update and removes prior history
+        force_orphan: true
         user_name: github-actions
         user_email: actions@github.com
         commit_message: "Update zapdos website based on"

--- a/include/postprocessors/AverageNodalDensity.h
+++ b/include/postprocessors/AverageNodalDensity.h
@@ -22,7 +22,8 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void execute() override;
-  virtual Real getValue() override;
+  using Postprocessor::getValue;
+  virtual PostprocessorValue getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 
 protected:

--- a/include/postprocessors/AverageNodalDifference.h
+++ b/include/postprocessors/AverageNodalDifference.h
@@ -21,11 +21,14 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  virtual Real getValue() override;
+  using Postprocessor::getValue;
+  virtual PostprocessorValue getValue() const override;
+  virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
 
 protected:
   const VariableValue & _other_var;
   Real _sum_of_squared_diff;
   Real _n;
+  Real _value;
 };

--- a/include/postprocessors/PeriodicComparisonCounter.h
+++ b/include/postprocessors/PeriodicComparisonCounter.h
@@ -21,7 +21,9 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  virtual PostprocessorValue getValue() override;
+  using Postprocessor::getValue;
+  virtual PostprocessorValue getValue() const override;
+  virtual void finalize() override;
 
 protected:
   /// Comparison type

--- a/include/postprocessors/PlasmaFrequencyInverse.h
+++ b/include/postprocessors/PlasmaFrequencyInverse.h
@@ -25,7 +25,9 @@ public:
   static InputParameters validParams();
 
   virtual void initialize() override;
-  virtual Real getValue() override;
+  using Postprocessor::getValue;
+  virtual PostprocessorValue getValue() const override;
+  virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
 
 protected:
@@ -36,4 +38,5 @@ protected:
   Real _value;
   Real _em_density;
   bool _use_moles;
+  Real _inverse;
 };

--- a/include/postprocessors/RelativeElementL2Difference.h
+++ b/include/postprocessors/RelativeElementL2Difference.h
@@ -22,7 +22,8 @@ public:
 
   static InputParameters validParams();
 
-  virtual Real getValue() override;
+  using Postprocessor::getValue;
+  virtual PostprocessorValue getValue() const override;
 
 protected:
   virtual Real computeQpIntegral() override;

--- a/src/postprocessors/AverageNodalDensity.C
+++ b/src/postprocessors/AverageNodalDensity.C
@@ -43,8 +43,8 @@ AverageNodalDensity::execute()
   _n++;
 }
 
-Real
-AverageNodalDensity::getValue()
+PostprocessorValue
+AverageNodalDensity::getValue() const
 {
   return _sum / _n;
 }

--- a/src/postprocessors/AverageNodalDifference.C
+++ b/src/postprocessors/AverageNodalDifference.C
@@ -27,7 +27,8 @@ AverageNodalDifference::AverageNodalDifference(const InputParameters & parameter
   : NodalVariablePostprocessor(parameters),
     _other_var(coupledValue("other_variable")),
     _sum_of_squared_diff(0.0),
-    _n(0)
+    _n(0),
+    _value(0)
 {
 }
 
@@ -48,13 +49,19 @@ AverageNodalDifference::execute()
   _n++;
 }
 
-Real
-AverageNodalDifference::getValue()
+PostprocessorValue
+AverageNodalDifference::getValue() const
+{
+  return _value;
+}
+
+void
+AverageNodalDifference::finalize()
 {
   gatherSum(_sum_of_squared_diff);
   gatherSum(_n);
 
-  return std::sqrt(_sum_of_squared_diff / (_n * _n));
+  _value = std::sqrt(_sum_of_squared_diff / (_n * _n));
 }
 
 void

--- a/src/postprocessors/PeriodicComparisonCounter.C
+++ b/src/postprocessors/PeriodicComparisonCounter.C
@@ -58,7 +58,13 @@ PeriodicComparisonCounter::execute()
 }
 
 PostprocessorValue
-PeriodicComparisonCounter::getValue()
+PeriodicComparisonCounter::getValue() const
+{
+  return _counter;
+}
+
+void
+PeriodicComparisonCounter::finalize()
 {
   Real remainder = std::remainder(_feproblem.time(), _period);
   Real max = std::numeric_limits<double>::epsilon();
@@ -75,42 +81,33 @@ PeriodicComparisonCounter::getValue()
           _counter++;
         else
           _counter = 0.0;
-        return _counter;
         break;
       case ComparisonType::GREATER_THAN_EQUALS:
         if (_value1 >= _value2)
           _counter++;
         else
           _counter = 0.0;
-        return _counter;
         break;
       case ComparisonType::LESS_THAN_EQUALS:
         if (_value1 <= _value2)
           _counter++;
         else
           _counter = 0.0;
-        return _counter;
         break;
       case ComparisonType::GREATER_THAN:
         if (_value1 > _value2)
           _counter++;
         else
           _counter = 0.0;
-        return _counter;
         break;
       case ComparisonType::LESS_THAN:
         if (_value1 < _value2)
           _counter++;
         else
           _counter = 0.0;
-        return _counter;
         break;
       default:
         mooseError("Invalid comparison type.");
     }
-  }
-  else
-  {
-    return _counter;
   }
 }

--- a/src/postprocessors/PlasmaFrequencyInverse.C
+++ b/src/postprocessors/PlasmaFrequencyInverse.C
@@ -32,28 +32,32 @@ PlasmaFrequencyInverse::PlasmaFrequencyInverse(const InputParameters & parameter
   : ElementVariablePostprocessor(parameters),
     _value(-std::numeric_limits<Real>::max()),
     _em_density(0),
-    _use_moles(getParam<bool>("use_moles"))
+    _use_moles(getParam<bool>("use_moles")),
+    _inverse(0)
 {
 }
 
 void
 PlasmaFrequencyInverse::initialize()
 {
-
   _value = -std::numeric_limits<Real>::max(); // start w/ the min
 }
 
 void
 PlasmaFrequencyInverse::computeQpValue()
 {
-
   _value = std::max(_value, _u[_qp]);
 }
 
-Real
-PlasmaFrequencyInverse::getValue()
+PostprocessorValue
+PlasmaFrequencyInverse::getValue() const
 {
+  return _inverse;
+}
 
+void
+PlasmaFrequencyInverse::finalize()
+{
   gatherMax(_value);
 
   if (_use_moles)
@@ -67,7 +71,7 @@ PlasmaFrequencyInverse::getValue()
 
   Real _plasma_freq = std::sqrt(std::pow(1.6022e-19, 2) * _em_density / (8.8542e-12 * 9.1094e-31));
 
-  return 1. / _plasma_freq;
+  _inverse = 1. / _plasma_freq;
 }
 
 void

--- a/src/postprocessors/RelativeElementL2Difference.C
+++ b/src/postprocessors/RelativeElementL2Difference.C
@@ -29,8 +29,8 @@ RelativeElementL2Difference::RelativeElementL2Difference(const InputParameters &
 {
 }
 
-Real
-RelativeElementL2Difference::getValue()
+PostprocessorValue
+RelativeElementL2Difference::getValue() const
 {
   return std::sqrt(ElementIntegralPostprocessor::getValue());
 }


### PR DESCRIPTION
Fixes up build warnings currently being experienced on devel testing: https://civet.inl.gov/event/138892/

This PR also changes the github pages action to force an orphan commit on every update. This should reduce the size of the repository by making sure that only one set of doxygen files are present in the repository history at any given time. (Refs #202)