### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/actions/AddDriftDiffusionAction.C
+++ b/src/actions/AddDriftDiffusionAction.C
@@ -48,13 +48,15 @@ AddDriftDiffusionAction::validParams()
   InputParameters params = AddVariableAction::validParams();
 
   params.addParam<std::vector<NonlinearVariableName>>(
-      "charged_particle", "User given variable name for energy independent charged particle");
+      "charged_particle", {}, "User given variable name for energy independent charged particle");
   params.addParam<std::vector<NonlinearVariableName>>(
       "secondary_charged_particles",
+      {},
       "These are charged particles whose advection term in determined by"
       " an effective potential.");
   params.addParam<std::vector<NonlinearVariableName>>(
       "eff_potentials",
+      {},
       "The effective potentials that only affect their respective secondary"
       " charged particle.");
   params.addParam<NonlinearVariableName>("electrons",
@@ -73,9 +75,9 @@ AddDriftDiffusionAction::validParams()
   params.addParam<NonlinearVariableName>("mean_energy",
                                          "The gives the mean energy a variable name");
   params.addParam<std::vector<NonlinearVariableName>>(
-      "Neutrals", "The names of the neutrals that should be added");
-  params.addParam<std::vector<SubdomainName>>("block",
-                                              "The subdomain that this action applies to.");
+      "Neutrals", {}, "The names of the neutrals that should be added");
+  params.addParam<std::vector<SubdomainName>>(
+      "block", {}, "The subdomain that this action applies to.");
   params.addRequiredParam<Real>("position_units", "Units of position");
   params.addParam<bool>("using_offset", false, "Is the LogStabilizationMoles Kernel being used");
   params.addParam<Real>(
@@ -84,6 +86,7 @@ AddDriftDiffusionAction::validParams()
   params.addRequiredParam<bool>("use_moles", "Whether to convert from units of moles to #.");
   params.addParam<std::vector<std::string>>(
       "Additional_Outputs",
+      {},
       "Current list of available ouputs options in this action: Current, ElectronTemperature,"
       " EField");
   return params;

--- a/src/actions/AddPeriodicRelativeNodalDifference.C
+++ b/src/actions/AddPeriodicRelativeNodalDifference.C
@@ -50,16 +50,16 @@ AddPeriodicRelativeNodalDifference::validParams()
 
   InputParameters params = AddVariableAction::validParams();
   params.addParam<std::vector<NonlinearVariableName>>(
-      "periodic_variable_log", "The periodic variables that are in log form.");
-  params.addParam<std::vector<NonlinearVariableName>>("periodic_variable",
-                                                      "The periodic variables (Not in log form).");
+      "periodic_variable_log", {}, "The periodic variables that are in log form.");
+  params.addParam<std::vector<NonlinearVariableName>>(
+      "periodic_variable", {}, "The periodic variables (Not in log form).");
   params.addParam<Real>(
       "starting_cycle", 0.0, "The number of the cycles before starting the difference calculation");
   params.addRequiredParam<Real>("cycle_frequency", "The cycle's frequency in Hz");
   params.addParam<Real>(
       "num_cycles", 2000.0, "The number of cycles to calculation the difference for.");
-  params.addParam<std::vector<SubdomainName>>("block",
-                                              "The subdomain that this action applies to.");
+  params.addParam<std::vector<SubdomainName>>(
+      "block", {}, "The subdomain that this action applies to.");
   params.addClassDescription(
       "This Action automatically adds the necessary objects to calculate the relative"
       " periodic difference. Relative Difference will be outputted as an Postprocessor named: "


### PR DESCRIPTION
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This issue is up to fix the some left out vector parameters in Zapdos since last patch. It has been a while since we made the patch in Zapdos to adapt the new changes in MOOSE because we are waiting for other apps finish merging first. Hopefully this is the last patch we need.