### PR TITLE
Bump GitHub action to 4 cores for website build

### DIFF
--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -25,12 +25,12 @@ jobs:
         use-mamba: true
         activate-environment: zapdos
         environment-file: scripts/conda_environment.yml
-    # GitHub-hosted runners are currently limited to 2 cores
+    # GitHub-hosted runners are currently limited to 4 cores
     # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
     - name: Build Zapdos
       run: |
         conda activate zapdos
-        make -j2
+        make -j4
     - name: Build Doxygen
       uses: mattnotmitt/doxygen-action@v1.9.5
       with:
@@ -38,7 +38,7 @@ jobs:
     - name: Build MooseDocs
       run: |
         cd doc
-        ./moosedocs.py build --destination site
+        ./moosedocs.py build --num-threads 4 --destination site
     - name: Update gh-pages branch
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
![image](https://github.com/shannon-lab/zapdos/assets/16690058/c9f26cdc-15ad-4b0a-93d6-80004c7efbc4)

https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

We now have access to 4 cores in our actions! Bumping the website generation script accordingly. 
