### PR TITLE
Website modifications and add a mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,7 +7,6 @@ Casey Icenhour <cticehour@gmail.com>
 Shane Keniley <keniley1@illinois.edu>
 Corey DeChant <csdechan@ncsu.edu>
 Corey DeChant <37221357+csdechant@users.noreply.github.com>
-Corey DeChant <csdechan@ncsu.edu>
 John Ryan Haase <jhaase1@nd.edu>
 John Ryan Haase <jhaase1@users.noreply.github.com>
 Cody Permann <codypermann@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,23 @@
+Alex Lindsay <adlinds3@ncsu.edu>
+Alex Lindsay <lindsayad@users.noreply.github.com>
+Alex Lindsay <alexlindsay239@gmail.com>
+Casey Icenhour <cticenho@ncsu.edu>
+Casey Icenhour <casey.icenhour@inl.gov>
+Casey Icenhour <cticehour@gmail.com>
+Shane Keniley <keniley1@illinois.edu>
+Corey DeChant <csdechan@ncsu.edu>
+Corey DeChant <37221357+csdechant@users.noreply.github.com>
+Corey DeChant <csdechan@ncsu.edu>
+John Ryan Haase <jhaase1@nd.edu>
+John Ryan Haase <jhaase1@users.noreply.github.com>
+Cody Permann <codypermann@gmail.com>
+Cody Permann <cody.permann@inl.gov>
+Cody Permann <Cody.Permann@inl.gov>
+Derek Gaston <friedmud@gmail.com>
+Derek Gaston <derek.gaston@inl.gov>
+Grayson Gall <ggall713@gmail.com>
+Grayson Gall <66559200+gsgall@users.noreply.github.com>
+Daniel Schwen <daniel.schwen@inl.gov>
+Daniel Schwen <daniel@schwen.de>
+MOOSE maintenance <bounces@inl.gov>
+Mengnan Li <118846840+MengnanLi91@users.noreply.github.com>

--- a/doc/content/bib/documentation.bib
+++ b/doc/content/bib/documentation.bib
@@ -1,0 +1,24 @@
+@article{Lymberopoulos1993,
+    author = {Lymberopoulos, Dimitris P. and Economou, Demetre J.},
+    title = {Fluid simulations of glow discharges: Effect of metastable atoms in argon},
+    journal = {Journal of Applied Physics},
+    volume = {73},
+    number = {8},
+    pages = {3668-3679},
+    year = {1993},
+    month = {04},
+    issn = {0021-8979},
+    doi = {10.1063/1.352926}
+}
+
+@article{Gogolides1992,
+  author = {E. Gogolides and H.H. Sawin and R.A. Brown},
+  title = {Direct calculation of time-periodic states of continuum models of radio-frequency plasmas},
+  journal = {Chemical Engineering Science},
+  volume = {47},
+  number = {15},
+  pages = {3839-3855},
+  year = {1992},
+  issn = {0009-2509},
+  doi = {10.1016/0009-2509(92)85133-V}
+}

--- a/doc/content/citing.md
+++ b/doc/content/citing.md
@@ -6,15 +6,16 @@
 If you use Zapdos for your publication, please cite the following:
 
 ```
-@Article{zapdos-paper,
-  author = {Alexander D Lindsay and David B Graves and Steven C Shannon},
-  title = {Fully coupled simulation of the plasma liquid interface and interfacial coefficient effects},
-  journal = {J. Phys. D: Appl Phys.},
+@article{zapdos-paper,
+  doi = {10.1088/0022-3727/49/23/235204},
   year = {2016},
+  publisher = {IOP Publishing},
   volume = {49},
   number = {23},
   pages = {235204},
-  note = {\url{http://dx.doi.org/10.1088/0022-3727/49/23/235204}}
+  author = {Alexander D. Lindsay and David B. Graves and Steven C. Shannon},
+  title = {Fully coupled simulation of the plasma liquid interface and interfacial coefficient effects},
+  journal = {Journal of Physics D: Applied Physics}
 }
 ```
 

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -44,9 +44,9 @@ Begin by exploring [our installation page](getting_started/installation.md).
 # Collaborators (current and former) class=center style=font-weight:200;font-size:200%
 
 - [Laboratory of Computational Plasma Physics (University of Illinois Urbana-Champaign)](https://curreli.npre.illinois.edu/)
-- [Go Research Group (University of Notre Dame)](https://gogroup.nd.edu/)
-- [Graves Lab (University of California, Berkeley)](http://www.graveslab.org/)
 - [Oak Ridge National Laboratory, Fusion Energy Division](https://www.ornl.gov/division/fed)
+- [Go Research Group (University of Notre Dame)](https://gogroup.nd.edu/)
+- Graves Lab (University of California, Berkeley)
 
 # Funding Acknowledgements class=center style=font-weight:200;font-size:200%
 
@@ -63,9 +63,9 @@ Begin by exploring [our installation page](getting_started/installation.md).
 - This research is being performed using funding received from the DOE Office of
   Nuclear Energy's [Nuclear Energy University Programs](https://neup.inl.gov/SitePages/Home.aspx).
 
-- This research made use of [Idaho National Laboratory computing resources](https://hpc.inl.gov/)
-  which are supported by the Office of Nuclear Energy of the U.S. Department of
-  Energy and the Nuclear Science User Facilities under Contract No. DE-AC07-05ID14517.
+- This research made use of [Idaho National Laboratory's High Performance Computing systems](https://hpc.inl.gov/)
+  located at the Collaborative Computing Center and supported by the Office of Nuclear Energy of
+  the U.S. Department of Energy and the Nuclear Science User Facilities under Contract No. DE-AC07-05ID14517.
 
 - This research was supported by the [Idaho National Laboratory Graduate Fellowship Program](https://inl.gov/inl-initiatives/education/graduate-fellowship-program/)
   which is supported by the U.S. Department of Energy under Contract No.

--- a/doc/content/source/kernels/ShootMethodLog.md
+++ b/doc/content/source/kernels/ShootMethodLog.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-To reduce the run time of simulations of radio frequency discharges involving neutral particles (such as metastable species), acceleration by shooting method can be implemented. Zapdos' version of the shooting method scheme is based on work presented by [Lymberopoulos and Economou](https://doi.org/10.1063/1.352926), but a more general description of the method can be found by [Gogolides, Sawin and Brown](https://www.sciencedirect.com/science/article/abs/pii/000925099285133V?via%3Dihub). This scheme takes advantage of the fact that a RF discharge will eventually have a periodic steady-state, in the form of:
+To reduce the run time of simulations of radio frequency discharges involving neutral particles (such as metastable species), acceleration by shooting method can be implemented. Zapdos' version of the shooting method scheme is based on work presented by [!cite](Lymberopoulos1993), but a more general description of the method can be found by [!cite](Gogolides1992). This scheme takes advantage of the fact that a RF discharge will eventually have a periodic steady-state, in the form of:
 
 \begin{equation}
   N_{j}(0)-N_{j}(T)=0


### PR DESCRIPTION
Made a few adjustments to the website:

- Cleaned up a broken link for David Graves' old group at UC-Berkeley.
- Updated the INL HPC acknowledgement to reflect the current language.
- Updated the Zapdos BibTeX citation to a slightly better version in the bib files. 
- Added a `documentation.bib` file for BibTeX entries used in the documentation, and demonstrated usage of the MooseDocs BibTeX extension in the body of ShootMethodLog documentation. This bib file should be used for all similar in-text citations that are needed in the text in the future. The other bib files present in `doc/content/bib` are for the "Works that cite Zapdos" listings.

Also added a mailmap file to unify contribution statistics across multiple emails that have creeped into the repository. Without the file, contributors under the same name, but with a different email, would be counted as separate contributors.

@csdechant the MooseDocs demo is the one I mentioned in #227. 