### PR TITLE
Website Update - AuxKernels

### DIFF
--- a/doc/content/source/auxkernels/AbsValueAux.md
+++ b/doc/content/source/auxkernels/AbsValueAux.md
@@ -1,20 +1,17 @@
 # AbsValueAux
 
-!alert construction title=Undocumented Class
-The AbsValueAux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/AbsValueAux
 
 ## Overview
 
-!! Replace these lines with information regarding the AbsValueAux object.
+`AbsValueAux` returns the absolute value a coupled variable.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the AbsValueAux object.
+An example of how to use `AbsValueAux` can be found in the
+test file `TM_steady.i`.
+
+!listing test/tests/TM10_circular_wg/TM_steady.i block=AuxKernels/Hphi_mag
 
 !syntax parameters /AuxKernels/AbsValueAux
 

--- a/doc/content/source/auxkernels/Current.md
+++ b/doc/content/source/auxkernels/Current.md
@@ -10,7 +10,7 @@ assumes the electrostatic approximation for the electric field.
 The electrostatic current density is defined as
 
 \begin{equation}
-J_{j} = q_{j} (\text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j}))
+J_{j} = q_{j} (\text{sign}_{j} \mu_{j} \left( \text{-} \nabla V\right) n_{j} - D_{j} \nabla (n_{j}))
 \end{equation}
 
 Where $J_{j}$ is the current density, $q_{j}$ is the charge of the species, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient, $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient. When converting the density to logarithmic form and applying a scaling factor of the mesh, `Current` is defined as

--- a/doc/content/source/auxkernels/Current.md
+++ b/doc/content/source/auxkernels/Current.md
@@ -1,20 +1,40 @@
 # Current
 
-!alert construction title=Undocumented Class
-The Current has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/Current
 
 ## Overview
 
-!! Replace these lines with information regarding the Current object.
+`Current` returns the electric current density of a species in logarithmic form. `Current`
+assumes the electrostatic approximation for the electric field.
+
+The electrostatic current density is defined as
+
+\begin{equation}
+J_{j} = q_{j} (\text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j}))
+\end{equation}
+
+Where $J_{j}$ is the current density, $q_{j}$ is the charge of the species, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient, $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient. When converting the density to logarithmic form and applying a scaling factor of the mesh, `Current` is defined as
+
+\begin{equation}
+J_{j} = q_{j} N_{A} \left(\text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j}) - D_{j} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}} \right)
+\end{equation}
+
+Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is Avogadro's number, $l_{c}$ is the scaling factor of the mesh.
+
+For the case of the where artificial diffusion is introduced to the charge specie flux, an additional term is included in the current density, such that:
+
+\begin{equation}
+J_{j Total} = J_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\end{equation}
+
+Where $h_{max}$ is the max length of the current element.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the Current object.
+An example of how to use `Current` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/Current_em
 
 !syntax parameters /AuxKernels/Current
 

--- a/doc/content/source/auxkernels/Current.md
+++ b/doc/content/source/auxkernels/Current.md
@@ -24,10 +24,10 @@ Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is
 For the case of the where artificial diffusion is introduced to the charge specie flux, an additional term is included in the current density, such that:
 
 \begin{equation}
-J_{j Total} = J_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+J_{j,\text{ Total}} = J_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_\text{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
 \end{equation}
 
-Where $h_{max}$ is the max length of the current element.
+Where $h_\text{max}$ is the max length of the current element.
 
 ## Example Input File Syntax
 

--- a/doc/content/source/auxkernels/DensityMoles.md
+++ b/doc/content/source/auxkernels/DensityMoles.md
@@ -1,20 +1,23 @@
 # DensityMoles
 
-!alert construction title=Undocumented Class
-The DensityMoles has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/DensityMoles
 
 ## Overview
 
-!! Replace these lines with information regarding the DensityMoles object.
+`DensityMoles` converts the density value of a coupled species from a logarithmic molar density into units of $\frac{\#}{m^{3}}$, such that:
+
+\begin{equation}
+n_{j} = N_{A} exp(N_{j})
+\end{equation}
+
+Where $n_{j}$ is the density, $N_{j}$ is the molar density of the specie in logarithmic form, and $N_{A}$ is Avogadro's number. This is often needed due to Zapdos solving densities using a logarithmic molar formulation to help avoid negative densities and ill-conditioned matrices.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the DensityMoles object.
+An example of how to use `DensityMoles` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/em_lin
 
 !syntax parameters /AuxKernels/DensityMoles
 

--- a/doc/content/source/auxkernels/DensityMoles.md
+++ b/doc/content/source/auxkernels/DensityMoles.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-`DensityMoles` converts the density value of a coupled species from a logarithmic molar density into units of $\frac{\#}{m^{3}}$, such that:
+`DensityMoles` converts the density value of a coupled species from a logarithmic molar density into units of #$/m^{3}$, such that:
 
 \begin{equation}
-n_{j} = N_{A} exp(N_{j})
+n_{j} = N_{A} \exp(N_{j})
 \end{equation}
 
 Where $n_{j}$ is the density, $N_{j}$ is the molar density of the specie in logarithmic form, and $N_{A}$ is Avogadro's number. This is often needed due to Zapdos solving densities using a logarithmic molar formulation to help avoid negative densities and ill-conditioned matrices.

--- a/doc/content/source/auxkernels/DensityMoles.md
+++ b/doc/content/source/auxkernels/DensityMoles.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-`DensityMoles` converts the density value of a coupled species from a logarithmic molar density into units of #$/m^{3}$, such that:
+`DensityMoles` converts the density value of a coupled species from a logarithmic molar density into units of #/m$^{3}$, such that:
 
 \begin{equation}
 n_{j} = N_{A} \exp(N_{j})

--- a/doc/content/source/auxkernels/DensityNormalization.md
+++ b/doc/content/source/auxkernels/DensityNormalization.md
@@ -10,7 +10,13 @@ documentation clear for users.
 
 ## Overview
 
-!! Replace these lines with information regarding the DensityNormalization object.
+`DensityNormalization` is similar to [`NormalizationAux`](/auxkernels/NormalizationAux.md), except it normalizes a variable in logarithmic form based on a Postprocessor value.
+
+The formulation of `DensityNormalization` is defined as
+
+\begin{equation}
+\frac{\exp(\text{variable})*\text{normal factor}}{\text{normalization}} - \text{shift}
+\end{equation}
 
 ## Example Input File Syntax
 

--- a/doc/content/source/auxkernels/DensityNormalization.md
+++ b/doc/content/source/auxkernels/DensityNormalization.md
@@ -13,11 +13,11 @@ The formulation of `DensityNormalization` is defined as
 \end{equation}
 
 !alert warning title=Untested Class
-The DensityNormalization does not have a formulized test, yet. For this reason,
-users should be aware of unforseen debugs when using DensityNormalization. To
-report debug or discuss future contributions to Zapdos, please refer to the
+The DensityNormalization does not have a formalized test, yet. For this reason,
+users should be aware of unforeseen bugs when using DensityNormalization. To
+report a bug or discuss future contributions to Zapdos, please refer to the
 [Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
-For standards of have to contribute to Zapdos and the MOOSE framework,
+For standards of how to contribute to Zapdos and the MOOSE framework,
 please refer to the [MOOSE Contributing page](framework/contributing.md).
 
 ## Example Input File Syntax

--- a/doc/content/source/auxkernels/DensityNormalization.md
+++ b/doc/content/source/auxkernels/DensityNormalization.md
@@ -1,11 +1,5 @@
 # DensityNormalization
 
-!alert construction title=Undocumented Class
-The DensityNormalization has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/DensityNormalization
 
 ## Overview
@@ -18,9 +12,28 @@ The formulation of `DensityNormalization` is defined as
 \frac{\exp(\text{variable})*\text{normal factor}}{\text{normalization}} - \text{shift}
 \end{equation}
 
+!alert warning title=Undocumented Test
+The DensityNormalization does not have a formulized test, yet. For this reason,
+users should be aware of unforseen debugs when using DensityNormalization. To
+report debug or discuss future contributions to Zapdos, please refer to the
+[Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
+For standards of have to contribute to Zapdos and the MOOSE framework,
+please refer to the [MOOSE Contributing page](framework/contributing.md).
+
 ## Example Input File Syntax
 
 !! Describe and include an example of how to use the DensityNormalization object.
+
+```text
+[AuxKernels]
+  [Normalized_Electrons]
+    type = DensityNormalization
+    variable = norm_electrons
+    Density = electrons
+    normalization = max_electron
+  []
+[]
+```
 
 !syntax parameters /AuxKernels/DensityNormalization
 

--- a/doc/content/source/auxkernels/DensityNormalization.md
+++ b/doc/content/source/auxkernels/DensityNormalization.md
@@ -12,7 +12,7 @@ The formulation of `DensityNormalization` is defined as
 \frac{\exp(\text{variable})*\text{normal factor}}{\text{normalization}} - \text{shift}
 \end{equation}
 
-!alert warning title=Undocumented Test
+!alert warning title=Untested Class
 The DensityNormalization does not have a formulized test, yet. For this reason,
 users should be aware of unforseen debugs when using DensityNormalization. To
 report debug or discuss future contributions to Zapdos, please refer to the

--- a/doc/content/source/auxkernels/DiffusiveFlux.md
+++ b/doc/content/source/auxkernels/DiffusiveFlux.md
@@ -9,15 +9,15 @@
 The diffusive flux is defined as
 
 \begin{equation}
-\Gamma_{Diffusion}  = \text{-}D_{j} \nabla (n_{j})
+\Gamma_{\text{Diffusion}}  = \text{-}D_{j} \nabla (n_{j})
 \end{equation}
 
-Where $\Gamma$ is the diffusive flux, $D_{j}$ is the diffusion coefficient and $n_{j}$ is the density.
+Where $\Gamma_{\text{Diffusion}}$ is the diffusive flux, $D_{j}$ is the diffusion coefficient and $n_{j}$ is the density.
 When converting the density to logarithmic form and applying a scaling factor of the mesh,
 `DiffusiveFlux` is defined as
 
 \begin{equation}
-\Gamma_{Diffusion} = \text{-}D_{j} N_{A} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\Gamma_{\text{Diffusion}} = \text{-}D_{j} N_{A} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
 \end{equation}
 
 Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is Avogadro's

--- a/doc/content/source/auxkernels/DiffusiveFlux.md
+++ b/doc/content/source/auxkernels/DiffusiveFlux.md
@@ -1,20 +1,34 @@
 # DiffusiveFlux
 
-!alert construction title=Undocumented Class
-The DiffusiveFlux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/DiffusiveFlux
 
 ## Overview
 
-!! Replace these lines with information regarding the DiffusiveFlux object.
+`DiffusiveFlux` returns the diffusive flux of a species in logarithmic form.
+
+The diffusive flux is defined as
+
+\begin{equation}
+\Gamma_{Diffusion}  = \text{-}D_{j} \nabla (n_{j})
+\end{equation}
+
+Where $\Gamma$ is the diffusive flux, $D_{j}$ is the diffusion coefficient and $n_{j}$ is the density.
+When converting the density to logarithmic form and applying a scaling factor of the mesh,
+`DiffusiveFlux` is defined as
+
+\begin{equation}
+\Gamma_{Diffusion} = \text{-}D_{j} N_{A} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\end{equation}
+
+Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is Avogadro's
+number, $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the DiffusiveFlux object.
+An example of how to use `DiffusiveFlux` can be found in the
+test file `mean_en.i`.
+
+!listing test/tests/1d_dc/mean_en.i block=AuxKernels/DiffusiveFlux_em
 
 !syntax parameters /AuxKernels/DiffusiveFlux
 

--- a/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
+++ b/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
@@ -10,7 +10,20 @@ documentation clear for users.
 
 ## Overview
 
-!! Replace these lines with information regarding the DriftDiffusionFluxAux object.
+`DriftDiffusionFluxAux` returns the simplified drift-diffusion flux of a species. `DriftDiffusionFluxAux`
+assumes a mobility and diffusion coefficient of unity, the electrostatic approximation for the electric field, and a non-scaled version of the specie's density.
+
+The electrostatic flux is defined as
+
+\begin{equation}
+\Gamma_{j} = \text{sign}_{j} \ \text{-} \nabla (V) n_{j} - \nabla (n_{j})
+\end{equation}
+
+Where $\Gamma_{j}$ is the flux assuming drift-diffusion formulation, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species),
+$V$ is the potential, and $n_{j}$ is the density.
+
+!alert note
+When calculating the drift-diffusion flux for scaled densities and non-unity coefficients, please refer to [`TotalFlux`](/auxkernels/TotalFlux.md).
 
 ## Example Input File Syntax
 

--- a/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
+++ b/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
@@ -20,11 +20,11 @@ $V$ is the potential, and $n_{j}$ is the density.
 When calculating the drift-diffusion flux for scaled densities and non-unity coefficients, please refer to [`TotalFlux`](/auxkernels/TotalFlux.md).
 
 !alert warning title=Undocumented Test
-The DriftDiffusionFluxAux does not have a formulized test, yet. For this reason,
-users should be aware of unforseen debugs when using DriftDiffusionFluxAux. To
-report debug or discuss future contributions to Zapdos, please refer to the
+The DriftDiffusionFluxAux does not have a formalized test, yet. For this reason,
+users should be aware of unforeseen bugs when using DriftDiffusionFluxAux. To
+report bugs or discuss future contributions to Zapdos, please refer to the
 [Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
-For standards of have to contribute to Zapdos and the MOOSE framework,
+For standards of how to contribute to Zapdos and the MOOSE framework,
 please refer to the [MOOSE Contributing page](framework/contributing.md).
 
 ## Example Input File Syntax

--- a/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
+++ b/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
@@ -16,7 +16,7 @@ assumes a mobility and diffusion coefficient of unity, the electrostatic approxi
 The electrostatic flux is defined as
 
 \begin{equation}
-\Gamma_{j} = \text{sign}_{j} \ \text{-} \nabla (V) n_{j} - \nabla (n_{j})
+\Gamma_{j} =  \text{sign}_{j}  \left( \text{-}\nabla V\right) n_{j} - \nabla (n_{j})
 \end{equation}
 
 Where $\Gamma_{j}$ is the flux assuming drift-diffusion formulation, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species),

--- a/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
+++ b/doc/content/source/auxkernels/DriftDiffusionFluxAux.md
@@ -1,11 +1,5 @@
 # DriftDiffusionFluxAux
 
-!alert construction title=Undocumented Class
-The DriftDiffusionFluxAux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/DriftDiffusionFluxAux
 
 ## Overview
@@ -25,9 +19,30 @@ $V$ is the potential, and $n_{j}$ is the density.
 !alert note
 When calculating the drift-diffusion flux for scaled densities and non-unity coefficients, please refer to [`TotalFlux`](/auxkernels/TotalFlux.md).
 
+!alert warning title=Undocumented Test
+The DriftDiffusionFluxAux does not have a formulized test, yet. For this reason,
+users should be aware of unforseen debugs when using DriftDiffusionFluxAux. To
+report debug or discuss future contributions to Zapdos, please refer to the
+[Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
+For standards of have to contribute to Zapdos and the MOOSE framework,
+please refer to the [MOOSE Contributing page](framework/contributing.md).
+
 ## Example Input File Syntax
 
 !! Describe and include an example of how to use the DriftDiffusionFluxAux object.
+
+```text
+[AuxKernels]
+  [Electron_Flux]
+    type = DriftDiffusionFluxAux
+    variable = electron_flux
+    u = electrons
+    potential =  potential
+    positive_charge = false
+    component = 0
+  []
+[]
+```
 
 !syntax parameters /AuxKernels/DriftDiffusionFluxAux
 

--- a/doc/content/source/auxkernels/EFieldAdvAux.md
+++ b/doc/content/source/auxkernels/EFieldAdvAux.md
@@ -10,14 +10,14 @@ assumes the electrostatic approximation for the electric field.
 The advective flux is defined as
 
 \begin{equation}
-\Gamma_{Advection}  = \text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j}
+\Gamma_{\text{Advection}}  = \text{sign}_{j} \mu_{j} \left( \text{-} \nabla V\right) n_{j}
 \end{equation}
 
-Where $\Gamma$ is the advective flux, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient, $V$ is the potential, and $n_{j}$ is the density. When converting the density to logarithmic form and applying a scaling factor of the mesh,
+Where $\Gamma_{\text{Advection}}$ is the advective flux, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient, $V$ is the potential, and $n_{j}$ is the density. When converting the density to logarithmic form and applying a scaling factor of the mesh,
 `EFieldAdvAux` is defined as
 
 \begin{equation}
-\Gamma_{Advection}  = N_{A} \text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j})
+\Gamma_{\text{Advection}}  = N_{A} \text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j})
 \end{equation}
 
 Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is Avogadro's

--- a/doc/content/source/auxkernels/EFieldAdvAux.md
+++ b/doc/content/source/auxkernels/EFieldAdvAux.md
@@ -1,20 +1,34 @@
 # EFieldAdvAux
 
-!alert construction title=Undocumented Class
-The EFieldAdvAux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/EFieldAdvAux
 
 ## Overview
 
-!! Replace these lines with information regarding the EFieldAdvAux object.
+`EFieldAdvAux` returns electric field driven advective flux of defined species in logarithmic form. `EFieldAdvAux`
+assumes the electrostatic approximation for the electric field.
+
+The advective flux is defined as
+
+\begin{equation}
+\Gamma_{Advection}  = \text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j}
+\end{equation}
+
+Where $\Gamma$ is the advective flux, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient, $V$ is the potential, and $n_{j}$ is the density. When converting the density to logarithmic form and applying a scaling factor of the mesh,
+`EFieldAdvAux` is defined as
+
+\begin{equation}
+\Gamma_{Advection}  = N_{A} \text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j})
+\end{equation}
+
+Where $N_{j}$ is the molar density of the specie in logarithmic form, $N_{A}$ is Avogadro's
+number, $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the EFieldAdvAux object.
+An example of how to use `EFieldAdvAux` can be found in the
+test file `mean_en.i`.
+
+!listing test/tests/1d_dc/mean_en.i block=AuxKernels/EFieldAdvAux_em
 
 !syntax parameters /AuxKernels/EFieldAdvAux
 

--- a/doc/content/source/auxkernels/Efield.md
+++ b/doc/content/source/auxkernels/Efield.md
@@ -9,10 +9,10 @@
 The formulation of `Efield` is defined as
 
 \begin{equation}
-E_{comp.} = \frac{\text{-} \nabla_{comp.} (V) \ V_{c}}{l_{c}}
+E_{\text{comp.}} = \frac{\text{-} \nabla_{\text{comp.}} (V) \ V_{c}}{l_{c}}
 \end{equation}
 
-Where $E_{comp.}$ is a component of the electric field, $V$ is the potential, $V_{c}$ is the
+Where $E_{\text{comp.}}$ is a component of the electric field, $V$ is the potential, $V_{c}$ is the
 scaling factor of the potential , and $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax

--- a/doc/content/source/auxkernels/Efield.md
+++ b/doc/content/source/auxkernels/Efield.md
@@ -1,20 +1,26 @@
 # Efield
 
-!alert construction title=Undocumented Class
-The Efield has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/Efield
 
 ## Overview
 
-!! Replace these lines with information regarding the Efield object.
+`Efield` returns a component of the electrostatic electric field.
+
+The formulation of `Efield` is defined as
+
+\begin{equation}
+E_{comp.} = \frac{\text{-} \nabla_{comp.} (V) \ V_{c}}{l_{c}}
+\end{equation}
+
+Where $E_{comp.}$ is a component of the electric field, $V$ is the potential, $V_{c}$ is the
+scaling factor of the potential , and $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the Efield object.
+An example of how to use `Efield` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/Efield_calc
 
 !syntax parameters /AuxKernels/Efield
 

--- a/doc/content/source/auxkernels/ElectronTemperature.md
+++ b/doc/content/source/auxkernels/ElectronTemperature.md
@@ -1,20 +1,35 @@
 # ElectronTemperature
 
-!alert construction title=Undocumented Class
-The ElectronTemperature has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/ElectronTemperature
 
 ## Overview
 
-!! Replace these lines with information regarding the ElectronTemperature object.
+`ElectronTemperature` returns the electron temperature.
+
+The electron temperature is defined as
+
+\begin{equation}
+T_{e} = \frac{2}{3} \frac{n_{\varepsilon}}{n_{e}}
+\end{equation}
+
+Where $T_{e}$ is the electron temperature, $n_{\varepsilon}$ is the mean energy density
+of the electrons, and $n_{e}$ is the electron density.
+When converting the density to logarithmic form,
+`ElectronTemperature` is defined as
+
+\begin{equation}
+T_{e} = \frac{2}{3} \exp(N_{\varepsilon} - N_{e})
+\end{equation}
+
+Where $N_{\varepsilon}$ is the electron mean energy density in logarithmic form
+and $N_{e}$ is the electron density in logarithmic form.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the ElectronTemperature object.
+An example of how to use `ElectronTemperature` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/Te
 
 !syntax parameters /AuxKernels/ElectronTemperature
 

--- a/doc/content/source/auxkernels/Position.md
+++ b/doc/content/source/auxkernels/Position.md
@@ -1,20 +1,20 @@
 # Position
 
-!alert construction title=Undocumented Class
-The Position has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/Position
 
 ## Overview
 
-!! Replace these lines with information regarding the Position object.
+`Position` returns the characteristic scaling length for a given direction. Zapdos
+users can uniformly scale the position units for a given set of equations. This means
+a user can construct a normalized mesh of some factor and scale all equations to
+that same factor. `Position` is then used to plot against any spatial results.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the Position object.
+An example of how to use `Position` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/x_g
 
 !syntax parameters /AuxKernels/Position
 

--- a/doc/content/source/auxkernels/PowerDep.md
+++ b/doc/content/source/auxkernels/PowerDep.md
@@ -34,10 +34,10 @@ of the potential.
 For the case where artificial diffusion is introduced to the charge specie flux, an additional term is included, such that:
 
 \begin{equation}
-\Gamma_{j\text{, Total}} = \Gamma_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\Gamma_{j\text{, Total}} = \Gamma_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_\text{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
 \end{equation}
 
-Where $h_{max}$ is the max length of the current element.
+Where $h_\text{max}$ is the max length of the current element.
 
 ## Example Input File Syntax
 

--- a/doc/content/source/auxkernels/PowerDep.md
+++ b/doc/content/source/auxkernels/PowerDep.md
@@ -11,18 +11,18 @@ assumes the electrostatic approximation for the electric field.
 The power deposited by Joule Heating is defined as
 
 \begin{equation}
-P_{Joule Heating} = \Gamma_{j} \cdot \text{-} \nabla (V) \\
+P_{\text{Joule Heating}} = \Gamma_{j} \cdot \text{-} \nabla (V) \\
 \\[10pt]
-\Gamma_{j} = q_{j} (\text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j}))
+\Gamma_{j} = q_{j} (\text{sign}_{j} \mu_{j} \left( \text{-} \nabla V\right) n_{j} - D_{j} \nabla (n_{j}))
 \end{equation}
 
-Where $P$ is the power deposited by Joule heating, $q_{j}$ is the charge of the species, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient,
+Where $P_{\text{Joule Heating}}$ is the power deposited by Joule heating, $q_{j}$ is the charge of the species, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient,
 $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient.
 When converting the density to log form and applying a scaling factor of the mesh / voltage,
 `PowerDep` is defined as
 
 \begin{equation}
-P_{Joule Heating} = \Gamma_{j}  \cdot \frac{\text{-} \nabla (V) V_{c}}{l_{c}} \\
+P_{\text{Joule Heating}} = \Gamma_{j}  \cdot \frac{\text{-} \nabla (V) V_{c}}{l_{c}} \\
 \\[10pt]
 \Gamma_{j} = q_{j} N_{A} \left( \text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j}) - D_{j} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}} \right)
 \end{equation}
@@ -34,7 +34,7 @@ of the potential.
 For the case where artificial diffusion is introduced to the charge specie flux, an additional term is included, such that:
 
 \begin{equation}
-\Gamma_{j Total} = \Gamma_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\Gamma_{j\text{, Total}} = \Gamma_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
 \end{equation}
 
 Where $h_{max}$ is the max length of the current element.

--- a/doc/content/source/auxkernels/PowerDep.md
+++ b/doc/content/source/auxkernels/PowerDep.md
@@ -1,20 +1,50 @@
 # PowerDep
 
-!alert construction title=Undocumented Class
-The PowerDep has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/PowerDep
 
 ## Overview
 
-!! Replace these lines with information regarding the PowerDep object.
+`PowerDep` returns the amount of power deposited into a user specified specie by
+Joule Heating. `PowerDep`
+assumes the electrostatic approximation for the electric field.
+
+The power deposited by Joule Heating is defined as
+
+\begin{equation}
+P_{Joule Heating} = \Gamma_{j} \cdot \text{-} \nabla (V) \\
+\\[10pt]
+\Gamma_{j} = q_{j} (\text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j}))
+\end{equation}
+
+Where $P$ is the power deposited by Joule heating, $q_{j}$ is the charge of the species, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species), $\mu_{j}$ is the mobility coefficient,
+$V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient.
+When converting the density to log form and applying a scaling factor of the mesh / voltage,
+`PowerDep` is defined as
+
+\begin{equation}
+P_{Joule Heating} = \Gamma_{j}  \cdot \frac{\text{-} \nabla (V) V_{c}}{l_{c}} \\
+\\[10pt]
+\Gamma_{j} = q_{j} N_{A} \left( \text{sign}_{j} \mu_{j} \frac{\text{-} \nabla (V)}{l_{c}} \exp(N_{j}) - D_{j} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}} \right)
+\end{equation}
+
+Where $N_{j}$ is the molar density of the specie in log form, $N_{A}$ is Avogadro's
+number, $l_{c}$ is the scaling factor of the mesh, and $V_{c}$ is the scaling factor
+of the potential.
+
+For the case where artificial diffusion is introduced to the charge specie flux, an additional term is included, such that:
+
+\begin{equation}
+\Gamma_{j Total} = \Gamma_{j} + q_{j} N_{A} \mu_{j} \frac{\text{-}\lVert \nabla (V) \rVert_{2}}{l_{c}} \frac{h_{max}}{2} \exp(N_{j}) \frac{\nabla (N_{j})}{l_{c}}
+\end{equation}
+
+Where $h_{max}$ is the max length of the current element.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the PowerDep object.
+An example of how to use `PowerDep` can be found in the
+test file `mean_en.i`.
+
+!listing test/tests/1d_dc/mean_en.i block=AuxKernels/PowerDep_em
 
 !syntax parameters /AuxKernels/PowerDep
 

--- a/doc/content/source/auxkernels/ProcRate.md
+++ b/doc/content/source/auxkernels/ProcRate.md
@@ -4,22 +4,22 @@
 
 ## Overview
 
-`ProcRate` returns the production rate for chemistry reactions determined by Townsend coefficients in units of $\frac{\#}{m^{3}s}$. `ProcRate`
+`ProcRate` returns the production rate for chemistry reactions determined by Townsend coefficients in units of #/m$^{3}$s. `ProcRate`
 assumes the electrostatic approximation for the current.
 
 The production rate is defined as
 
 \begin{equation}
-S_{Townsend} = \alpha_{j} (\mu_{e} \nabla (V) n_{e} - D_{e} \nabla (n_{e}))
+S_{\text{Townsend}} = \alpha_{j} (\mu_{e} \left( \nabla -V\right) n_{e} - D_{e} \nabla (n_{e}))
 \end{equation}
 
-Where $S_{Townsend}$ is the production rate determined by Townsend coefficients, $\alpha_{j}$ is the Townsend coefficient for the reaction, $\mu_{e}$ is the mobility coefficient,
+Where $S_{\text{Townsend}}$ is the production rate determined by Townsend coefficients, $\alpha_{j}$ is the Townsend coefficient for the reaction, $\mu_{e}$ is the mobility coefficient,
 $V$ is the potential, $n_{e}$ is the electron density, and $D_{e}$ is the diffusion coefficient.
 When converting the density to logarithmic form and applying a scaling factor of the mesh,
 `ProcRate` is defined as
 
 \begin{equation}
-S_{Townsend} = \alpha_{j} N_{A} \left(\mu_{e} \frac{\nabla (V)}{l_{c}} \exp(N_{e}) - D_{e} \exp(N_{e}) \frac{\nabla (N_{e})}{l_{c}} \right)
+S_{\text{Townsend}} = \alpha_{j} N_{A} \left(\mu_{e} \frac{-\nabla (V)}{l_{c}} \exp(N_{e}) - D_{e} \exp(N_{e}) \frac{\nabla (N_{e})}{l_{c}} \right)
 \end{equation}
 
 Where $N_{e}$ is the molar density of the electrons in logarithmic form, $N_{A}$ is Avogadro's

--- a/doc/content/source/auxkernels/ProcRate.md
+++ b/doc/content/source/auxkernels/ProcRate.md
@@ -1,20 +1,36 @@
 # ProcRate
 
-!alert construction title=Undocumented Class
-The ProcRate has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/ProcRate
 
 ## Overview
 
-!! Replace these lines with information regarding the ProcRate object.
+`ProcRate` returns the production rate for chemistry reactions determined by Townsend coefficients in units of $\frac{\#}{m^{3}s}$. `ProcRate`
+assumes the electrostatic approximation for the current.
+
+The production rate is defined as
+
+\begin{equation}
+S_{Townsend} = \alpha_{j} (\mu_{e} \nabla (V) n_{e} - D_{e} \nabla (n_{e}))
+\end{equation}
+
+Where $S_{Townsend}$ is the production rate determined by Townsend coefficients, $\alpha_{j}$ is the Townsend coefficient for the reaction, $\mu_{e}$ is the mobility coefficient,
+$V$ is the potential, $n_{e}$ is the electron density, and $D_{e}$ is the diffusion coefficient.
+When converting the density to logarithmic form and applying a scaling factor of the mesh,
+`ProcRate` is defined as
+
+\begin{equation}
+S_{Townsend} = \alpha_{j} N_{A} \left(\mu_{e} \frac{\nabla (V)}{l_{c}} \exp(N_{e}) - D_{e} \exp(N_{e}) \frac{\nabla (N_{e})}{l_{c}} \right)
+\end{equation}
+
+Where $N_{e}$ is the molar density of the electrons in logarithmic form, $N_{A}$ is Avogadro's
+number, $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the ProcRate object.
+An example of how to use `ProcRate` can be found in the
+test file `mean_en.i`.
+
+!listing test/tests/1d_dc/mean_en.i block=AuxKernels/ProcRate_el
 
 !syntax parameters /AuxKernels/ProcRate
 

--- a/doc/content/source/auxkernels/ProcRateForRateCoeff.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeff.md
@@ -1,20 +1,37 @@
 # ProcRateForRateCoeff
 
-!alert construction title=Undocumented Class
-The ProcRateForRateCoeff has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/ProcRateForRateCoeff
 
 ## Overview
 
-!! Replace these lines with information regarding the ProcRateForRateCoeff object.
+`ProcRateForRateCoeff` returns the production rate for a two body reactions determined by rate coefficients in units of $\frac{\#}{m^{3}s}$.
+
+The production rate is defined as
+
+\begin{equation}
+S_{Rate} = k n_{i} n_{j}
+\end{equation}
+
+Where $S_{Rate}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, and $n_{j}$ is the density for the second species.
+When converting the density to logarithmic form,
+`ProcRateForRateCoeff` is defined as
+
+\begin{equation}
+S_{Rate} = k N_{A}  \exp(N_{i}) \exp(N_{j})
+\end{equation}
+
+Where $N_{i}$ and $N_{j}$ is the molar density of the species in logarithmic form, and $N_{A}$ is Avogadro's
+number.
+
+!alert note
+When coupling Zapdos with CRANE, `ProcRateForRateCoeff` serves the same function as CRANE's [`ReactionRateSecondOrderLog`](/auxkernels/ReactionRateSecondOrderLog.md).
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the ProcRateForRateCoeff object.
+An example of how to use `ProcRateForRateCoeff` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/emRate
 
 !syntax parameters /AuxKernels/ProcRateForRateCoeff
 

--- a/doc/content/source/auxkernels/ProcRateForRateCoeff.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeff.md
@@ -4,20 +4,20 @@
 
 ## Overview
 
-`ProcRateForRateCoeff` returns the production rate for a two body reactions determined by rate coefficients in units of $\frac{\#}{m^{3}s}$.
+`ProcRateForRateCoeff` returns the production rate for a two body reactions determined by rate coefficients in units of #/m$^{3}$s.
 
 The production rate is defined as
 
 \begin{equation}
-S_{Rate} = k n_{i} n_{j}
+S_{\text{Rate}} = k n_{i} n_{j}
 \end{equation}
 
-Where $S_{Rate}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, and $n_{j}$ is the density for the second species.
+Where $S_{\text{Rate}}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, and $n_{j}$ is the density for the second species.
 When converting the density to logarithmic form,
 `ProcRateForRateCoeff` is defined as
 
 \begin{equation}
-S_{Rate} = k N_{A}  \exp(N_{i}) \exp(N_{j})
+S_{\text{Rate}} = k N_{A}  \exp(N_{i}) \exp(N_{j})
 \end{equation}
 
 Where $N_{i}$ and $N_{j}$ is the molar density of the species in logarithmic form, and $N_{A}$ is Avogadro's

--- a/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
@@ -1,20 +1,37 @@
 # ProcRateForRateCoeffThreeBody
 
-!alert construction title=Undocumented Class
-The ProcRateForRateCoeffThreeBody has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/ProcRateForRateCoeffThreeBody
 
 ## Overview
 
-!! Replace these lines with information regarding the ProcRateForRateCoeffThreeBody object.
+`ProcRateForRateCoeffThreeBody` returns the production rate for a three body reactions determined by rate coefficients in units of $\frac{\#}{m^{3}s}$.
+
+The production rate is defined as
+
+\begin{equation}
+S_{Rate} =  k n_{i} n_{j} n_{k}
+\end{equation}
+
+Where $S_{Rate}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, $n_{j}$ is the density for the second species, and $n_{k}$ is the density for the third species.
+When converting the density to logarithmic form,
+`ProcRateForRateCoeffThreeBody` is defined as
+
+\begin{equation}
+S_{Rate} = k N_{A}  \exp(N_{i}) \exp(N_{j}) \exp(N_{k})
+\end{equation}
+
+Where $N_{k}$, $N_{j}$ and $N_{k}$ is the molar density of the species in logarithmic form, and $N_{A}$ is Avogadro's
+number.
+
+!alert note
+When coupling Zapdos with CRANE, `ProcRateForRateCoeffThreeBody` serves the same function as CRANE's [`ReactionRateThirdOrderLog`](/auxkernels/ReactionRateThirdOrderLog.md).
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the ProcRateForRateCoeffThreeBody object.
+An example of how to use `ProcRateForRateCoeffThreeBody` can be found in the
+test file `Lymberopoulos_with_argon_metastables.i`.
+
+!listing test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i block=AuxKernels/ThreeBRate
 
 !syntax parameters /AuxKernels/ProcRateForRateCoeffThreeBody
 

--- a/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
+++ b/doc/content/source/auxkernels/ProcRateForRateCoeffThreeBody.md
@@ -4,20 +4,20 @@
 
 ## Overview
 
-`ProcRateForRateCoeffThreeBody` returns the production rate for a three body reactions determined by rate coefficients in units of $\frac{\#}{m^{3}s}$.
+`ProcRateForRateCoeffThreeBody` returns the production rate for a three body reactions determined by rate coefficients in units of #/m$^{3}$s.
 
 The production rate is defined as
 
 \begin{equation}
-S_{Rate} =  k n_{i} n_{j} n_{k}
+S_{\text{Rate}} =  k n_{i} n_{j} n_{k}
 \end{equation}
 
-Where $S_{Rate}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, $n_{j}$ is the density for the second species, and $n_{k}$ is the density for the third species.
+Where $S_{\text{Rate}}$ is the production rate determined by rate coefficients, $k$ is the rate coefficient for the reaction, $n_{j}$ is the density for the first species, $n_{j}$ is the density for the second species, and $n_{k}$ is the density for the third species.
 When converting the density to logarithmic form,
 `ProcRateForRateCoeffThreeBody` is defined as
 
 \begin{equation}
-S_{Rate} = k N_{A}  \exp(N_{i}) \exp(N_{j}) \exp(N_{k})
+S_{\text{Rate}} = k N_{A}  \exp(N_{i}) \exp(N_{j}) \exp(N_{k})
 \end{equation}
 
 Where $N_{k}$, $N_{j}$ and $N_{k}$ is the molar density of the species in logarithmic form, and $N_{A}$ is Avogadro's

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -26,7 +26,7 @@ Where $\sigma_{t}$ is the surface charge of the current time step, $\sigma_{t-1}
 !alert note
 When calculating the surface charge for scaled densities, non-unity coefficients, and includes contribution due to electron flux, please refer to [`ADSurfaceCharge`](/materials/ADSurfaceCharge.md).
 
-!alert warning title=Undocumented Test
+!alert warning title=Untested Class
 The Sigma does not have a formulized test, yet. For this reason,
 users should be aware of unforseen debugs when using Sigma. To
 report debug or discuss future contributions to Zapdos, please refer to the

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -10,7 +10,27 @@ documentation clear for users.
 
 ## Overview
 
-!! Replace these lines with information regarding the Sigma object.
+`Sigma` calculates a simplifed version of the surface charge on a boundary due to the advection flux of an ion species. `Sigma` assumes a mobility coefficient of unity, the electrostatic approximation for the electric field, and a non-scaled version of the specie's density.
+
+The surface charge is defined as
+
+\begin{equation}
+\sigma = \int \Gamma_{i} \cdot \textbf{n} \ \text{d}t \\[10pt]
+\Gamma_{i} = \text{-} \nabla (V) n_{i}
+\end{equation}
+
+Where $\sigma$ is the surface charge, $\Gamma_{i}$ is the advective flux of the ions, $\textbf{n}$ is the outward pointing unit normal on the boundary, $V$ is the potential, and $n_{i}$ is the ion density.
+
+Using the midpoint method for integration, the surface charge calculation becomes
+
+\begin{equation}
+\sigma_{t} = \sigma_{t-1} + \text{-} \nabla (V) n_{i}  \cdot \textbf{n} \ \text{d}t
+\end{equation}
+
+Where $\sigma_{t}$ is the surface charge of the current time step, $\sigma_{t-1}$ is the surface of the previous time step, and $\text{d}t$ is the difference between time steps.
+
+!alert note
+When calculating the surface charge for scaled densities, non-unity coefficients, and includes contribution due to electron flux, please refer to [`ADSurfaceCharge`](/materials/ADSurfaceCharge.md).
 
 ## Example Input File Syntax
 

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -1,11 +1,5 @@
 # Sigma
 
-!alert construction title=Undocumented Class
-The Sigma has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/Sigma
 
 ## Overview
@@ -32,9 +26,28 @@ Where $\sigma_{t}$ is the surface charge of the current time step, $\sigma_{t-1}
 !alert note
 When calculating the surface charge for scaled densities, non-unity coefficients, and includes contribution due to electron flux, please refer to [`ADSurfaceCharge`](/materials/ADSurfaceCharge.md).
 
+!alert warning title=Undocumented Test
+The Sigma does not have a formulized test, yet. For this reason,
+users should be aware of unforseen debugs when using Sigma. To
+report debug or discuss future contributions to Zapdos, please refer to the
+[Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
+For standards of have to contribute to Zapdos and the MOOSE framework,
+please refer to the [MOOSE Contributing page](framework/contributing.md).
+
 ## Example Input File Syntax
 
 !! Describe and include an example of how to use the Sigma object.
+
+```text
+[AuxKernels]
+  [Surface_Charge]
+    type = Sigma
+    variable = charge
+    n = ions
+    potential =  potential
+  []
+[]
+```
 
 !syntax parameters /AuxKernels/Sigma
 

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -24,7 +24,7 @@ Where $\sigma$ is the surface charge, $\Gamma_{i}$ is the advective flux of the 
 Using the midpoint method for integration, the surface charge calculation becomes
 
 \begin{equation}
-\sigma_{t} = \sigma_{t-1} + \text{-} \nabla (V) n_{i}  \cdot \textbf{n} \ \text{d}t
+\sigma_{t} = \sigma_{t-1} - \nabla (V) n_{i}  \cdot \textbf{n} \ \text{d}t
 \end{equation}
 
 Where $\sigma_{t}$ is the surface charge of the current time step, $\sigma_{t-1}$ is the surface of the previous time step, and $\text{d}t$ is the difference between time steps.

--- a/doc/content/source/auxkernels/Sigma.md
+++ b/doc/content/source/auxkernels/Sigma.md
@@ -27,11 +27,11 @@ Where $\sigma_{t}$ is the surface charge of the current time step, $\sigma_{t-1}
 When calculating the surface charge for scaled densities, non-unity coefficients, and includes contribution due to electron flux, please refer to [`ADSurfaceCharge`](/materials/ADSurfaceCharge.md).
 
 !alert warning title=Untested Class
-The Sigma does not have a formulized test, yet. For this reason,
-users should be aware of unforseen debugs when using Sigma. To
-report debug or discuss future contributions to Zapdos, please refer to the
+The Sigma does not have a formalized test, yet. For this reason,
+users should be aware of unforeseen bugs when using Sigma. To
+report a bug or discuss future contributions to Zapdos, please refer to the
 [Zapdos GitHub Discussions page](https://github.com/shannon-lab/zapdos/discussions).
-For standards of have to contribute to Zapdos and the MOOSE framework,
+For standards of how to contribute to Zapdos and the MOOSE framework,
 please refer to the [MOOSE Contributing page](framework/contributing.md).
 
 ## Example Input File Syntax

--- a/doc/content/source/auxkernels/TM0CylindricalErAux.md
+++ b/doc/content/source/auxkernels/TM0CylindricalErAux.md
@@ -1,20 +1,25 @@
 # TM0CylindricalErAux
 
-!alert construction title=Undocumented Class
-The TM0CylindricalErAux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/TM0CylindricalErAux
 
 ## Overview
 
-!! Replace these lines with information regarding the TM0CylindricalErAux object.
+`TM0CylindricalErAux` calculates the radial component of the E-field based on the azimuthal component of the magnetic field. `TM0CylindricalErAux` assumes an axisymmetric transverse magnetic (TM) wave and negligible current density compared to the displacement current.
+
+The radial component of the displacement E-field for a TM$_{0}$ wave is defined as
+
+\begin{equation}
+E_{r} = \frac{\text{-} 1}{\omega \varepsilon_{0} \varepsilon_{r}} \frac{dH_{\phi}}{dz}
+\end{equation}
+
+Where $E_{r}$ is the radial component of the E-field, $H_{\phi}$ is the azimuthal component of the magnetic field, $\omega$ is the drive frequency, $\varepsilon_{0}$ is the permittivity of free space, and $\varepsilon_{r}$ is the relative permittivity of the medium.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the TM0CylindricalErAux object.
+An example of how to use `TM0CylindricalErAux` can be found in the
+test file `TM_steady.i`.
+
+!listing test/tests/TM10_circular_wg/TM_steady.i block=AuxKernels/Er
 
 !syntax parameters /AuxKernels/TM0CylindricalErAux
 

--- a/doc/content/source/auxkernels/TM0CylindricalEzAux.md
+++ b/doc/content/source/auxkernels/TM0CylindricalEzAux.md
@@ -1,20 +1,25 @@
 # TM0CylindricalEzAux
 
-!alert construction title=Undocumented Class
-The TM0CylindricalEzAux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/TM0CylindricalEzAux
 
 ## Overview
 
-!! Replace these lines with information regarding the TM0CylindricalEzAux object.
+`TM0CylindricalEzAux` calculates the axial component of the E-field based on the azimuthal component of the magnetic field. `TM0CylindricalEzAux` assumes an axisymmetric transverse magnetic (TM) wave and negligible current density compared to the displacement current.
+
+The axial component of the displacement E-field for a TM$_{0}$ wave is defined as
+
+\begin{equation}
+E_{z} = \frac{1}{\omega \varepsilon_{0} \varepsilon_{r}} \left( \frac{H_{\phi}}{r} + \frac{dH_{\phi}}{dr} \right)
+\end{equation}
+
+Where $E_{z}$ is the axial component of the E-field, $H_{\phi}$ is the azimuthal component of the magnetic field, $\omega$ is the drive frequency, $r$ is the radial distance from the axial centerline, $\varepsilon_{0}$ is the permittivity of free space, and $\varepsilon_{r}$ is the relative permittivity of the medium.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the TM0CylindricalEzAux object.
+An example of how to use `TM0CylindricalEzAux` can be found in the
+test file `TM_steady.i`.
+
+!listing test/tests/TM10_circular_wg/TM_steady.i block=AuxKernels/Electric_z
 
 !syntax parameters /AuxKernels/TM0CylindricalEzAux
 

--- a/doc/content/source/auxkernels/TotalFlux.md
+++ b/doc/content/source/auxkernels/TotalFlux.md
@@ -1,20 +1,32 @@
 # TotalFlux
 
-!alert construction title=Undocumented Class
-The TotalFlux has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /AuxKernels/TotalFlux
 
 ## Overview
 
-!! Replace these lines with information regarding the TotalFlux object.
+`TotalFlux` returns the total flux of a species in logarithmic form. `TotalFlux`
+assumes the electrostatic approximation for the electric field.
+
+The electrostatic flux is usually defined as
+
+\begin{equation}
+\Gamma = \text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j})
+\end{equation}
+
+Where $\Gamma$ is the flux assuming drift-diffusion formulation, $\mu_{j}$ is the mobility coefficient, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species, $\text{-}1$ for negatively charged species and $\text{0}$ for neutral species), $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient. When converting the density to logarithmic form, `TotalFlux` is defined as
+
+\begin{equation}
+\Gamma = \text{sign}_{j} \mu_{j} \text{-} \nabla (V) \exp(N_{j}) - D_{j} \exp(N_{j}) \nabla (N_{j})
+\end{equation}
+
+Where $N_{j}$ is the molar density of the specie in logarithmic form.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the TotalFlux object.
+An example of how to use `TotalFlux` can be found in the
+test file `mean_en.i`.
+
+!listing test/tests/1d_dc/mean_en.i block=AuxKernels/tot_flux_OHm
 
 !syntax parameters /AuxKernels/TotalFlux
 

--- a/doc/content/source/auxkernels/TotalFlux.md
+++ b/doc/content/source/auxkernels/TotalFlux.md
@@ -10,13 +10,13 @@ assumes the electrostatic approximation for the electric field.
 The electrostatic flux is usually defined as
 
 \begin{equation}
-\Gamma = \text{sign}_{j} \mu_{j} \ \text{-} \nabla (V) n_{j} - D_{j} \nabla (n_{j})
+\Gamma_{j} = \text{sign}_{j} \mu_{j} \left( \text{-} \nabla V \right) n_{j} - D_{j} \nabla (n_{j})
 \end{equation}
 
-Where $\Gamma$ is the flux assuming drift-diffusion formulation, $\mu_{j}$ is the mobility coefficient, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species, $\text{-}1$ for negatively charged species and $\text{0}$ for neutral species), $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient. When converting the density to logarithmic form, `TotalFlux` is defined as
+Where $\Gamma_{j}$ is the flux assuming drift-diffusion formulation, $\mu_{j}$ is the mobility coefficient, $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species, $\text{-}1$ for negatively charged species and $\text{0}$ for neutral species), $V$ is the potential, $n_{j}$ is the density, and $D_{j}$ is the diffusion coefficient. When converting the density to logarithmic form, `TotalFlux` is defined as
 
 \begin{equation}
-\Gamma = \text{sign}_{j} \mu_{j} \text{-} \nabla (V) \exp(N_{j}) - D_{j} \exp(N_{j}) \nabla (N_{j})
+\Gamma_{j} = \text{sign}_{j} \mu_{j} \left(\text{-} \nabla V\right) \exp(N_{j}) - D_{j} \exp(N_{j}) \nabla (N_{j})
 \end{equation}
 
 Where $N_{j}$ is the molar density of the specie in logarithmic form.

--- a/include/auxkernels/Current.h
+++ b/include/auxkernels/Current.h
@@ -24,6 +24,7 @@ public:
   virtual Real computeValue() override;
 
 protected:
+  int _component;
   Real _r_units;
 
   MooseVariable & _density_var;

--- a/include/auxkernels/Current.h
+++ b/include/auxkernels/Current.h
@@ -24,10 +24,10 @@ public:
   virtual Real computeValue() override;
 
 protected:
-  int _component;
-  Real _r_units;
+  const int _component;
+  const Real _r_units;
 
-  MooseVariable & _density_var;
+  const MooseVariable & _density_var;
   const VariableValue & _density_log;
   const VariableGradient & _grad_density_log;
   const VariableGradient & _grad_potential;

--- a/include/auxkernels/DiffusiveFlux.h
+++ b/include/auxkernels/DiffusiveFlux.h
@@ -23,8 +23,8 @@ public:
 protected:
   virtual Real computeValue() override;
 
-  int _component;
-  Real _r_units;
+  const int _component;
+  const Real _r_units;
 
   // Coupled variables
 

--- a/include/auxkernels/DiffusiveFlux.h
+++ b/include/auxkernels/DiffusiveFlux.h
@@ -23,6 +23,7 @@ public:
 protected:
   virtual Real computeValue() override;
 
+  int _component;
   Real _r_units;
 
   // Coupled variables

--- a/include/auxkernels/EFieldAdvAux.h
+++ b/include/auxkernels/EFieldAdvAux.h
@@ -23,8 +23,8 @@ public:
 protected:
   virtual Real computeValue() override;
 
-  int _component;
-  Real _r_units;
+  const int _component;
+  const Real _r_units;
 
   // Coupled variables
 

--- a/include/auxkernels/EFieldAdvAux.h
+++ b/include/auxkernels/EFieldAdvAux.h
@@ -23,6 +23,7 @@ public:
 protected:
   virtual Real computeValue() override;
 
+  int _component;
   Real _r_units;
 
   // Coupled variables

--- a/include/auxkernels/ProcRateForRateCoeffThreeBody.h
+++ b/include/auxkernels/ProcRateForRateCoeffThreeBody.h
@@ -25,7 +25,7 @@ public:
 protected:
   const VariableValue & _v;
   const VariableValue & _w;
-  const VariableValue & _vv;
+  const VariableValue & _x;
   const GenericMaterialProperty<Real, is_ad> & _reaction_coeff;
 };
 

--- a/include/auxkernels/TotalFlux.h
+++ b/include/auxkernels/TotalFlux.h
@@ -23,6 +23,7 @@ public:
   virtual Real computeValue() override;
 
 protected:
+  int _component;
   MooseVariable & _density_var;
   const VariableValue & _density_log;
   const VariableGradient & _grad_density_log;

--- a/include/auxkernels/TotalFlux.h
+++ b/include/auxkernels/TotalFlux.h
@@ -23,8 +23,8 @@ public:
   virtual Real computeValue() override;
 
 protected:
-  int _component;
-  MooseVariable & _density_var;
+  const int _component;
+  const MooseVariable & _density_var;
   const VariableValue & _density_log;
   const VariableGradient & _grad_density_log;
   const VariableGradient & _grad_potential;

--- a/src/auxkernels/AbsValueAux.C
+++ b/src/auxkernels/AbsValueAux.C
@@ -17,7 +17,7 @@ AbsValueAux::validParams()
 {
   InputParameters params = AuxKernel::validParams();
   params.addRequiredCoupledVar("u", "Variable we want absolute value of.");
-  params.addClassDescription("Returns the absolute value of variable");
+  params.addClassDescription("Returns the absolute value of the specified variable");
   return params;
 }
 

--- a/src/auxkernels/Current.C
+++ b/src/auxkernels/Current.C
@@ -23,7 +23,7 @@ CurrentTempl<is_ad>::validParams()
 {
   InputParameters params = AuxKernel::validParams();
 
-  params.addRequiredCoupledVar("density_log", "The electron density");
+  params.addRequiredCoupledVar("density_log", "The log of the species density");
   params.addRequiredCoupledVar("potential", "The potential");
   params.addParam<int>(
       "component", 0, "The component of the Current vector. (0 = x, 1 = y, 2 = z)");

--- a/src/auxkernels/Current.C
+++ b/src/auxkernels/Current.C
@@ -25,6 +25,7 @@ CurrentTempl<is_ad>::validParams()
 
   params.addRequiredCoupledVar("density_log", "The electron density");
   params.addRequiredCoupledVar("potential", "The potential");
+  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
   params.addParam<bool>(
       "art_diff", false, "Whether there is a current contribution from artificial diffusion.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
@@ -37,6 +38,7 @@ template <bool is_ad>
 CurrentTempl<is_ad>::CurrentTempl(const InputParameters & parameters)
   : AuxKernel(parameters),
 
+    _component(getParam<int>("component")),
     _r_units(1. / getParam<Real>("position_units")),
 
     _density_var(*getVar("density_log", 0)),
@@ -54,18 +56,18 @@ template <bool is_ad>
 Real
 CurrentTempl<is_ad>::computeValue()
 {
-  Real r =
-      _sgn[_qp] * 1.6e-19 * 6.02e23 *
-      (_sgn[_qp] * raw_value(_mu[_qp]) * -_grad_potential[_qp](0) * _r_units *
-           std::exp(_density_log[_qp]) -
-       raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) * _grad_density_log[_qp](0) * _r_units);
+  Real r = _sgn[_qp] * 1.6e-19 * 6.02e23 *
+           (_sgn[_qp] * raw_value(_mu[_qp]) * -_grad_potential[_qp](_component) * _r_units *
+                std::exp(_density_log[_qp]) -
+            raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) *
+                _grad_density_log[_qp](_component) * _r_units);
 
   if (_art_diff)
   {
     Real vd_mag = raw_value(_mu[_qp]) * _grad_potential[_qp].norm() * _r_units;
     Real delta = vd_mag * _current_elem->hmax() / 2.;
     r += _sgn[_qp] * 1.6e-19 * 6.02e23 * -delta * std::exp(_density_log[_qp]) *
-         _grad_density_log[_qp](0) * _r_units;
+         _grad_density_log[_qp](_component) * _r_units;
   }
 
   return r;

--- a/src/auxkernels/Current.C
+++ b/src/auxkernels/Current.C
@@ -25,12 +25,13 @@ CurrentTempl<is_ad>::validParams()
 
   params.addRequiredCoupledVar("density_log", "The electron density");
   params.addRequiredCoupledVar("potential", "The potential");
-  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
+  params.addParam<int>(
+      "component", 0, "The component of the Current vector. (0 = x, 1 = y, 2 = z)");
   params.addParam<bool>(
       "art_diff", false, "Whether there is a current contribution from artificial diffusion.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-      "Returns the electric current associated with the flux of defined species");
+      "Returns the electric current associated with the flux of the specified species");
   return params;
 }
 

--- a/src/auxkernels/DensityMoles.C
+++ b/src/auxkernels/DensityMoles.C
@@ -18,7 +18,7 @@ DensityMoles::validParams()
   InputParameters params = Density::validParams();
 
   params.addRequiredParam<bool>("use_moles", "Whether to convert from units of moles to #.");
-  params.addClassDescription("Returns physical densities in units of #/m^3");
+  params.addClassDescription("Returns physical densities in units of #/m$^3$");
   return params;
 }
 

--- a/src/auxkernels/DiffusiveFlux.C
+++ b/src/auxkernels/DiffusiveFlux.C
@@ -24,6 +24,7 @@ DiffusiveFluxTempl<is_ad>::validParams()
   InputParameters params = AuxKernel::validParams();
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
   params.addClassDescription("Returns the diffusive flux of defined species");
   return params;
 }
@@ -31,6 +32,7 @@ DiffusiveFluxTempl<is_ad>::validParams()
 template <bool is_ad>
 DiffusiveFluxTempl<is_ad>::DiffusiveFluxTempl(const InputParameters & parameters)
   : AuxKernel(parameters),
+    _component(getParam<int>("component")),
     _r_units(1. / getParam<Real>("position_units")),
 
     // Coupled variables
@@ -49,7 +51,7 @@ template <bool is_ad>
 Real
 DiffusiveFluxTempl<is_ad>::computeValue()
 {
-  return -raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) * _grad_density_log[_qp](0) *
+  return -raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) * _grad_density_log[_qp](_component) *
          _r_units * 6.02e23;
 }
 

--- a/src/auxkernels/DiffusiveFlux.C
+++ b/src/auxkernels/DiffusiveFlux.C
@@ -25,7 +25,7 @@ DiffusiveFluxTempl<is_ad>::validParams()
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
-  params.addClassDescription("Returns the diffusive flux of defined species");
+  params.addClassDescription("Returns the diffusive flux of the specified species");
   return params;
 }
 

--- a/src/auxkernels/DriftDiffusionFluxAux.C
+++ b/src/auxkernels/DriftDiffusionFluxAux.C
@@ -24,7 +24,7 @@ DriftDiffusionFluxAux::validParams()
                         "negative.");
   params.addRequiredCoupledVar("u", "The drift-diffusing species.");
   params.addParam<int>("component", 0, "The flux component you want to see.");
-  params.addClassDescription("Returns the drift-diffusion flux of defined species");
+  params.addClassDescription("Returns the drift-diffusion flux of the specified species");
   return params;
 }
 

--- a/src/auxkernels/EFieldAdvAux.C
+++ b/src/auxkernels/EFieldAdvAux.C
@@ -26,6 +26,7 @@ EFieldAdvAuxTempl<is_ad>::validParams()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
   params.addClassDescription("Returns the electric field driven advective flux of defined species");
   return params;
 }
@@ -33,6 +34,7 @@ EFieldAdvAuxTempl<is_ad>::validParams()
 template <bool is_ad>
 EFieldAdvAuxTempl<is_ad>::EFieldAdvAuxTempl(const InputParameters & parameters)
   : AuxKernel(parameters),
+    _component(getParam<int>("component")),
     _r_units(1. / getParam<Real>("position_units")),
 
     // Coupled variables
@@ -52,8 +54,8 @@ template <bool is_ad>
 Real
 EFieldAdvAuxTempl<is_ad>::computeValue()
 {
-  return _sgn[_qp] * raw_value(_mu[_qp]) * std::exp(_density_log[_qp]) * -_grad_potential[_qp](0) *
-         _r_units * 6.02e23;
+  return _sgn[_qp] * raw_value(_mu[_qp]) * std::exp(_density_log[_qp]) *
+         -_grad_potential[_qp](_component) * _r_units * 6.02e23;
 }
 
 template class EFieldAdvAuxTempl<false>;

--- a/src/auxkernels/EFieldAdvAux.C
+++ b/src/auxkernels/EFieldAdvAux.C
@@ -26,8 +26,9 @@ EFieldAdvAuxTempl<is_ad>::validParams()
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
-  params.addClassDescription("Returns the electric field driven advective flux of defined species");
+  params.addParam<int>("component", 0, "The component the EField Vector. (0 = x, 1 = y, 2 = z)");
+  params.addClassDescription(
+      "Returns the electric field driven advective flux of the specified species");
   return params;
 }
 

--- a/src/auxkernels/Position.C
+++ b/src/auxkernels/Position.C
@@ -19,9 +19,9 @@ Position::validParams()
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
   params.addClassDescription(
-      "Produces an elemental auxiliary variable useful for plotting against other"
-      "elemental auxiliary variables. Mesh points automatically output by Zapdos only work"
-      "for plotting nodal variables. Since almost all auxiliary variables are elemental, this"
+      "Produces an elemental auxiliary variable useful for plotting against other "
+      "elemental auxiliary variables. Mesh points automatically output by Zapdos only work "
+      "for plotting nodal variables. Since almost all auxiliary variables are elemental, this "
       "AuxKernel is very important");
   return params;
 }

--- a/src/auxkernels/ProcRate.C
+++ b/src/auxkernels/ProcRate.C
@@ -30,7 +30,7 @@ ProcRateTempl<is_ad>::validParams()
       "The process that we want to get the townsend coefficient for. Options are iz, ex, and el.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-      "Reaction rate for electron impact collisions in units of #/m^3s. User can pass "
+      "Reaction rate for electron impact collisions in units of #/m$^{3}$s. User can pass "
       "choice of elastic, excitation, or ionization Townsend coefficients");
   return params;
 }

--- a/src/auxkernels/ProcRate.C
+++ b/src/auxkernels/ProcRate.C
@@ -30,7 +30,7 @@ ProcRateTempl<is_ad>::validParams()
       "The process that we want to get the townsend coefficient for. Options are iz, ex, and el.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
-      "Reaction rate for electron impact collisions in units of #/m^3s. User can pass"
+      "Reaction rate for electron impact collisions in units of #/m^3s. User can pass "
       "choice of elastic, excitation, or ionization Townsend coefficients");
   return params;
 }

--- a/src/auxkernels/ProcRateForRateCoeff.C
+++ b/src/auxkernels/ProcRateForRateCoeff.C
@@ -25,7 +25,7 @@ ProcRateForRateCoeffTempl<is_ad>::validParams()
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-      "Reaction rate for two body collisions in units of #/m^3s. User can pass "
+      "Reaction rate for two body collisions in units of #/m$^{3}$s. User can pass "
       "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;

--- a/src/auxkernels/ProcRateForRateCoeff.C
+++ b/src/auxkernels/ProcRateForRateCoeff.C
@@ -25,7 +25,7 @@ ProcRateForRateCoeffTempl<is_ad>::validParams()
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-      "Reaction rate for two body collisions in units of #/m^3s. User can pass"
+      "Reaction rate for two body collisions in units of #/m^3s. User can pass "
       "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody.C
@@ -26,7 +26,7 @@ ProcRateForRateCoeffThreeBodyTempl<is_ad>::validParams()
   params.addCoupledVar("x", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-      "Reaction rate for three body collisions in units of #/m^3s. User can pass "
+      "Reaction rate for three body collisions in units of #/m$^{3}$s. User can pass "
       "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody.C
@@ -23,7 +23,7 @@ ProcRateForRateCoeffThreeBodyTempl<is_ad>::validParams()
 
   params.addCoupledVar("v", "The first variable that is reacting to create u.");
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
-  params.addCoupledVar("x", "The second variable that is reacting to create u.");
+  params.addCoupledVar("x", "The third variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
       "Reaction rate for three body collisions in units of #/m$^{3}$s. User can pass "

--- a/src/auxkernels/ProcRateForRateCoeffThreeBody.C
+++ b/src/auxkernels/ProcRateForRateCoeffThreeBody.C
@@ -23,10 +23,10 @@ ProcRateForRateCoeffThreeBodyTempl<is_ad>::validParams()
 
   params.addCoupledVar("v", "The first variable that is reacting to create u.");
   params.addCoupledVar("w", "The second variable that is reacting to create u.");
-  params.addCoupledVar("vv", "The second variable that is reacting to create u.");
+  params.addCoupledVar("x", "The second variable that is reacting to create u.");
   params.addRequiredParam<std::string>("reaction", "The full reaction equation.");
   params.addClassDescription(
-      "Reaction rate for three body collisions in units of #/m^3s. User can pass"
+      "Reaction rate for three body collisions in units of #/m^3s. User can pass "
       "choice of elastic, excitation, or ionization reaction rate coefficients");
 
   return params;
@@ -39,7 +39,7 @@ ProcRateForRateCoeffThreeBodyTempl<is_ad>::ProcRateForRateCoeffThreeBodyTempl(
 
     _v(coupledValue("v")),
     _w(coupledValue("w")),
-    _vv(coupledValue("vv")),
+    _x(coupledValue("x")),
     _reaction_coeff(
         getGenericMaterialProperty<Real, is_ad>("k_" + getParam<std::string>("reaction")))
 {
@@ -51,7 +51,7 @@ ProcRateForRateCoeffThreeBodyTempl<is_ad>::computeValue()
 {
 
   return 6.02e23 * raw_value(_reaction_coeff[_qp]) * std::exp(_v[_qp]) * std::exp(_w[_qp]) *
-         std::exp(_vv[_qp]);
+         std::exp(_x[_qp]);
 }
 
 typedef ProcRateForRateCoeffThreeBodyTempl<false> ProcRateForRateCoeffThreeBody;

--- a/src/auxkernels/Sigma.C
+++ b/src/auxkernels/Sigma.C
@@ -20,6 +20,9 @@ Sigma::validParams()
 
   params.addRequiredCoupledVar("n", "The density of the ions.");
   params.addRequiredCoupledVar("potential", "The potential");
+  params.addClassDescription(
+      "Calculates the surface charge due to a simplified version of the ion flux "
+      "to a boundary.");
   return params;
 }
 

--- a/src/auxkernels/TM0CylindricalErAux.C
+++ b/src/auxkernels/TM0CylindricalErAux.C
@@ -19,7 +19,7 @@ TM0CylindricalErAux::validParams()
   params.addRequiredCoupledVar("Hphi", "Magnetic field component Hphi.");
   params.addRequiredParam<Real>("f", "The drive frequency.");
   params.addParam<Real>("eps_r", 1., "The relative permittivity of the medium.");
-  params.addClassDescription("Calculates the radial E-field for a axisymmetric "
+  params.addClassDescription("Calculates the radial E-field for an axisymmetric "
                              "TM$_{0}$ wave.");
   return params;
 }

--- a/src/auxkernels/TM0CylindricalErAux.C
+++ b/src/auxkernels/TM0CylindricalErAux.C
@@ -19,6 +19,8 @@ TM0CylindricalErAux::validParams()
   params.addRequiredCoupledVar("Hphi", "Magnetic field component Hphi.");
   params.addRequiredParam<Real>("f", "The drive frequency.");
   params.addParam<Real>("eps_r", 1., "The relative permittivity of the medium.");
+  params.addClassDescription("Calculates the radial E-field for a axisymmetric "
+                             "TM$_{0}$ wave.");
   return params;
 }
 

--- a/src/auxkernels/TM0CylindricalEzAux.C
+++ b/src/auxkernels/TM0CylindricalEzAux.C
@@ -19,6 +19,8 @@ TM0CylindricalEzAux::validParams()
   params.addRequiredCoupledVar("Hphi", "Magnetic field component Hphi.");
   params.addRequiredParam<Real>("f", "The drive frequency.");
   params.addParam<Real>("eps_r", 1., "The relative permittivity of the medium.");
+  params.addClassDescription("Calculates the axial E-field for a axisymmetric "
+                             "TM$_{0}$ wave.");
   return params;
 }
 

--- a/src/auxkernels/TM0CylindricalEzAux.C
+++ b/src/auxkernels/TM0CylindricalEzAux.C
@@ -19,7 +19,7 @@ TM0CylindricalEzAux::validParams()
   params.addRequiredCoupledVar("Hphi", "Magnetic field component Hphi.");
   params.addRequiredParam<Real>("f", "The drive frequency.");
   params.addParam<Real>("eps_r", 1., "The relative permittivity of the medium.");
-  params.addClassDescription("Calculates the axial E-field for a axisymmetric "
+  params.addClassDescription("Calculates the axial E-field for an axisymmetric "
                              "TM$_{0}$ wave.");
   return params;
 }

--- a/src/auxkernels/TotalFlux.C
+++ b/src/auxkernels/TotalFlux.C
@@ -25,8 +25,9 @@ TotalFluxTempl<is_ad>::validParams()
 
   params.addRequiredCoupledVar("density_log", "The electron density");
   params.addRequiredCoupledVar("potential", "The potential");
-  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
-  params.addClassDescription("Returns the total flux of defined species");
+  params.addParam<int>(
+      "component", 0, "The component of the TotalFlux vector. (0 = x, 1 = y, 2 = z)");
+  params.addClassDescription("Returns the total flux of the specified species");
 
   return params;
 }

--- a/src/auxkernels/TotalFlux.C
+++ b/src/auxkernels/TotalFlux.C
@@ -25,6 +25,7 @@ TotalFluxTempl<is_ad>::validParams()
 
   params.addRequiredCoupledVar("density_log", "The electron density");
   params.addRequiredCoupledVar("potential", "The potential");
+  params.addParam<int>("component", 0, "The component of position. (0 = x, 1 = y, 2 = z)");
   params.addClassDescription("Returns the total flux of defined species");
 
   return params;
@@ -34,6 +35,7 @@ template <bool is_ad>
 TotalFluxTempl<is_ad>::TotalFluxTempl(const InputParameters & parameters)
   : AuxKernel(parameters),
 
+    _component(getParam<int>("component")),
     _density_var(*getVar("density_log", 0)),
     _density_log(coupledValue("density_log")),
     _grad_density_log(coupledGradient("density_log")),
@@ -48,8 +50,9 @@ template <bool is_ad>
 Real
 TotalFluxTempl<is_ad>::computeValue()
 {
-  return _sgn[_qp] * raw_value(_mu[_qp]) * -_grad_potential[_qp](0) * std::exp(_density_log[_qp]) -
-         raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) * _grad_density_log[_qp](0);
+  return _sgn[_qp] * raw_value(_mu[_qp]) * -_grad_potential[_qp](_component) *
+             std::exp(_density_log[_qp]) -
+         raw_value(_diff[_qp]) * std::exp(_density_log[_qp]) * _grad_density_log[_qp](_component);
 }
 
 template class TotalFluxTempl<false>;

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables.i
@@ -497,7 +497,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At100mTorr.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At100mTorr.i
@@ -523,7 +523,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At1Torr.i
+++ b/test/tests/Conference_Syntax_Tests/Lymberopoulos_with_argon_metastables_2D_At1Torr.i
@@ -524,7 +524,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/DriftDiffusionAction/2D_RF_Plasma_actions.i
+++ b/test/tests/DriftDiffusionAction/2D_RF_Plasma_actions.i
@@ -348,7 +348,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
 

--- a/test/tests/DriftDiffusionAction/2D_RF_Plasma_no_actions.i
+++ b/test/tests/DriftDiffusionAction/2D_RF_Plasma_no_actions.i
@@ -491,7 +491,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [e_temp]

--- a/test/tests/DriftDiffusionAction/RF_Plasma_actions.i
+++ b/test/tests/DriftDiffusionAction/RF_Plasma_actions.i
@@ -318,7 +318,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
 

--- a/test/tests/DriftDiffusionAction/RF_Plasma_no_actions.i
+++ b/test/tests/DriftDiffusionAction/RF_Plasma_no_actions.i
@@ -458,7 +458,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [e_temp]

--- a/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i
+++ b/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables.i
@@ -497,7 +497,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh.i
+++ b/test/tests/Lymberopoulos_rf_discharge/Lymberopoulos_with_argon_metastables_2D_At100mTorr_CoarseMesh.i
@@ -523,7 +523,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/accelerations/Acceleration_By_Averaging_main.i
+++ b/test/tests/accelerations/Acceleration_By_Averaging_main.i
@@ -460,7 +460,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/accelerations/Acceleration_By_Shooting_Method.i
+++ b/test/tests/accelerations/Acceleration_By_Shooting_Method.i
@@ -450,7 +450,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]

--- a/test/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
+++ b/test/tests/accelerations/Acceleration_By_Shooting_Method_SensitivityMatrix.i
@@ -563,7 +563,7 @@ dom0Scale = 25.4e-3
     variable = ThreeBRate
     v = Ar*
     w = Ar
-    vv = Ar
+    x = Ar
     reaction = 'Ar* + Ar + Ar -> Ar_2 + Ar'
   []
   [Te]


### PR DESCRIPTION
This will be the start of a series of PRs to update the documentation of the Zapdos website. This PR includes:

- Updated documentation to the Zapdos AuxKernel System.
- Edits in flux AuxKernels to allow for the output of any component of the flux.
- Minor edits in nomenclature for three body reactions to better a line with CRANE terminology.