### PR TITLE
BCs input parameters have been updated and deprecated for all AD BCs

### DIFF
--- a/include/bcs/CircuitDirichletPotential.h
+++ b/include/bcs/CircuitDirichletPotential.h
@@ -30,14 +30,14 @@ protected:
   /// The value for this BC
   const PostprocessorValue & _current;
   const Function & _surface_potential;
-  std::string _surface;
-  Real _resist;
-  Real _coulomb_charge;
-  Real _N_A;
-  std::string _potential_units;
-  Real _r_units;
-  bool _convert_moles;
-  Real _A;
+  const std::string _surface;
+  const Real _resist;
+  const Real _coulomb_charge;
+  const Real _N_A;
+  const std::string _potential_units;
+  const Real _r_units;
+  const bool _convert_moles;
+  const Real _A;
 
   Real _current_sign;
   Real _voltage_scaling;

--- a/include/bcs/DriftDiffusionDoNothingBC.h
+++ b/include/bcs/DriftDiffusionDoNothingBC.h
@@ -24,7 +24,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   const ADMaterialProperty<Real> & _mu;
   const MaterialProperty<Real> & _sign;

--- a/include/bcs/EconomouDielectricBC.h
+++ b/include/bcs/EconomouDielectricBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   const ADVariableValue & _mean_en;
   const ADVariableValue & _em;
@@ -37,7 +37,8 @@ protected:
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   const MaterialProperty<Real> & _massem;
-  std::vector<Real> _user_se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _user_se_coeff;
 
   const Real & _epsilon_d;
   const Real & _thickness;
@@ -50,8 +51,5 @@ protected:
 
   Real _voltage_scaling;
 
-  unsigned int _num_ions;
-  unsigned int _ip_index;
-  std::vector<unsigned int>::iterator _iter;
-  std::vector<unsigned int>::iterator _iter_potential;
+  const unsigned int _num_ions;
 };

--- a/include/bcs/EconomouDielectricBC.h
+++ b/include/bcs/EconomouDielectricBC.h
@@ -37,12 +37,13 @@ protected:
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   const MaterialProperty<Real> & _massem;
-  Real _user_se_coeff;
+  std::vector<Real> _user_se_coeff;
 
   const Real & _epsilon_d;
   const Real & _thickness;
   Real _a;
   ADRealVectorValue _ion_flux;
+  ADRealVectorValue _temp_flux;
   ADReal _v_thermal;
   ADRealVectorValue _em_flux;
   std::string _potential_units;

--- a/include/bcs/ElectronAdvectionDoNothingBC.h
+++ b/include/bcs/ElectronAdvectionDoNothingBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _position_units;
+  const Real _position_units;
 
   // Material properties
 

--- a/include/bcs/ElectronAdvectionDoNothingBC.h
+++ b/include/bcs/ElectronAdvectionDoNothingBC.h
@@ -32,5 +32,4 @@ protected:
 private:
   // Coupled variables
   const ADVariableGradient & _grad_potential;
-  const ADVariableValue & _mean_en;
 };

--- a/include/bcs/ElectronDiffusionDoNothingBC.h
+++ b/include/bcs/ElectronDiffusionDoNothingBC.h
@@ -24,7 +24,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   const ADMaterialProperty<Real> & _diffem;
 };

--- a/include/bcs/ElectronDiffusionDoNothingBC.h
+++ b/include/bcs/ElectronDiffusionDoNothingBC.h
@@ -27,5 +27,4 @@ protected:
   Real _r_units;
 
   const ADMaterialProperty<Real> & _diffem;
-  const ADVariableValue & _mean_en;
 };

--- a/include/bcs/ElectronTemperatureDirichletBC.h
+++ b/include/bcs/ElectronTemperatureDirichletBC.h
@@ -26,6 +26,6 @@ protected:
   virtual ADReal computeQpResidual() override;
 
   const ADVariableValue & _em;
-  Real _value;
-  Real _penalty_value;
+  const Real _value;
+  const Real _penalty_value;
 };

--- a/include/bcs/FieldEmissionBC.h
+++ b/include/bcs/FieldEmissionBC.h
@@ -39,15 +39,16 @@ protected:
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   std::vector<const ADMaterialProperty<Real> *> _Dip;
-  const std::vector<Real> _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   const MaterialProperty<Real> & _work_function;
   const MaterialProperty<Real> & _field_enhancement;
 
   Real _a;
   ADRealVectorValue _ion_flux;
-  Real _tau;
+  const Real _tau;
   bool _relax;
-  std::string _potential_units;
+  const std::string _potential_units;
 
   // Unique variables
 
@@ -55,4 +56,11 @@ protected:
   Real FE_a;
   Real FE_b;
   Real FE_c;
+
+  ADReal v;
+  ADReal f;
+  ADReal jFE;
+  ADReal jSE;
+  ADReal F;
+  Real _relaxation_Expr;
 };

--- a/include/bcs/FieldEmissionBC.h
+++ b/include/bcs/FieldEmissionBC.h
@@ -22,24 +22,24 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  Real _r;
+  const Real _r_units;
+  const Real _r;
 
+  const unsigned int _num_ions;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
-  const ADVariableValue & _mean_en;
-  MooseVariable & _ip_var;
-  const ADVariableValue & _ip;
-  const ADVariableGradient & _grad_ip;
+  std::vector<MooseVariable *> _ip_var;
+  std::vector<const ADVariableValue *> _ip;
+  std::vector<const ADVariableGradient *> _grad_ip;
 
   const ADMaterialProperty<Real> & _muem;
   const MaterialProperty<Real> & _massem;
   const MaterialProperty<Real> & _e;
-  const MaterialProperty<Real> & _sgnip;
-  const ADMaterialProperty<Real> & _muip;
-  const ADMaterialProperty<Real> & _Dip;
-  const MaterialProperty<Real> & _se_coeff;
+  std::vector<const MaterialProperty<Real> *> _sgnip;
+  std::vector<const ADMaterialProperty<Real> *> _muip;
+  std::vector<const ADMaterialProperty<Real> *> _Dip;
+  const std::vector<Real> _se_coeff;
   const MaterialProperty<Real> & _work_function;
   const MaterialProperty<Real> & _field_enhancement;
 

--- a/include/bcs/HagelaarElectronAdvectionBC.h
+++ b/include/bcs/HagelaarElectronAdvectionBC.h
@@ -22,8 +22,8 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  Real _r;
+  const Real _r_units;
+  const Real _r;
 
   // Coupled variables
   const ADVariableGradient & _grad_potential;

--- a/include/bcs/HagelaarEnergyAdvectionBC.h
+++ b/include/bcs/HagelaarEnergyAdvectionBC.h
@@ -22,8 +22,8 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  Real _r;
+  const Real _r_units;
+  const Real _r;
   const unsigned int _num_ions;
   // Coupled variables
 
@@ -35,7 +35,8 @@ protected:
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   std::vector<const ADMaterialProperty<Real> *> _Dip;
-  const std::vector<Real> _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   const Real _se_energy;
   const ADMaterialProperty<Real> & _mumean_en;
 

--- a/include/bcs/HagelaarEnergyAdvectionBC.h
+++ b/include/bcs/HagelaarEnergyAdvectionBC.h
@@ -24,23 +24,24 @@ protected:
 
   Real _r_units;
   Real _r;
-
+  const unsigned int _num_ions;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
-  MooseVariable & _ip_var;
-  const ADVariableValue & _ip;
-  const ADVariableGradient & _grad_ip;
+  std::vector<MooseVariable *> _ip_var;
+  std::vector<const ADVariableValue *> _ip;
+  std::vector<const ADVariableGradient *> _grad_ip;
 
-  const MaterialProperty<Real> & _sgnip;
-  const ADMaterialProperty<Real> & _muip;
-  const ADMaterialProperty<Real> & _Dip;
-  const MaterialProperty<Real> & _se_coeff;
-  const MaterialProperty<Real> & _se_energy;
+  std::vector<const MaterialProperty<Real> *> _sgnip;
+  std::vector<const ADMaterialProperty<Real> *> _muip;
+  std::vector<const ADMaterialProperty<Real> *> _Dip;
+  const std::vector<Real> _se_coeff;
+  const Real _se_energy;
   const ADMaterialProperty<Real> & _mumean_en;
 
   Real _a;
   ADRealVectorValue _ion_flux;
   Real _v_thermal;
   Real _n_gamma;
+  ADReal _bc_val;
 };

--- a/include/bcs/HagelaarEnergyBC.h
+++ b/include/bcs/HagelaarEnergyBC.h
@@ -30,8 +30,6 @@ protected:
 
   const MaterialProperty<Real> & _massem;
   const MaterialProperty<Real> & _e;
-  const MaterialProperty<Real> & _se_coeff;
-  const MaterialProperty<Real> & _se_energy;
   const ADMaterialProperty<Real> & _mumean_en;
 
   Real _a;

--- a/include/bcs/LogDensityDirichletBC.h
+++ b/include/bcs/LogDensityDirichletBC.h
@@ -25,5 +25,5 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _value;
+  const Real _value;
 };

--- a/include/bcs/LymberopoulosElectronBC.h
+++ b/include/bcs/LymberopoulosElectronBC.h
@@ -22,23 +22,18 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  Real _ks;
-  Real _gamma;
+  const Real _r_units;
+  const Real _ks;
+  const std::vector<Real> _gamma;
+  const unsigned int _num_ions;
 
   // Coupled variables
   const ADVariableGradient & _grad_potential;
   std::vector<MooseVariable *> _ion_var;
   std::vector<const ADVariableValue *> _ion;
 
-  Real _sign;
-
   std::vector<const MaterialProperty<Real> *> _sgnion;
   std::vector<const ADMaterialProperty<Real> *> _muion;
-
-  unsigned int _num_ions;
-  unsigned int _ip_index;
-  std::vector<unsigned int>::iterator _iter;
 
   ADRealVectorValue _ion_flux;
 };

--- a/include/bcs/LymberopoulosIonBC.h
+++ b/include/bcs/LymberopoulosIonBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   // Coupled variables
   const ADVariableGradient & _grad_potential;

--- a/include/bcs/MatchedValueLogBC.h
+++ b/include/bcs/MatchedValueLogBC.h
@@ -27,5 +27,5 @@ protected:
 
   const ADVariableValue & _v;
 
-  Real _H;
+  const Real _H;
 };

--- a/include/bcs/NeumannCircuitVoltageMoles_KV.h
+++ b/include/bcs/NeumannCircuitVoltageMoles_KV.h
@@ -34,7 +34,7 @@ protected:
   const ADVariableValue & _mean_en;
   const ADVariableValue & _em;
 
-  const MaterialProperty<Real> & _se_coeff;
+  const std::vector<Real> & _se_coeff;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   const MaterialProperty<Real> & _eps;
   const MaterialProperty<Real> & _N_A;

--- a/include/bcs/NeumannCircuitVoltageMoles_KV.h
+++ b/include/bcs/NeumannCircuitVoltageMoles_KV.h
@@ -33,8 +33,8 @@ protected:
   std::vector<unsigned int> _ip_id;
   const ADVariableValue & _mean_en;
   const ADVariableValue & _em;
-
-  const std::vector<Real> & _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   std::vector<const ADMaterialProperty<Real> *> _muip;
   const MaterialProperty<Real> & _eps;
   const MaterialProperty<Real> & _N_A;
@@ -64,5 +64,5 @@ protected:
 
   ADReal _ion_drift;
   ADReal _secondary_ion;
-  unsigned int _num_ions;
+  const unsigned int _num_ions;
 };

--- a/include/bcs/NeumannCircuitVoltageNew.h
+++ b/include/bcs/NeumannCircuitVoltageNew.h
@@ -35,7 +35,7 @@ protected:
   const CurrentDensityShapeSideUserObject & _current_uo;
   const Real & _current;
   const std::vector<Real> & _current_jac;
-  std::string _surface;
+  const std::string _surface;
   Real _current_sign;
 
   // Data
@@ -55,12 +55,12 @@ protected:
 
   // System properties
   const Function & _V_source;
-  Real _resistance;
+  const Real _resistance;
   Real _area;
   bool _use_area;
 
   // Units
   std::string _potential_units;
-  Real _r_units;
+  const Real _r_units;
   Real _voltage_scaling;
 };

--- a/include/bcs/PenaltyCircuitPotential.h
+++ b/include/bcs/PenaltyCircuitPotential.h
@@ -36,10 +36,10 @@ protected:
   const CurrentDensityShapeSideUserObject & _current_uo;
   const Real & _current;
   const std::vector<Real> & _current_jac;
-  Real _surface_potential;
-  std::string _surface;
+  const Real _surface_potential;
+  const std::string _surface;
   Real _current_sign;
-  Real _p;
+  const Real _p;
   const ProvideMobility & _data;
   const std::vector<dof_id_type> & _var_dofs;
   unsigned int _em_id;
@@ -53,4 +53,10 @@ protected:
   Real _area;
   bool _use_area;
   Real _voltage_scaling;
+  Real curr_times_resist;
+  Real d_curr_times_resist_d_potential;
+  Real d_curr_times_resist_d_em;
+  Real d_curr_times_resist_d_ip;
+  Real d_curr_times_resist_d_mean_en;
+  Real d_curr_times_resist_d_coupled_var;
 };

--- a/include/bcs/PotentialDriftOutflowBC.h
+++ b/include/bcs/PotentialDriftOutflowBC.h
@@ -24,7 +24,6 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  int _charge_sign;
-  unsigned int _potential_id;
+  const int _charge_sign;
   const ADVariableGradient & _grad_potential;
 };

--- a/include/bcs/SakiyamaElectronDiffusionBC.h
+++ b/include/bcs/SakiyamaElectronDiffusionBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   // Coupled variables
   const ADVariableValue & _mean_en;

--- a/include/bcs/SakiyamaEnergyDiffusionBC.h
+++ b/include/bcs/SakiyamaEnergyDiffusionBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   // Coupled variables
   const ADVariableValue & _em;

--- a/include/bcs/SakiyamaEnergySecondaryElectronBC.h
+++ b/include/bcs/SakiyamaEnergySecondaryElectronBC.h
@@ -22,9 +22,10 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  bool Te_dependent;
-
+  const Real _r_units;
+  const bool Te_dependent;
+  const unsigned int _num_ions;
+  const std::vector<Real> _se_coeff;
   // Coupled variables
   const ADVariableGradient & _grad_potential;
   const ADVariableValue & _em;
@@ -33,14 +34,10 @@ protected:
 
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
-  Real _se_coeff;
+
   Real _user_se_energy;
 
   Real _a;
   ADReal _se_energy;
   ADRealVectorValue _ion_flux;
-
-  unsigned int _num_ions;
-  unsigned int _ip_index;
-  std::vector<unsigned int>::iterator _iter;
 };

--- a/include/bcs/SakiyamaEnergySecondaryElectronBC.h
+++ b/include/bcs/SakiyamaEnergySecondaryElectronBC.h
@@ -25,7 +25,8 @@ protected:
   const Real _r_units;
   const bool Te_dependent;
   const unsigned int _num_ions;
-  const std::vector<Real> _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   // Coupled variables
   const ADVariableGradient & _grad_potential;
   const ADVariableValue & _em;
@@ -35,7 +36,7 @@ protected:
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
 
-  Real _user_se_energy;
+  const Real _user_se_energy;
 
   Real _a;
   ADReal _se_energy;

--- a/include/bcs/SakiyamaIonAdvectionBC.h
+++ b/include/bcs/SakiyamaIonAdvectionBC.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
+  const Real _r_units;
 
   // Coupled variables
 

--- a/include/bcs/SakiyamaSecondaryElectronBC.h
+++ b/include/bcs/SakiyamaSecondaryElectronBC.h
@@ -22,8 +22,9 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-
+  const Real _r_units;
+  const unsigned int _num_ions;
+  const std::vector<Real> _user_se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
@@ -31,10 +32,7 @@ protected:
 
   Real _a;
   ADRealVectorValue _ion_flux;
-  Real _user_se_coeff;
 
   std::vector<const MaterialProperty<Real> *> _sgnip;
   std::vector<const ADMaterialProperty<Real> *> _muip;
-
-  unsigned int _num_ions;
 };

--- a/include/bcs/SakiyamaSecondaryElectronBC.h
+++ b/include/bcs/SakiyamaSecondaryElectronBC.h
@@ -24,7 +24,8 @@ protected:
 
   const Real _r_units;
   const unsigned int _num_ions;
-  const std::vector<Real> _user_se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;

--- a/include/bcs/SchottkyEmissionBC.h
+++ b/include/bcs/SchottkyEmissionBC.h
@@ -22,24 +22,25 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _r_units;
-  Real _r;
-
+  const Real _r_units;
+  const Real _r;
+  const unsigned int _num_ions;
+  const std::vector<Real> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
   const ADVariableValue & _mean_en;
 
-  MooseVariable & _ip_var;
-  const ADVariableValue & _ip;
-  const ADVariableGradient & _grad_ip;
+  std::vector<MooseVariable *> _ip_var;
+  std::vector<const ADVariableValue *> _ip;
+  std::vector<const ADVariableGradient *> _grad_ip;
+
+  std::vector<const MaterialProperty<Real> *> _sgnip;
+  std::vector<const ADMaterialProperty<Real> *> _muip;
+  std::vector<const ADMaterialProperty<Real> *> _Dip;
 
   const MaterialProperty<Real> & _massem;
   const MaterialProperty<Real> & _e;
-  const MaterialProperty<Real> & _sgnip;
-  const ADMaterialProperty<Real> & _muip;
-  const ADMaterialProperty<Real> & _Dip;
-  const MaterialProperty<Real> & _se_coeff;
   const MaterialProperty<Real> & _work_function;
   const MaterialProperty<Real> & _field_enhancement;
   const MaterialProperty<Real> & _Richardson_coefficient;

--- a/include/bcs/SchottkyEmissionBC.h
+++ b/include/bcs/SchottkyEmissionBC.h
@@ -25,7 +25,8 @@ protected:
   const Real _r_units;
   const Real _r;
   const unsigned int _num_ions;
-  const std::vector<Real> _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
@@ -49,7 +50,7 @@ protected:
   Real _a;
   ADReal _v_thermal;
   ADRealVectorValue _ion_flux;
-  Real _tau;
+  const Real _tau;
   bool _relax;
   std::string _potential_units;
 
@@ -57,4 +58,10 @@ protected:
 
   Real _voltage_scaling;
   Real _dPhi_over_F;
+  ADReal dPhi;
+  Real kB;
+  ADReal jRD;
+  ADReal jSE;
+  ADReal F;
+  Real _relaxation_Expr;
 };

--- a/include/bcs/SecondaryElectronBC.h
+++ b/include/bcs/SecondaryElectronBC.h
@@ -26,7 +26,8 @@ protected:
   const Real & _r;
   const Real & _r_ion;
   const MaterialProperty<Real> & _kb;
-
+  const unsigned int _num_ions;
+  const std::vector<Real> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
@@ -41,13 +42,10 @@ protected:
   std::vector<const ADMaterialProperty<Real> *> _muip;
   std::vector<const ADMaterialProperty<Real> *> _Tip;
   std::vector<const MaterialProperty<Real> *> _massip;
-  const MaterialProperty<Real> & _se_coeff;
 
   Real _a;
   Real _b;
   ADReal _v_thermal;
   ADReal _ion_flux;
   ADReal _n_gamma;
-
-  unsigned int _num_ions;
 };

--- a/include/bcs/SecondaryElectronBC.h
+++ b/include/bcs/SecondaryElectronBC.h
@@ -27,7 +27,8 @@ protected:
   const Real & _r_ion;
   const MaterialProperty<Real> & _kb;
   const unsigned int _num_ions;
-  const std::vector<Real> _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;

--- a/include/bcs/SecondaryElectronEnergyBC.h
+++ b/include/bcs/SecondaryElectronEnergyBC.h
@@ -27,7 +27,8 @@ protected:
   const Real & _r_ion;
   const MaterialProperty<Real> & _kb;
   const unsigned int _num_ions;
-  const std::vector<Real> & _se_coeff;
+  const std::vector<std::string> _se_coeff_names;
+  std::vector<const ADMaterialProperty<Real> *> _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;

--- a/include/bcs/SecondaryElectronEnergyBC.h
+++ b/include/bcs/SecondaryElectronEnergyBC.h
@@ -26,7 +26,8 @@ protected:
   const Real & _r;
   const Real & _r_ion;
   const MaterialProperty<Real> & _kb;
-
+  const unsigned int _num_ions;
+  const std::vector<Real> & _se_coeff;
   // Coupled variables
 
   const ADVariableGradient & _grad_potential;
@@ -41,8 +42,8 @@ protected:
   std::vector<const ADMaterialProperty<Real> *> _muip;
   std::vector<const ADMaterialProperty<Real> *> _Tip;
   std::vector<const MaterialProperty<Real> *> _massip;
-  const MaterialProperty<Real> & _se_coeff;
-  const MaterialProperty<Real> & _se_energy;
+
+  const Real & _se_energy;
   const ADMaterialProperty<Real> & _mumean_en;
 
   Real _a;
@@ -50,6 +51,4 @@ protected:
   ADReal _v_thermal;
   ADReal _ion_flux;
   ADReal _n_gamma;
-
-  unsigned int _num_ions;
 };

--- a/include/bcs/TM0AntennaVertBC.h
+++ b/include/bcs/TM0AntennaVertBC.h
@@ -22,8 +22,8 @@ public:
 protected:
   virtual ADReal computeQpResidual() override;
 
-  Real _omega;
-  Real _eps_r;
-  Real _eps0;
-  bool _time_dependent;
+  const Real _omega;
+  const Real _eps_r;
+  const Real _eps0;
+  const bool _time_dependent;
 };

--- a/src/bcs/EconomouDielectricBC.C
+++ b/src/bcs/EconomouDielectricBC.C
@@ -19,13 +19,29 @@ EconomouDielectricBC::validParams()
   params.addRequiredParam<Real>("dielectric_constant", "The dielectric constant of the material.");
   params.addRequiredParam<Real>("thickness", "The thickness of the material.");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
+  params.deprecateCoupledVar("mean_en", "electron_energy", "06/01/2024");
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("potential_ion", "The ion potential");
-  params.addParam<Real>("users_gamma",
-                        "A secondary electron emission coeff. only used for this BC.");
+  params.deprecateCoupledVar("potential_ion", "ion_potentials", "06/01/2024");
+  params.addParam<std::vector<Real>>("users_gamma",
+                                     "A secondary electron emission coeff. only used for this BC.");
+  params.deprecateParam("users_gamma", "emission_coeffs", "06/01/2024");
+
+  params.addRequiredCoupledVar("electron_energy", "The mean electron energy density. In log form");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
+  params.addRequiredCoupledVar("ion_potentials",
+                               "The effective potential for each ion provided in 'ions'");
+  params.addParam<std::vector<Real>>(
+      "emission_coeffs",
+      "The seconday electron emmision coefficient for each ion provided in `ions`");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
+
   params.addClassDescription("Dielectric boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
@@ -35,19 +51,20 @@ EconomouDielectricBC::EconomouDielectricBC(const InputParameters & parameters)
   : ADIntegratedBC(parameters),
     _r_units(1. / getParam<Real>("position_units")),
 
-    _mean_en(adCoupledValue("mean_en")),
-    _em(adCoupledValue("em")),
+    _mean_en(adCoupledValue("electron_energy")),
+    _em(adCoupledValue("electrons")),
     _grad_u_dot(_var.gradSlnDot()), // TODO: make an AD version of this in MOOSE
     _u_dot(_var.adUDot()),
 
     _e(getMaterialProperty<Real>("e")),
     _massem(getMaterialProperty<Real>("massem")),
-    _user_se_coeff(getParam<Real>("users_gamma")),
+    _user_se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
 
     _epsilon_d(getParam<Real>("dielectric_constant")),
     _thickness(getParam<Real>("thickness")),
     _a(0.5),
     _ion_flux(0, 0, 0),
+    _temp_flux(0, 0, 0),
     _v_thermal(0),
     _em_flux(0, 0, 0),
     _potential_units(getParam<std::string>("potential_units"))
@@ -58,7 +75,7 @@ EconomouDielectricBC::EconomouDielectricBC(const InputParameters & parameters)
   else if (_potential_units.compare("kV") == 0)
     _voltage_scaling = 1000;
 
-  _num_ions = coupledComponents("ip");
+  _num_ions = coupledComponents("ions");
 
   _ip.resize(_num_ions);
   _ip_var.resize(_num_ions);
@@ -75,39 +92,44 @@ EconomouDielectricBC::EconomouDielectricBC(const InputParameters & parameters)
   //
   //   2. There are no effective potentials, and potential_ion = potential. If so, ensure
   //   potential_ion is still same size as _ip.
-  if (coupledComponents("potential_ion") != _num_ions)
+  if (coupledComponents("ion_potentials") != _num_ions)
   {
-    if ((coupledComponents("potential_ion") == 1) &&
-        (getVar("potential_ion", 0)->number() == _var.number()))
+    if ((coupledComponents("ion_potentials") == 1) &&
+        (getVar("ion_potentials", 0)->number() == _var.number()))
     {
       fill_potential_vector = true;
     }
     else
     {
       mooseError(
-          "EconomouDielectricBC: ip and potential_ion vectors are not same length. There are two "
+          "EconomouDielectricBC: `ion` and `ion_potentials` vectors are not same length. There are "
+          "two "
           "possible options: \n 1) Ions respond to an effective potential. If so, make sure each "
           "ion has an associated effective potential. \n 2) Ions and electrons respond to the same "
           "potential. If so, set potential_ion equal to this potential.\n");
     }
+
+    if (_user_se_coeff.size() != _num_ions)
+      mooseError(
+          "EconomouDielectricBC: The lengths of `ions` and `emission_coeffs` must be the same");
   }
 
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ip_var[i] = getVar("ip", i);
-    _ip[i] = &adCoupledValue("ip", i);
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
+    _ip_var[i] = getVar("ions", i);
+    _ip[i] = &adCoupledValue("ions", i);
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
 
     if (fill_potential_vector)
     {
-      _potential_ion[i] = &adCoupledValue("potential_ion", 0);
-      _grad_potential_ion[i] = &adCoupledGradient("potential_ion", 0);
+      _potential_ion[i] = &adCoupledValue("ion_potentials", 0);
+      _grad_potential_ion[i] = &adCoupledGradient("ion_potentials", 0);
     }
     else
     {
-      _potential_ion[i] = &adCoupledValue("potential_ion", i);
-      _grad_potential_ion[i] = &adCoupledGradient("potential_ion", i);
+      _potential_ion[i] = &adCoupledValue("ion_potentials", i);
+      _grad_potential_ion[i] = &adCoupledGradient("ion_potentials", i);
     }
   }
 }
@@ -126,16 +148,16 @@ EconomouDielectricBC::computeQpResidual()
     {
       _a = 0.0;
     }
-
-    _ion_flux += _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -(*_grad_potential_ion[i])[_qp] *
+    _temp_flux = _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -(*_grad_potential_ion[i])[_qp] *
                  _r_units * std::exp((*_ip[i])[_qp]);
+    _ion_flux += _temp_flux;
+    _em_flux -= _user_se_coeff[i] * _temp_flux;
   }
 
   _v_thermal =
       std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_mean_en[_qp] - _em[_qp]) / (M_PI * _massem[_qp]));
 
-  _em_flux =
-      (0.25 * _v_thermal * std::exp(_em[_qp]) * _normals[_qp]) - (_user_se_coeff * _ion_flux);
+  _em_flux += (0.25 * _v_thermal * std::exp(_em[_qp]) * _normals[_qp]);
 
   return _test[_i][_qp] * _r_units *
          ((_thickness / _epsilon_d) * _e[_qp] * 6.022e23 * (_ion_flux - _em_flux) * _normals[_qp] /

--- a/src/bcs/EconomouDielectricBC.C
+++ b/src/bcs/EconomouDielectricBC.C
@@ -39,7 +39,7 @@ EconomouDielectricBC::validParams()
                                "The effective potential for each ion provided in 'ions'");
   params.addParam<std::vector<Real>>(
       "emission_coeffs",
-      "The seconday electron emmision coefficient for each ion provided in `ions`");
+      "The secondary electron emission coefficient for each ion provided in `ions`");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
 
   params.addClassDescription("Dielectric boundary condition"
@@ -102,7 +102,7 @@ EconomouDielectricBC::EconomouDielectricBC(const InputParameters & parameters)
     else
     {
       mooseError(
-          "EconomouDielectricBC: `ion` and `ion_potentials` vectors are not same length. There are "
+          "EconomouDielectricBC with name ", name(), ": `ion` and `ion_potentials` vectors are not same length. There are "
           "two "
           "possible options: \n 1) Ions respond to an effective potential. If so, make sure each "
           "ion has an associated effective potential. \n 2) Ions and electrons respond to the same "
@@ -111,7 +111,7 @@ EconomouDielectricBC::EconomouDielectricBC(const InputParameters & parameters)
 
     if (_user_se_coeff.size() != _num_ions)
       mooseError(
-          "EconomouDielectricBC: The lengths of `ions` and `emission_coeffs` must be the same");
+          "EconomouDielectricBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
   }
 
   for (unsigned int i = 0; i < _num_ions; ++i)

--- a/src/bcs/ElectronAdvectionDoNothingBC.C
+++ b/src/bcs/ElectronAdvectionDoNothingBC.C
@@ -18,7 +18,6 @@ ElectronAdvectionDoNothingBC::validParams()
   InputParameters params = ADIntegratedBC::validParams();
   params.addRequiredCoupledVar(
       "potential", "The gradient of the potential will be used to compute the advection velocity.");
-  params.addRequiredCoupledVar("mean_en", "The log of the mean energy.");
   params.addRequiredParam<Real>("position_units", "The units of position.");
   params.addClassDescription("Boundary condition where the election advection flux at the boundary "
                              "is equal to the bulk election advection equation");
@@ -34,8 +33,7 @@ ElectronAdvectionDoNothingBC::ElectronAdvectionDoNothingBC(const InputParameters
     _sign(getMaterialProperty<Real>("sgnem")),
 
     // Coupled variables
-    _grad_potential(adCoupledGradient("potential")),
-    _mean_en(adCoupledValue("mean_en"))
+    _grad_potential(adCoupledGradient("potential"))
 {
 }
 

--- a/src/bcs/ElectronDiffusionDoNothingBC.C
+++ b/src/bcs/ElectronDiffusionDoNothingBC.C
@@ -16,8 +16,6 @@ InputParameters
 ElectronDiffusionDoNothingBC::validParams()
 {
   InputParameters params = ADIntegratedBC::validParams();
-  params.addRequiredCoupledVar("mean_en",
-                               "The log of the product of mean energy times electron density.");
   params.addRequiredParam<Real>("position_units", "Units of position");
   params.addClassDescription("Boundary condition where the election diffusion flux at the boundary "
                              "is equal to the bulk election diffusion equation");
@@ -31,9 +29,7 @@ ElectronDiffusionDoNothingBC::ElectronDiffusionDoNothingBC(const InputParameters
 
     _r_units(1. / getParam<Real>("position_units")),
 
-    _diffem(getADMaterialProperty<Real>("diffem")),
-
-    _mean_en(adCoupledValue("mean_en"))
+    _diffem(getADMaterialProperty<Real>("diffem"))
 {
 }
 

--- a/src/bcs/ElectronTemperatureDirichletBC.C
+++ b/src/bcs/ElectronTemperatureDirichletBC.C
@@ -18,6 +18,8 @@ ElectronTemperatureDirichletBC::validParams()
   InputParameters params = ADNodalBC::validParams();
   params.addRequiredParam<Real>("value", "Value of the BC");
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
   params.addParam<Real>("penalty_value", 1.0, "The penalty value for the Dirichlet BC.");
   params.addClassDescription("Electron temperature boundary condition");
   return params;
@@ -25,7 +27,7 @@ ElectronTemperatureDirichletBC::validParams()
 
 ElectronTemperatureDirichletBC::ElectronTemperatureDirichletBC(const InputParameters & parameters)
   : ADNodalBC(parameters),
-    _em(adCoupledValue("em")),
+    _em(adCoupledValue("electrons")),
     _value(getParam<Real>("value")),
     _penalty_value(getParam<Real>("penalty_value"))
 {

--- a/src/bcs/FieldEmissionBC.C
+++ b/src/bcs/FieldEmissionBC.C
@@ -23,7 +23,7 @@ FieldEmissionBC::validParams()
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<std::vector<Real>>(
       "emission_coeffs",
-      "The species dependent secondary electron emmision coefficients for this boundary");
+      "The species dependent secondary electron emission coefficients for this boundary");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addParam<Real>("tau", 1e-9, "The time constant for ramping the boundary condition.");
@@ -54,7 +54,7 @@ FieldEmissionBC::FieldEmissionBC(const InputParameters & parameters)
 {
 
   if (_se_coeff.size() != _num_ions)
-    mooseError("FieldEmissionBC: The lengths of `ions` and `emission_coeffs` must be the same");
+    mooseError("FieldEmissionBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
 
   if (_potential_units.compare("V") == 0)
   {

--- a/src/bcs/FieldEmissionBC.C
+++ b/src/bcs/FieldEmissionBC.C
@@ -106,7 +106,7 @@ FieldEmissionBC::computeQpResidual()
   {
     _a = 0.0;
 
-    for (auto i = 0; i < _num_ions; ++i)
+    for (unsigned int i = 0; i < _num_ions; ++i)
     {
 
       _ion_flux = (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *

--- a/src/bcs/HagelaarElectronBC.C
+++ b/src/bcs/HagelaarElectronBC.C
@@ -19,6 +19,9 @@ HagelaarElectronBC::validParams()
   params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
+  params.deprecateCoupledVar("mean_en", "electron_energy", "06/01/2024");
+  params.addRequiredCoupledVar("electron_energy", "The mean electron energy density in log form");
+
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription("Kinetic electron boundary condition"
                              "(Based on DOI:https://doi.org/10.1103/PhysRevE.62.1452)");
@@ -32,7 +35,7 @@ HagelaarElectronBC::HagelaarElectronBC(const InputParameters & parameters)
 
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
-    _mean_en(adCoupledValue("mean_en")),
+    _mean_en(adCoupledValue("electron_energy")),
 
     _muem(getADMaterialProperty<Real>("muem")),
     _massem(getMaterialProperty<Real>("massem")),

--- a/src/bcs/HagelaarEnergyAdvectionBC.C
+++ b/src/bcs/HagelaarEnergyAdvectionBC.C
@@ -23,7 +23,7 @@ HagelaarEnergyAdvectionBC::validParams()
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<std::vector<Real>>(
       "emission_coeffs",
-      "The species dependent secondary electron emmision coefficients for this boundary");
+      "The species-dependent secondary electron emission coefficients for this boundary");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<Real>("secondary_electron_energy", "The secondary electron energy in eV");
   params.addClassDescription("Kinetic advective electron energy boundary condition"

--- a/src/bcs/HagelaarEnergyAdvectionBC.C
+++ b/src/bcs/HagelaarEnergyAdvectionBC.C
@@ -80,7 +80,7 @@ HagelaarEnergyAdvectionBC::computeQpResidual()
     _a = 0.0;
   }
 
-  for (auto i = 0; i < _num_ions; ++i)
+  for (unsigned int i = 0; i < _num_ions; ++i)
   {
     _ion_flux = (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *
                     std::exp((*_ip[i])[_qp]) -

--- a/src/bcs/HagelaarEnergyAdvectionBC.C
+++ b/src/bcs/HagelaarEnergyAdvectionBC.C
@@ -19,7 +19,13 @@ HagelaarEnergyAdvectionBC::validParams()
   params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs",
+      "The species dependent secondary electron emmision coefficients for this boundary");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<Real>("secondary_electron_energy", "The secondary electron energy in eV");
   params.addClassDescription("Kinetic advective electron energy boundary condition"
                              "(Based on DOI:https://doi.org/10.1063/1.2715745)");
   return params;
@@ -30,29 +36,41 @@ HagelaarEnergyAdvectionBC::HagelaarEnergyAdvectionBC(const InputParameters & par
 
     _r_units(1. / getParam<Real>("position_units")),
     _r(getParam<Real>("r")),
-
+    _num_ions(coupledComponents("ions")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
-    _ip_var(*getVar("ip", 0)),
-    _ip(adCoupledValue("ip")),
-    _grad_ip(adCoupledGradient("ip")),
-
-    _sgnip(getMaterialProperty<Real>("sgn" + _ip_var.name())),
-    _muip(getADMaterialProperty<Real>("mu" + _ip_var.name())),
-    _Dip(getADMaterialProperty<Real>("diff" + _ip_var.name())),
-    _se_coeff(getMaterialProperty<Real>("se_coeff")),
-    _se_energy(getMaterialProperty<Real>("se_energy")),
+    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
+    _se_energy(getParam<Real>("secondary_electron_energy")),
     _mumean_en(getADMaterialProperty<Real>("mumean_en")),
     _a(0.5),
     _ion_flux(0, 0, 0),
     _v_thermal(0),
-    _n_gamma(0)
+    _n_gamma(0),
+    _bc_val(0)
 {
+  _ip.resize(_num_ions);
+  _ip_var.resize(_num_ions);
+  _grad_ip.resize(_num_ions);
+  _sgnip.resize(_num_ions);
+  _muip.resize(_num_ions);
+  _Dip.resize(_num_ions);
+
+  for (unsigned int i = 0; i < _num_ions; ++i)
+  {
+    _ip_var[i] = getVar("ions", i);
+    _ip[i] = &adCoupledValue("ions", i);
+    _grad_ip[i] = &adCoupledGradient("ions", i);
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _Dip[i] = &getADMaterialProperty<Real>("diff" + (*getVar("ions", i)).name());
+  }
 }
 
 ADReal
 HagelaarEnergyAdvectionBC::computeQpResidual()
 {
+  // reset this value just to be safe
+  _bc_val = 0;
   if (_normals[_qp] * -1.0 * -_grad_potential[_qp] > 0.0)
   {
     _a = 1.0;
@@ -62,14 +80,17 @@ HagelaarEnergyAdvectionBC::computeQpResidual()
     _a = 0.0;
   }
 
-  _ion_flux = _sgnip[_qp] * _muip[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_ip[_qp]) -
-              _Dip[_qp] * std::exp(_ip[_qp]) * _grad_ip[_qp] * _r_units;
+  for (auto i = 0; i < _num_ions; ++i)
+  {
+    _ion_flux = (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *
+                    std::exp((*_ip[i])[_qp]) -
+                (*_Dip[i])[_qp] * std::exp((*_ip[i])[_qp]) * (*_grad_ip[i])[_qp] * _r_units;
+    _bc_val += 10. * _ion_flux * _normals[_qp] * _se_energy * _se_coeff[i] * (_a - 1.) * (_r + 1.);
+  }
 
   return _test[_i][_qp] * _r_units / (6. * (_r + 1.)) *
-         (10. * _ion_flux * _normals[_qp] * _se_energy[_qp] * _se_coeff[_qp] * (_a - 1.) *
-              (_r + 1.) +
-          (_r - 1.) * (std::exp(_u[_qp]) - _se_energy[_qp] * _n_gamma) *
-              (6. * -_grad_potential[_qp] * _r_units * _normals[_qp] * _mumean_en[_qp] *
-                   (2. * _a - 1.) -
-               5. * _v_thermal));
+         (_bc_val + (_r - 1.) * (std::exp(_u[_qp]) - _se_energy * _n_gamma) *
+                        (6. * -_grad_potential[_qp] * _r_units * _normals[_qp] * _mumean_en[_qp] *
+                             (2. * _a - 1.) -
+                         5. * _v_thermal));
 }

--- a/src/bcs/HagelaarEnergyBC.C
+++ b/src/bcs/HagelaarEnergyBC.C
@@ -19,6 +19,8 @@ HagelaarEnergyBC::validParams()
   params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   return params;
 }
@@ -34,8 +36,6 @@ HagelaarEnergyBC::HagelaarEnergyBC(const InputParameters & parameters)
 
     _massem(getMaterialProperty<Real>("massem")),
     _e(getMaterialProperty<Real>("e")),
-    _se_coeff(getMaterialProperty<Real>("se_coeff")),
-    _se_energy(getMaterialProperty<Real>("se_energy")),
     _mumean_en(getADMaterialProperty<Real>("mumean_en"))
 {
   _a = 0.5;

--- a/src/bcs/LymberopoulosElectronBC.C
+++ b/src/bcs/LymberopoulosElectronBC.C
@@ -20,7 +20,7 @@ LymberopoulosElectronBC::validParams()
   params.addRequiredParam<std::vector<Real>>("gamma", "The secondary electron coefficient");
   params.deprecateParam("gamma", "emission_coeffs", "06/01/2024");
   params.addRequiredParam<std::vector<Real>>(
-      "emission_coeffs", "The species dependent secondary electron emmision coefficients");
+      "emission_coeffs", "The species-dependent secondary electron emission coefficients");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("ion", "The ion density.");
   params.deprecateCoupledVar("ion", "ions", "06/01/2024");

--- a/src/bcs/NeumannCircuitVoltageMoles_KV.C
+++ b/src/bcs/NeumannCircuitVoltageMoles_KV.C
@@ -23,10 +23,23 @@ NeumannCircuitVoltageMoles_KV::validParams()
   params.addRequiredParam<UserObjectName>(
       "data_provider",
       "The name of the UserObject that can provide some data to materials, bcs, etc.");
+
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log-molar form");
+
   params.addRequiredCoupledVar("em", "The log of the electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
+
   params.addRequiredCoupledVar(
       "mean_en", "The log of the product of the mean energy and the electron density.");
+  params.deprecateCoupledVar("mean_en", "electron_energy", "06/01/2024");
+  params.addRequiredCoupledVar("electron_energy", "The mean electron energy density in log form");
+
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs",
+      "The seconday electron emmision coefficient for each ion provided in `ions`");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addRequiredParam<Real>("r",
                                 "The reflection coefficient applied to both electrons and ions");
@@ -40,9 +53,9 @@ NeumannCircuitVoltageMoles_KV::NeumannCircuitVoltageMoles_KV(const InputParamete
     _r_units(1. / getParam<Real>("position_units")),
     _V_bat(getFunction("function")),
     _data(getUserObject<ProvideMobility>("data_provider")),
-    _mean_en(adCoupledValue("mean_en")),
-    _em(adCoupledValue("em")),
-    _se_coeff(getMaterialProperty<Real>("se_coeff")),
+    _mean_en(adCoupledValue("electron_energy")),
+    _em(adCoupledValue("electrons")),
+    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
     _eps(getMaterialProperty<Real>("eps")),
     _N_A(getMaterialProperty<Real>("N_A")),
     _muem(getADMaterialProperty<Real>("muem")),
@@ -69,8 +82,11 @@ NeumannCircuitVoltageMoles_KV::NeumannCircuitVoltageMoles_KV(const InputParamete
 
   // First we need to initialize all of the ion densities and material properties.
   // Find the number of ions coupled into this BC:
-  _num_ions = coupledComponents("ip");
+  _num_ions = coupledComponents("ions");
 
+  if (_se_coeff.size() != _num_ions)
+    mooseError("NeumannCircuitVoltageMoles_KV: The lengths of `ions` and `emission_coeffs` must be "
+               "the same");
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);
   _grad_ip.resize(_num_ions);
@@ -87,13 +103,13 @@ NeumannCircuitVoltageMoles_KV::NeumannCircuitVoltageMoles_KV(const InputParamete
   // refers to a single ion species.
   for (unsigned int i = 0; i < _ip.size(); ++i)
   {
-    _ip[i] = &adCoupledValue("ip", i);
+    _ip[i] = &adCoupledValue("ions", i);
     _grad_ip[i] = &adCoupledGradient("ip", i);
-    _T_heavy[i] = &getADMaterialProperty<Real>("T" + (*getVar("ip", i)).name());
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _Dip[i] = &getADMaterialProperty<Real>("diff" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
-    _mass[i] = &getMaterialProperty<Real>("mass" + (*getVar("ip", i)).name());
+    _T_heavy[i] = &getADMaterialProperty<Real>("T" + (*getVar("ions", i)).name());
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _Dip[i] = &getADMaterialProperty<Real>("diff" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
+    _mass[i] = &getMaterialProperty<Real>("mass" + (*getVar("ions", i)).name());
   }
 }
 
@@ -117,16 +133,19 @@ NeumannCircuitVoltageMoles_KV::computeQpResidual()
   _ion_drift = 0;
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ion_flux +=
-        (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_u[_qp] * _r_units * std::exp((*_ip[i])[_qp]) -
-        (*_Dip[i])[_qp] * std::exp((*_ip[i])[_qp]) * (*_grad_ip[i])[_qp] * _r_units;
+    _ion_flux += _se_coeff[i] *
+                 ((*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_u[_qp] * _r_units *
+                      std::exp((*_ip[i])[_qp]) -
+                  (*_Dip[i])[_qp] * std::exp((*_ip[i])[_qp]) * (*_grad_ip[i])[_qp] * _r_units);
 
-    _secondary_ion += std::exp((*_ip[i])[_qp]) * (*_muip[i])[_qp];
+    _secondary_ion +=
+        (-1. + (-1. + _a) * _se_coeff[i]) * std::exp((*_ip[i])[_qp]) * (*_muip[i])[_qp];
 
-    _ion_drift += std::sqrt(8 * _kb[_qp] * (*_T_heavy[i])[_qp] / (M_PI * (*_mass[i])[_qp])) *
+    _ion_drift += (-1. + (-1. + _a) * _se_coeff[i]) *
+                  std::sqrt(8 * _kb[_qp] * (*_T_heavy[i])[_qp] / (M_PI * (*_mass[i])[_qp])) *
                   std::exp((*_ip[i])[_qp]);
   }
-  _n_gamma = (1. - _a) * _se_coeff[_qp] * _ion_flux * _normals[_qp] /
+  _n_gamma = (1. - _a) * _ion_flux * _normals[_qp] /
              (_muem[_qp] * -_grad_u[_qp] * _r_units * _normals[_qp]);
 
   _v_e_th = std::sqrt(8 * _data.coulomb_charge() * 2.0 / 3 * std::exp(_mean_en[_qp] - _em[_qp]) /
@@ -136,12 +155,10 @@ NeumannCircuitVoltageMoles_KV::computeQpResidual()
          (-2. * (1. + _r) * _u[_qp] - 2. * (1. + _r) * -_V_bat.value(_t, _q_point[_qp]) +
           _data.electrode_area() * _data.coulomb_charge() * _data.ballast_resist() /
               _voltage_scaling * (-1. + _r) *
-              ((-1. + (-1. + _a) * _se_coeff[_qp]) * _N_A[_qp] * _ion_drift +
-               _N_A[_qp] * (std::exp(_em[_qp]) - _n_gamma) * _v_e_th)) /
+              (_N_A[_qp] * _ion_drift + _N_A[_qp] * (std::exp(_em[_qp]) - _n_gamma) * _v_e_th)) /
          (2. * _data.electrode_area() * _data.coulomb_charge() *
           ((-1. + 2. * _a) * _muem[_qp] / _voltage_scaling * _N_A[_qp] *
                (std::exp(_em[_qp]) - _n_gamma) -
-           (-1. + 2. * _b) * (-1. + (-1. + _a) * _se_coeff[_qp]) * _secondary_ion /
-               _voltage_scaling * _N_A[_qp]) *
+           (-1. + 2. * _b) * _secondary_ion / _voltage_scaling * _N_A[_qp]) *
           _data.ballast_resist() * (-1. + _r));
 }

--- a/src/bcs/NeumannCircuitVoltageMoles_KV.C
+++ b/src/bcs/NeumannCircuitVoltageMoles_KV.C
@@ -39,7 +39,7 @@ NeumannCircuitVoltageMoles_KV::validParams()
 
   params.addRequiredParam<std::vector<Real>>(
       "emission_coeffs",
-      "The seconday electron emmision coefficient for each ion provided in `ions`");
+      "The secondary electron emission coefficient for each ion provided in `ions`");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addRequiredParam<Real>("r",
                                 "The reflection coefficient applied to both electrons and ions");
@@ -85,7 +85,7 @@ NeumannCircuitVoltageMoles_KV::NeumannCircuitVoltageMoles_KV(const InputParamete
   _num_ions = coupledComponents("ions");
 
   if (_se_coeff.size() != _num_ions)
-    mooseError("NeumannCircuitVoltageMoles_KV: The lengths of `ions` and `emission_coeffs` must be "
+    mooseError("NeumannCircuitVoltageMoles_KV with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be "
                "the same");
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);

--- a/src/bcs/PenaltyCircuitPotential.C
+++ b/src/bcs/PenaltyCircuitPotential.C
@@ -88,7 +88,7 @@ PenaltyCircuitPotential::PenaltyCircuitPotential(const InputParameters & paramet
 Real
 PenaltyCircuitPotential::computeQpResidual()
 {
-  Real curr_times_resist = _current_sign * _current * _resistance / _voltage_scaling;
+  curr_times_resist = _current_sign * _current * _resistance / _voltage_scaling;
   if (_use_area)
     curr_times_resist *= _area;
 
@@ -98,7 +98,7 @@ PenaltyCircuitPotential::computeQpResidual()
 Real
 PenaltyCircuitPotential::computeQpJacobian()
 {
-  Real d_curr_times_resist_d_potential =
+  d_curr_times_resist_d_potential =
       _current_sign * _current_jac[_var_dofs[_j]] * _resistance / _voltage_scaling;
   if (_use_area)
     d_curr_times_resist_d_potential *= _area;
@@ -111,7 +111,7 @@ PenaltyCircuitPotential::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _em_id)
   {
-    Real d_curr_times_resist_d_em =
+    d_curr_times_resist_d_em =
         _current_sign * _current_jac[_em_dofs[_j]] * _resistance / _voltage_scaling;
     if (_use_area)
       d_curr_times_resist_d_em *= _area;
@@ -121,7 +121,7 @@ PenaltyCircuitPotential::computeQpOffDiagJacobian(unsigned int jvar)
 
   else if (jvar == _ip_id)
   {
-    Real d_curr_times_resist_d_ip =
+    d_curr_times_resist_d_ip =
         _current_sign * _current_jac[_ip_dofs[_j]] * _resistance / _voltage_scaling;
     if (_use_area)
       d_curr_times_resist_d_ip *= _area;
@@ -131,7 +131,7 @@ PenaltyCircuitPotential::computeQpOffDiagJacobian(unsigned int jvar)
 
   else if (jvar == _mean_en_id)
   {
-    Real d_curr_times_resist_d_mean_en =
+    d_curr_times_resist_d_mean_en =
         _current_sign * _current_jac[_mean_en_dofs[_j]] * _resistance / _voltage_scaling;
     if (_use_area)
       d_curr_times_resist_d_mean_en *= _area;
@@ -146,7 +146,7 @@ PenaltyCircuitPotential::computeQpOffDiagJacobian(unsigned int jvar)
 Real
 PenaltyCircuitPotential::computeQpNonlocalJacobian(dof_id_type dof_index)
 {
-  Real d_curr_times_resist_d_potential =
+  d_curr_times_resist_d_potential =
       _current_sign * _current_jac[dof_index] * _resistance / _voltage_scaling;
   if (_use_area)
     d_curr_times_resist_d_potential *= _area;
@@ -159,7 +159,7 @@ PenaltyCircuitPotential::computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof
 {
   if (jvar == _em_id || jvar == _ip_id || jvar == _mean_en_id)
   {
-    Real d_curr_times_resist_d_coupled_var =
+    d_curr_times_resist_d_coupled_var =
         _current_sign * _current_jac[dof_index] * _resistance / _voltage_scaling;
     if (_use_area)
       d_curr_times_resist_d_coupled_var *= _area;

--- a/src/bcs/SakiyamaElectronDiffusionBC.C
+++ b/src/bcs/SakiyamaElectronDiffusionBC.C
@@ -17,6 +17,8 @@ SakiyamaElectronDiffusionBC::validParams()
 {
   InputParameters params = ADIntegratedBC::validParams();
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
+  params.deprecateCoupledVar("mean_en", "electron_energy", "06/01/2024");
+  params.addRequiredCoupledVar("electron_energy", "The mean electron energy density in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription("Kinetic electron boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
@@ -29,7 +31,7 @@ SakiyamaElectronDiffusionBC::SakiyamaElectronDiffusionBC(const InputParameters &
     _r_units(1. / getParam<Real>("position_units")),
 
     // Coupled Variables
-    _mean_en(adCoupledValue("mean_en")),
+    _mean_en(adCoupledValue("electron_energy")),
 
     _massem(getMaterialProperty<Real>("massem")),
     _e(getMaterialProperty<Real>("e")),

--- a/src/bcs/SakiyamaEnergyDiffusionBC.C
+++ b/src/bcs/SakiyamaEnergyDiffusionBC.C
@@ -17,6 +17,8 @@ SakiyamaEnergyDiffusionBC::validParams()
 {
   InputParameters params = ADIntegratedBC::validParams();
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription("Kinetic advective electron energy boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
@@ -29,7 +31,7 @@ SakiyamaEnergyDiffusionBC::SakiyamaEnergyDiffusionBC(const InputParameters & par
     _r_units(1. / getParam<Real>("position_units")),
 
     // Coupled Variables
-    _em(adCoupledValue("em")),
+    _em(adCoupledValue("electrons")),
 
     _massem(getMaterialProperty<Real>("massem")),
     _e(getMaterialProperty<Real>("e")),

--- a/src/bcs/SakiyamaEnergySecondaryElectronBC.C
+++ b/src/bcs/SakiyamaEnergySecondaryElectronBC.C
@@ -20,7 +20,7 @@ SakiyamaEnergySecondaryElectronBC::validParams()
   params.deprecateParam("se_coeff", "emission_coeffs", "06/01/2024");
   params.addRequiredParam<std::vector<Real>>(
       "emission_coeffs",
-      "The seconday electron emmision coefficient for each ion provided in `ions`");
+      "The secondary electron emission coefficient for each ion provided in `ions`");
   params.addRequiredParam<bool>(
       "Tse_equal_Te", "The secondary electron temperature equal the electron temperature in eV");
   params.addParam<Real>(
@@ -30,7 +30,7 @@ SakiyamaEnergySecondaryElectronBC::validParams()
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("em", "The electron density.");
   params.deprecateCoupledVar("em", "electrons", "06/01/2024");
-  params.addRequiredCoupledVar("electrons", "The elctron density in log form");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
   params.addRequiredCoupledVar("ip", "The ion density.");
   params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
@@ -62,7 +62,7 @@ SakiyamaEnergySecondaryElectronBC::SakiyamaEnergySecondaryElectronBC(
 {
 
   if (_se_coeff.size() != _num_ions)
-    mooseError("SakiyamaEnergySecondaryElectronBC: The lengths of `ions` and `emission_coeffs` "
+    mooseError("SakiyamaEnergySecondaryElectronBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` "
                "must be the same");
   _ip.resize(_num_ions);
   _ip_var.resize(_num_ions);

--- a/src/bcs/SakiyamaEnergySecondaryElectronBC.C
+++ b/src/bcs/SakiyamaEnergySecondaryElectronBC.C
@@ -16,14 +16,25 @@ InputParameters
 SakiyamaEnergySecondaryElectronBC::validParams()
 {
   InputParameters params = ADIntegratedBC::validParams();
-  params.addRequiredParam<Real>("se_coeff", "The secondary electron coefficient");
+  params.addRequiredParam<std::vector<Real>>("se_coeff", "The secondary electron coefficient");
+  params.deprecateParam("se_coeff", "emission_coeffs", "06/01/2024");
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs",
+      "The seconday electron emmision coefficient for each ion provided in `ions`");
   params.addRequiredParam<bool>(
       "Tse_equal_Te", "The secondary electron temperature equal the electron temperature in eV");
   params.addParam<Real>(
       "user_se_energy", 1.0, "The user's value of the secondary electron temperature in eV");
+  params.deprecateParam("user_se_energy", "secondary_electron_energy", "06/01/2024");
+  params.addParam<Real>("secondary_electron_energy", "The secondary electron temperature in eV");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The elctron density in log form");
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
+
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addClassDescription(
       "Kinetic secondary electron for mean electron energy boundary condition"
@@ -37,20 +48,22 @@ SakiyamaEnergySecondaryElectronBC::SakiyamaEnergySecondaryElectronBC(
 
     _r_units(1. / getParam<Real>("position_units")),
     Te_dependent(getParam<bool>("Tse_equal_Te")),
-
+    _num_ions(coupledComponents("ions")),
+    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
 
     _em(adCoupledValue("em")),
 
-    _se_coeff(getParam<Real>("se_coeff")),
-    _user_se_energy(getParam<Real>("user_se_energy")),
+    _user_se_energy(getParam<Real>("secondary_electron_energy")),
     _a(0.5),
     _se_energy(0),
     _ion_flux(0, 0, 0)
 {
-  _num_ions = coupledComponents("ip");
 
+  if (_se_coeff.size() != _num_ions)
+    mooseError("SakiyamaEnergySecondaryElectronBC: The lengths of `ions` and `emission_coeffs` "
+               "must be the same");
   _ip.resize(_num_ions);
   _ip_var.resize(_num_ions);
   _muip.resize(_num_ions);
@@ -58,10 +71,10 @@ SakiyamaEnergySecondaryElectronBC::SakiyamaEnergySecondaryElectronBC(
 
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ip_var[i] = getVar("ip", i);
-    _ip[i] = &adCoupledValue("ip", i);
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
+    _ip_var[i] = getVar("ions", i);
+    _ip[i] = &adCoupledValue("ions", i);
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
   }
 }
 
@@ -80,8 +93,8 @@ SakiyamaEnergySecondaryElectronBC::computeQpResidual()
       _a = 0.0;
     }
 
-    _ion_flux += _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *
-                 std::exp((*_ip[i])[_qp]);
+    _ion_flux += _se_coeff[i] * _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] *
+                 _r_units * std::exp((*_ip[i])[_qp]);
   }
 
   if (Te_dependent)
@@ -93,6 +106,5 @@ SakiyamaEnergySecondaryElectronBC::computeQpResidual()
     _se_energy = _user_se_energy;
   }
 
-  return -_test[_i][_qp] * _r_units * _se_coeff * (5.0 / 3.0) * _se_energy * _ion_flux *
-         _normals[_qp];
+  return -_test[_i][_qp] * _r_units * (5.0 / 3.0) * _se_energy * _ion_flux * _normals[_qp];
 }

--- a/src/bcs/SakiyamaSecondaryElectronBC.C
+++ b/src/bcs/SakiyamaSecondaryElectronBC.C
@@ -25,7 +25,7 @@ SakiyamaSecondaryElectronBC::validParams()
       "users_gamma", "A secondary electron emission coeff. only used for this BC.");
   params.deprecateParam("users_gamma", "emission_coeffs", "06/01/2024");
   params.addRequiredParam<std::vector<Real>>(
-      "emission_coeffs", "A list of species dependent secondary electron emmisions coefficients");
+      "emission_coeffs", "A list of species-dependent secondary electron emission coefficients");
   params.addClassDescription("Kinetic secondary electron boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
@@ -44,7 +44,7 @@ SakiyamaSecondaryElectronBC::SakiyamaSecondaryElectronBC(const InputParameters &
     _ion_flux(0, 0, 0)
 {
   if (_user_se_coeff.size() != _num_ions)
-    mooseError("SakiyamaSecondaryElectronBC: The lengths of `ions` and `emission_coeffs` must be "
+    mooseError("SakiyamaSecondaryElectronBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be "
                "the same");
   _ip.resize(_num_ions);
   _muip.resize(_num_ions);

--- a/src/bcs/SakiyamaSecondaryElectronBC.C
+++ b/src/bcs/SakiyamaSecondaryElectronBC.C
@@ -21,10 +21,10 @@ SakiyamaSecondaryElectronBC::validParams()
   params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addRequiredParam<std::vector<Real>>(
+  params.addRequiredParam<std::vector<std::string>>(
       "users_gamma", "A secondary electron emission coeff. only used for this BC.");
   params.deprecateParam("users_gamma", "emission_coeffs", "06/01/2024");
-  params.addRequiredParam<std::vector<Real>>(
+  params.addRequiredParam<std::vector<std::string>>(
       "emission_coeffs", "A list of species-dependent secondary electron emission coefficients");
   params.addClassDescription("Kinetic secondary electron boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
@@ -36,25 +36,29 @@ SakiyamaSecondaryElectronBC::SakiyamaSecondaryElectronBC(const InputParameters &
 
     _r_units(1. / getParam<Real>("position_units")),
     _num_ions(coupledComponents("ions")),
-    _user_se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
+    _se_coeff_names(getParam<std::vector<std::string>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
 
     _a(0.5),
     _ion_flux(0, 0, 0)
 {
-  if (_user_se_coeff.size() != _num_ions)
-    mooseError("SakiyamaSecondaryElectronBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be "
+  if (_se_coeff_names.size() != _num_ions)
+    mooseError("SakiyamaSecondaryElectronBC with name ",
+               name(),
+               ": The lengths of `ions` and `emission_coeffs` must be "
                "the same");
   _ip.resize(_num_ions);
   _muip.resize(_num_ions);
   _sgnip.resize(_num_ions);
+  _se_coeff.resize(_num_ions);
 
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
     _ip[i] = &adCoupledValue("ions", i);
     _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
     _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
+    _se_coeff[i] = &getADMaterialProperty<Real>(_se_coeff_names[i]);
   }
 }
 
@@ -73,7 +77,7 @@ SakiyamaSecondaryElectronBC::computeQpResidual()
       _a = 0.0;
     }
 
-    _ion_flux += _user_se_coeff[i] * _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] *
+    _ion_flux += (*_se_coeff[i])[_qp] * _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] *
                  -_grad_potential[_qp] * _r_units * std::exp((*_ip[i])[_qp]);
   }
 

--- a/src/bcs/SakiyamaSecondaryElectronBC.C
+++ b/src/bcs/SakiyamaSecondaryElectronBC.C
@@ -18,9 +18,14 @@ SakiyamaSecondaryElectronBC::validParams()
   InputParameters params = ADIntegratedBC::validParams();
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addParam<Real>("users_gamma",
-                        "A secondary electron emission coeff. only used for this BC.");
+  params.addRequiredParam<std::vector<Real>>(
+      "users_gamma", "A secondary electron emission coeff. only used for this BC.");
+  params.deprecateParam("users_gamma", "emission_coeffs", "06/01/2024");
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs", "A list of species dependent secondary electron emmisions coefficients");
   params.addClassDescription("Kinetic secondary electron boundary condition"
                              "(Based on DOI: https://doi.org/10.1116/1.579300)");
   return params;
@@ -30,25 +35,26 @@ SakiyamaSecondaryElectronBC::SakiyamaSecondaryElectronBC(const InputParameters &
   : ADIntegratedBC(parameters),
 
     _r_units(1. / getParam<Real>("position_units")),
-
+    _num_ions(coupledComponents("ions")),
+    _user_se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
 
     _a(0.5),
-    _ion_flux(0, 0, 0),
-    _user_se_coeff(getParam<Real>("users_gamma"))
+    _ion_flux(0, 0, 0)
 {
-  _num_ions = coupledComponents("ip");
-
+  if (_user_se_coeff.size() != _num_ions)
+    mooseError("SakiyamaSecondaryElectronBC: The lengths of `ions` and `emission_coeffs` must be "
+               "the same");
   _ip.resize(_num_ions);
   _muip.resize(_num_ions);
   _sgnip.resize(_num_ions);
 
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ip[i] = &adCoupledValue("ip", i);
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
+    _ip[i] = &adCoupledValue("ions", i);
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
   }
 }
 
@@ -67,9 +73,9 @@ SakiyamaSecondaryElectronBC::computeQpResidual()
       _a = 0.0;
     }
 
-    _ion_flux += _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *
-                 std::exp((*_ip[i])[_qp]);
+    _ion_flux += _user_se_coeff[i] * _a * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] *
+                 -_grad_potential[_qp] * _r_units * std::exp((*_ip[i])[_qp]);
   }
 
-  return -_test[_i][_qp] * _r_units * _a * _user_se_coeff * _ion_flux * _normals[_qp];
+  return -_test[_i][_qp] * _r_units * _a * _ion_flux * _normals[_qp];
 }

--- a/src/bcs/SchottkyEmissionBC.C
+++ b/src/bcs/SchottkyEmissionBC.C
@@ -25,8 +25,8 @@ SchottkyEmissionBC::validParams()
   params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<std::vector<Real>>("emission_coeffs",
-                                             "A list of species dependent secondary electron "
-                                             "emmision coefficients for each species in `ions`");
+                                             "A list of species-dependent secondary electron "
+                                             "emission coefficients for each species in `ions`");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addParam<Real>("tau", 1e-9, "The time constant for ramping the boundary condition.");
@@ -60,7 +60,7 @@ SchottkyEmissionBC::SchottkyEmissionBC(const InputParameters & parameters)
 
 {
   if (_se_coeff.size() != _num_ions)
-    mooseError("SchottkyEmissionBC: The lengths of `ions` and `emission_coeffs` must be the same");
+    mooseError("SchottkyEmissionBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
 
   if (_potential_units.compare("V") == 0)
   {

--- a/src/bcs/SchottkyEmissionBC.C
+++ b/src/bcs/SchottkyEmissionBC.C
@@ -24,9 +24,10 @@ SchottkyEmissionBC::validParams()
   params.addRequiredCoupledVar("ip", "The ion density.");
   params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
-  params.addRequiredParam<std::vector<Real>>("emission_coeffs",
-                                             "A list of species-dependent secondary electron "
-                                             "emission coefficients for each species in `ions`");
+  params.addRequiredParam<std::vector<std::string>>(
+      "emission_coeffs",
+      "A list of species-dependent secondary electron "
+      "emission coefficients for each species in `ions`");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::string>("potential_units", "The potential units.");
   params.addParam<Real>("tau", 1e-9, "The time constant for ramping the boundary condition.");
@@ -40,7 +41,7 @@ SchottkyEmissionBC::SchottkyEmissionBC(const InputParameters & parameters)
     _r_units(1. / getParam<Real>("position_units")),
     _r(getParam<Real>("r")),
     _num_ions(coupledComponents("ions")),
-    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
+    _se_coeff_names(getParam<std::vector<std::string>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
     _mean_en(adCoupledValue("electron_energy")),
@@ -59,8 +60,10 @@ SchottkyEmissionBC::SchottkyEmissionBC(const InputParameters & parameters)
     _potential_units(getParam<std::string>("potential_units"))
 
 {
-  if (_se_coeff.size() != _num_ions)
-    mooseError("SchottkyEmissionBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
+  if (_se_coeff_names.size() != _num_ions)
+    mooseError("SchottkyEmissionBC with name ",
+               name(),
+               ": The lengths of `ions` and `emission_coeffs` must be the same");
 
   if (_potential_units.compare("V") == 0)
   {
@@ -80,6 +83,7 @@ SchottkyEmissionBC::SchottkyEmissionBC(const InputParameters & parameters)
   _sgnip.resize(_num_ions);
   _muip.resize(_num_ions);
   _Dip.resize(_num_ions);
+  _se_coeff.resize(_num_ions);
 
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
@@ -89,19 +93,13 @@ SchottkyEmissionBC::SchottkyEmissionBC(const InputParameters & parameters)
     _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
     _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
     _Dip[i] = &getADMaterialProperty<Real>("diff" + (*getVar("ions", i)).name());
+    _se_coeff[i] = &getADMaterialProperty<Real>(_se_coeff_names[i]);
   }
 }
 
 ADReal
 SchottkyEmissionBC::computeQpResidual()
 {
-  ADReal dPhi;
-  Real kB;
-  ADReal jRD;
-  ADReal jSE;
-  ADReal F;
-  Real _relaxation_Expr;
-
   _v_thermal =
       std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_mean_en[_qp] - _u[_qp]) / (M_PI * _massem[_qp]));
 
@@ -117,7 +115,7 @@ SchottkyEmissionBC::computeQpResidual()
     _ion_flux.zero();
     for (unsigned int i = 0; i < _num_ions; ++i)
     {
-      _ion_flux += _se_coeff[i] *
+      _ion_flux += (*_se_coeff[i])[_qp] *
                    ((*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *
                         std::exp((*_ip[i])[_qp]) -
                     (*_Dip[i])[_qp] * std::exp((*_ip[i])[_qp]) * (*_grad_ip[i])[_qp] * _r_units);

--- a/src/bcs/SchottkyEmissionBC.C
+++ b/src/bcs/SchottkyEmissionBC.C
@@ -115,7 +115,7 @@ SchottkyEmissionBC::computeQpResidual()
     _a = 0.0;
 
     _ion_flux.zero();
-    for (auto i = 0; i < _num_ions; ++i)
+    for (unsigned int i = 0; i < _num_ions; ++i)
     {
       _ion_flux += _se_coeff[i] *
                    ((*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] * _r_units *

--- a/src/bcs/SecondaryElectronBC.C
+++ b/src/bcs/SecondaryElectronBC.C
@@ -27,7 +27,7 @@ SecondaryElectronBC::validParams()
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::vector<Real>>(
-      "emission_coeffs", "A list of species dependent secondary electron emmision coefficients");
+      "emission_coeffs", "A list of species-dependent secondary electron emission coefficients");
   return params;
 }
 
@@ -55,7 +55,7 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
   _n_gamma = 0.0;
 
   if (_se_coeff.size() != _num_ions)
-    mooseError("SecondaryElectronBC: The lengths of `ions` and `emission_coeffs` must be the same");
+    mooseError("SecondaryElectronBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);
   _grad_ip.resize(_num_ions);

--- a/src/bcs/SecondaryElectronBC.C
+++ b/src/bcs/SecondaryElectronBC.C
@@ -20,8 +20,14 @@ SecondaryElectronBC::validParams()
   params.addParam<Real>("r_ion", 0, "The reflection coefficient of the ions.");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("mean_en", "The mean energy.");
+  params.deprecateCoupledVar("mean_en", "electron_energy", "06/01/2024");
+  params.addRequiredCoupledVar("electron_energy", "The mean electron energy density in log form");
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs", "A list of species dependent secondary electron emmision coefficients");
   return params;
 }
 
@@ -31,15 +37,16 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
     _r(getParam<Real>("r")),
     _r_ion(getParam<Real>("r_ion")),
     _kb(getMaterialProperty<Real>("k_boltz")),
-
+    _num_ions(coupledComponents("ions")),
+    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
-    _mean_en(adCoupledValue("mean_en")),
+    _mean_en(adCoupledValue("electron_energy")),
 
     _muem(getADMaterialProperty<Real>("muem")),
     _massem(getMaterialProperty<Real>("massem")),
-    _e(getMaterialProperty<Real>("e")),
-    _se_coeff(getMaterialProperty<Real>("se_coeff"))
+    _e(getMaterialProperty<Real>("e"))
+
 {
   _ion_flux = 0;
   _a = 0.5;
@@ -47,8 +54,8 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
   _v_thermal = 0.0;
   _n_gamma = 0.0;
 
-  _num_ions = coupledComponents("ip");
-
+  if (_se_coeff.size() != _num_ions)
+    mooseError("SecondaryElectronBC: The lengths of `ions` and `emission_coeffs` must be the same");
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);
   _grad_ip.resize(_num_ions);
@@ -64,12 +71,12 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
   // refers to a single ion species.
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ip[i] = &adCoupledValue("ip", i);
-    _grad_ip[i] = &adCoupledGradient("ip", i);
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _Tip[i] = &getADMaterialProperty<Real>("T" + (*getVar("ip", i)).name());
-    _massip[i] = &getMaterialProperty<Real>("mass" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
+    _ip[i] = &adCoupledValue("ions", i);
+    _grad_ip[i] = &adCoupledGradient("ions", i);
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _Tip[i] = &getADMaterialProperty<Real>("T" + (*getVar("ions", i)).name());
+    _massip[i] = &getMaterialProperty<Real>("mass" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
   }
 }
 
@@ -92,14 +99,14 @@ SecondaryElectronBC::computeQpResidual()
       _b = 1.0;
     else
       _b = 0.0;
-    _ion_flux += std::exp((*_ip[i])[_qp]) *
+    _ion_flux += _se_coeff[i] * std::exp((*_ip[i])[_qp]) *
                  (0.5 * std::sqrt(8 * _kb[_qp] * (*_Tip[i])[_qp] / (M_PI * (*_massip[i])[_qp])) +
                   (2 * _b - 1) * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] *
                       _r_units * _normals[_qp]);
   }
   _ion_flux *= (1.0 - _r_ion) / (1.0 + _r_ion);
 
-  _n_gamma = (1. - _a) * _se_coeff[_qp] * _ion_flux /
+  _n_gamma = (1. - _a) * _ion_flux /
              (_muem[_qp] * -_grad_potential[_qp] * _r_units * _normals[_qp] +
               std::numeric_limits<double>::epsilon());
   _v_thermal =
@@ -107,5 +114,5 @@ SecondaryElectronBC::computeQpResidual()
 
   return _test[_i][_qp] * _r_units *
          ((1. - _r) / (1. + _r) * (-0.5 * _v_thermal * _n_gamma) -
-          2. / (1. + _r) * (1. - _a) * _se_coeff[_qp] * _ion_flux);
+          2. / (1. + _r) * (1. - _a) * _ion_flux);
 }

--- a/src/bcs/SecondaryElectronBC.C
+++ b/src/bcs/SecondaryElectronBC.C
@@ -26,7 +26,7 @@ SecondaryElectronBC::validParams()
   params.deprecateCoupledVar("ip", "ions", "06/01/2024");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addRequiredParam<std::vector<Real>>(
+  params.addRequiredParam<std::vector<std::string>>(
       "emission_coeffs", "A list of species-dependent secondary electron emission coefficients");
   return params;
 }
@@ -38,7 +38,7 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
     _r_ion(getParam<Real>("r_ion")),
     _kb(getMaterialProperty<Real>("k_boltz")),
     _num_ions(coupledComponents("ions")),
-    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
+    _se_coeff_names(getParam<std::vector<std::string>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
     _mean_en(adCoupledValue("electron_energy")),
@@ -54,8 +54,10 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
   _v_thermal = 0.0;
   _n_gamma = 0.0;
 
-  if (_se_coeff.size() != _num_ions)
-    mooseError("SecondaryElectronBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
+  if (_se_coeff_names.size() != _num_ions)
+    mooseError("SecondaryElectronBC with name ",
+               name(),
+               ": The lengths of `ions` and `emission_coeffs` must be the same");
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);
   _grad_ip.resize(_num_ions);
@@ -63,6 +65,7 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
   _Tip.resize(_num_ions);
   _massip.resize(_num_ions);
   _sgnip.resize(_num_ions);
+  _se_coeff.resize(_num_ions);
 
   // Retrieve the values for each ion and store in the relevant vectors.
   // Note that these need to be dereferenced to get the values inside the
@@ -77,6 +80,7 @@ SecondaryElectronBC::SecondaryElectronBC(const InputParameters & parameters)
     _Tip[i] = &getADMaterialProperty<Real>("T" + (*getVar("ions", i)).name());
     _massip[i] = &getMaterialProperty<Real>("mass" + (*getVar("ions", i)).name());
     _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
+    _se_coeff[i] = &getADMaterialProperty<Real>(_se_coeff_names[i]);
   }
 }
 
@@ -99,7 +103,7 @@ SecondaryElectronBC::computeQpResidual()
       _b = 1.0;
     else
       _b = 0.0;
-    _ion_flux += _se_coeff[i] * std::exp((*_ip[i])[_qp]) *
+    _ion_flux += (*_se_coeff[i])[_qp] * std::exp((*_ip[i])[_qp]) *
                  (0.5 * std::sqrt(8 * _kb[_qp] * (*_Tip[i])[_qp] / (M_PI * (*_massip[i])[_qp])) +
                   (2 * _b - 1) * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] *
                       _r_units * _normals[_qp]);

--- a/src/bcs/SecondaryElectronEnergyBC.C
+++ b/src/bcs/SecondaryElectronEnergyBC.C
@@ -28,7 +28,7 @@ SecondaryElectronEnergyBC::validParams()
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
   params.addRequiredParam<std::vector<Real>>(
-      "emission_coeffs", "A species dependent list of secondary electron emmision coefficients");
+      "emission_coeffs", "A species-dependent list of secondary electron emission coefficients");
   params.addRequiredParam<Real>("secondary_electron_energy", "The secondary electron energy in eV");
   return params;
 }
@@ -60,7 +60,7 @@ SecondaryElectronEnergyBC::SecondaryElectronEnergyBC(const InputParameters & par
 
   if (_se_coeff.size() != _num_ions)
     mooseError(
-        "SecondaryElectronEnergyBC: The lengths of `ions` and `emission_coeffs` must be the same");
+        "SecondaryElectronEnergyBC with name ", name(), ": The lengths of `ions` and `emission_coeffs` must be the same");
 
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);

--- a/src/bcs/SecondaryElectronEnergyBC.C
+++ b/src/bcs/SecondaryElectronEnergyBC.C
@@ -20,8 +20,16 @@ SecondaryElectronEnergyBC::validParams()
   params.addParam<Real>("r_ion", 0, "The reflection coefficient of the ions.");
   params.addRequiredCoupledVar("potential", "The electric potential");
   params.addRequiredCoupledVar("em", "The electron density.");
+  params.deprecateCoupledVar("em", "electrons", "06/01/2024");
+  params.addRequiredCoupledVar("electrons", "The electron density in log form");
+
   params.addRequiredCoupledVar("ip", "The ion density.");
+  params.deprecateCoupledVar("ip", "ions", "06/01/2024");
+  params.addRequiredCoupledVar("ions", "A list of ion densities in log form");
   params.addRequiredParam<Real>("position_units", "Units of position.");
+  params.addRequiredParam<std::vector<Real>>(
+      "emission_coeffs", "A species dependent list of secondary electron emmision coefficients");
+  params.addRequiredParam<Real>("secondary_electron_energy", "The secondary electron energy in eV");
   return params;
 }
 
@@ -31,16 +39,17 @@ SecondaryElectronEnergyBC::SecondaryElectronEnergyBC(const InputParameters & par
     _r(getParam<Real>("r")),
     _r_ion(getParam<Real>("r_ion")),
     _kb(getMaterialProperty<Real>("k_boltz")),
-
+    _num_ions(coupledComponents("ions")),
+    _se_coeff(getParam<std::vector<Real>>("emission_coeffs")),
     // Coupled Variables
     _grad_potential(adCoupledGradient("potential")),
-    _em(adCoupledValue("em")),
+    _em(adCoupledValue("electrons")),
 
     _muem(getADMaterialProperty<Real>("muem")),
     _massem(getMaterialProperty<Real>("massem")),
     _e(getMaterialProperty<Real>("e")),
-    _se_coeff(getMaterialProperty<Real>("se_coeff")),
-    _se_energy(getMaterialProperty<Real>("se_energy")),
+
+    _se_energy(getParam<Real>("secondary_electron_energy")),
     _mumean_en(getADMaterialProperty<Real>("mumean_en"))
 {
   _ion_flux = 0;
@@ -49,7 +58,9 @@ SecondaryElectronEnergyBC::SecondaryElectronEnergyBC(const InputParameters & par
   _v_thermal = 0.0;
   _n_gamma = 0.0;
 
-  _num_ions = coupledComponents("ip");
+  if (_se_coeff.size() != _num_ions)
+    mooseError(
+        "SecondaryElectronEnergyBC: The lengths of `ions` and `emission_coeffs` must be the same");
 
   // Resize the vectors to store _num_ions values:
   _ip.resize(_num_ions);
@@ -66,12 +77,12 @@ SecondaryElectronEnergyBC::SecondaryElectronEnergyBC(const InputParameters & par
   // refers to a single ion species.
   for (unsigned int i = 0; i < _num_ions; ++i)
   {
-    _ip[i] = &adCoupledValue("ip", i);
-    _grad_ip[i] = &adCoupledGradient("ip", i);
-    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ip", i)).name());
-    _Tip[i] = &getADMaterialProperty<Real>("T" + (*getVar("ip", i)).name());
-    _massip[i] = &getMaterialProperty<Real>("mass" + (*getVar("ip", i)).name());
-    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ip", i)).name());
+    _ip[i] = &adCoupledValue("ions", i);
+    _grad_ip[i] = &adCoupledGradient("ions", i);
+    _muip[i] = &getADMaterialProperty<Real>("mu" + (*getVar("ions", i)).name());
+    _Tip[i] = &getADMaterialProperty<Real>("T" + (*getVar("ions", i)).name());
+    _massip[i] = &getMaterialProperty<Real>("mass" + (*getVar("ions", i)).name());
+    _sgnip[i] = &getMaterialProperty<Real>("sgn" + (*getVar("ions", i)).name());
   }
 }
 
@@ -94,13 +105,13 @@ SecondaryElectronEnergyBC::computeQpResidual()
       _b = 1.0;
     else
       _b = 0.0;
-    _ion_flux += std::exp((*_ip[i])[_qp]) *
+    _ion_flux += _se_coeff[i] * std::exp((*_ip[i])[_qp]) *
                  (0.5 * std::sqrt(8 * _kb[_qp] * (*_Tip[i])[_qp] / (M_PI * (*_massip[i])[_qp])) +
                   (2 * _b - 1) * (*_sgnip[i])[_qp] * (*_muip[i])[_qp] * -_grad_potential[_qp] *
                       _r_units * _normals[_qp]);
   }
 
-  _n_gamma = (1. - _a) * _se_coeff[_qp] * _ion_flux /
+  _n_gamma = (1. - _a) * _ion_flux /
              (_muem[_qp] * -_grad_potential[_qp] * _r_units * _normals[_qp] +
               std::numeric_limits<double>::epsilon());
 
@@ -108,6 +119,6 @@ SecondaryElectronEnergyBC::computeQpResidual()
       std::sqrt(8 * _e[_qp] * 2.0 / 3 * std::exp(_u[_qp] - _em[_qp]) / (M_PI * _massem[_qp]));
 
   return _test[_i][_qp] * _r_units *
-         ((1 - _r) / (1 + _r) * (-5. / 6. * _v_thermal * _n_gamma * _se_energy[_qp]) -
-          5. / 3. * (2. / (1 + _r)) * _se_energy[_qp] * (1 - _a) * _se_coeff[_qp] * _ion_flux);
+         ((1 - _r) / (1 + _r) * (-5. / 6. * _v_thermal * _n_gamma * _se_energy) -
+          5. / 3. * (2. / (1 + _r)) * _se_energy * (1 - _a) * _ion_flux);
 }

--- a/test/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
+++ b/test/tests/1d_dc/NonlocalPotentialBCWithSchottky.i
@@ -566,6 +566,7 @@ area = 5.02e-7 # Formerly 3.14e-6
     position_units = ${dom0Scale}
     tau = ${relaxTime}
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/1d_dc/densities_mean_en.i
+++ b/test/tests/1d_dc/densities_mean_en.i
@@ -753,6 +753,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -811,6 +812,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/1d_dc/mean_en.i
+++ b/test/tests/1d_dc/mean_en.i
@@ -770,6 +770,8 @@ dom1Scale = 1e-7
     em = em
     ip = 'Arp'
     r = 0
+    emission_coeffs = 0.05
+    secondary_electron_energy = 3
     position_units = ${dom0Scale}
   []
 
@@ -784,6 +786,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -835,6 +838,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/1d_dc/mean_en_multi.i
+++ b/test/tests/1d_dc/mean_en_multi.i
@@ -839,6 +839,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -897,6 +898,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC
@@ -958,6 +960,8 @@ dom1Scale = 1e-7
     em = em
     ip = 'Arp'
     r = 0
+    emission_coeffs = 0.05
+    secondary_electron_energy = 3
     position_units = ${dom0Scale}
   []
   [emliq_right]

--- a/test/tests/DriftDiffusionAction/mean_en_actions.i
+++ b/test/tests/DriftDiffusionAction/mean_en_actions.i
@@ -468,7 +468,9 @@ dom1Scale = 1e-7
     em = em
     ip = 'Arp'
     r = 0
+    emission_coeffs = 0.05
     position_units = ${dom0Scale}
+    secondary_electron_energy = 3
   []
 
   [potential_left]
@@ -482,6 +484,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -532,6 +535,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/DriftDiffusionAction/mean_en_no_actions.i
+++ b/test/tests/DriftDiffusionAction/mean_en_no_actions.i
@@ -843,6 +843,8 @@ dom1Scale = 1e-7
     em = em
     ip = 'Arp'
     r = 0
+    emission_coeffs = 0.05
+    secondary_electron_energy = 3
     position_units = ${dom0Scale}
   []
 
@@ -857,6 +859,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -907,6 +910,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/Schottky_emission/Example1/Input.i
+++ b/test/tests/Schottky_emission/Example1/Input.i
@@ -498,6 +498,7 @@ vhigh = -200E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -520,6 +521,7 @@ vhigh = -200E-3 #kV
     position_units = ${dom0Scale}
     # tau = 10E-6
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/Schottky_emission/Example2/Input.i
+++ b/test/tests/Schottky_emission/Example2/Input.i
@@ -498,6 +498,7 @@ vhigh = -80E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -520,6 +521,7 @@ vhigh = -80E-3 #kV
     position_units = ${dom0Scale}
     # tau = 10E-6
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/Schottky_emission/Example3/Input.i
+++ b/test/tests/Schottky_emission/Example3/Input.i
@@ -501,6 +501,7 @@ threeTimesRelaxTime = 150E-6 #s
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -523,6 +524,7 @@ threeTimesRelaxTime = 150E-6 #s
     position_units = ${dom0Scale}
     # tau = ${relaxTime}
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/Schottky_emission/Example4/Input.i
+++ b/test/tests/Schottky_emission/Example4/Input.i
@@ -564,6 +564,7 @@ area = 5.02e-7 # Formerly 3.14e-6
     position_units = ${dom0Scale}
     tau = ${relaxTime}
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/Schottky_emission/PaschenLaw/Input.i
+++ b/test/tests/Schottky_emission/PaschenLaw/Input.i
@@ -499,6 +499,7 @@ vhigh = -0.10 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -521,6 +522,7 @@ vhigh = -0.10 #kV
     position_units = ${dom0Scale}
     # tau = 5E-6
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/automatic_differentiation/ad_argon.i
+++ b/test/tests/automatic_differentiation/ad_argon.i
@@ -510,7 +510,9 @@ dom0Scale = 1e-3
     em = em
     ip = 'Arp Ar2p'
     r = 0
+    emission_coeffs = '0.05 0.05'
     position_units = ${dom0Scale}
+    secondary_electron_energy = 3
   []
 
   [potential_left]
@@ -524,6 +526,7 @@ dom0Scale = 1e-3
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = '0.05 0.05'
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -590,6 +593,7 @@ dom0Scale = 1e-3
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/crane_action/townsend_units.i
+++ b/test/tests/crane_action/townsend_units.i
@@ -711,6 +711,8 @@ dom1Scale = 1e-7
     em = em
     ip = 'Arp'
     r = 0
+    emission_coeffs = 0.05
+    secondary_electron_energy = 3
     position_units = ${dom0Scale}
   []
 
@@ -725,6 +727,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC
@@ -776,6 +779,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [Arp_physical_left_diffusion]
     type = HagelaarIonDiffusionBC

--- a/test/tests/field_emission/field_emission.i
+++ b/test/tests/field_emission/field_emission.i
@@ -501,6 +501,7 @@ vhigh = -0.15 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   [potential_dirichlet_right]
     type = DirichletBC

--- a/test/tests/reflections/Schottky/Input.i
+++ b/test/tests/reflections/Schottky/Input.i
@@ -492,6 +492,7 @@ vhigh = -150E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -512,6 +513,7 @@ vhigh = -150E-3 #kV
     mean_en = mean_en
     r = 1
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/reflections/Schottky_300_V_5_um/Input.i
+++ b/test/tests/reflections/Schottky_300_V_5_um/Input.i
@@ -497,6 +497,7 @@ vhigh = -400E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -519,6 +520,7 @@ vhigh = -400E-3 #kV
     position_units = ${dom0Scale}
     tau = 100E-9
     relax = true
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]
@@ -582,6 +584,8 @@ vhigh = -400E-3 #kV
     ip = Arp
     r = 0
     position_units = ${dom0Scale}
+    secondary_electron_energy = 3
+    emission_coeffs = 0.02
   []
 
   [mean_en_physical_right]
@@ -656,3 +660,4 @@ vhigh = -400E-3 #kV
     block = 0
   []
 []
+

--- a/test/tests/reflections/Schottky_400_V_10_um/Input.i
+++ b/test/tests/reflections/Schottky_400_V_10_um/Input.i
@@ -494,6 +494,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   [potential_dirichlet_right]
@@ -514,6 +515,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 1
     position_units = ${dom0Scale}
+    emission_coeffs = 0.02
   []
 
   # [em_physical_left]

--- a/test/tests/reflections/base/Input.i
+++ b/test/tests/reflections/base/Input.i
@@ -489,6 +489,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [potential_dirichlet_right]
@@ -508,6 +509,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 1
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [em_physical_left]

--- a/test/tests/reflections/high_initial/Input.i
+++ b/test/tests/reflections/high_initial/Input.i
@@ -491,6 +491,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [potential_dirichlet_right]
@@ -510,6 +511,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 1
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [em_physical_left]

--- a/test/tests/reflections/low_initial/Input.i
+++ b/test/tests/reflections/low_initial/Input.i
@@ -491,6 +491,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [potential_dirichlet_right]
@@ -510,6 +511,7 @@ vhigh = -175E-3 #kV
     mean_en = mean_en
     r = 1
     position_units = ${dom0Scale}
+    emission_coeffs = 0.01
   []
 
   [em_physical_left]

--- a/tutorial/tutorial05-PlasmaWaterInterface/DC_argon-With-Water.i
+++ b/tutorial/tutorial05-PlasmaWaterInterface/DC_argon-With-Water.i
@@ -219,6 +219,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
   #Ground electrode under the water
   [potential_dirichlet_right]
@@ -247,6 +248,7 @@ dom1Scale = 1e-7
     mean_en = mean_en
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
   []
 
   #Mean electron energy on the powered electrode
@@ -268,6 +270,8 @@ dom1Scale = 1e-7
     ip = 'Arp'
     r = 0
     position_units = ${dom0Scale}
+    emission_coeffs = 0.05
+    secondary_electron_energy = 3
   []
 
   #Argon ions on the powered electrode


### PR DESCRIPTION
- input parameters were made consistent with issue #223
- secondary electron emmision coefficients were made material and species dependent
- secondary electron energy was moved to a BC input parameters
- several test inputs were updated in order to facilitate this as well