### PR TITLE
Add CITATION.cff file so that Zapdos can use the GitHub citations system

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+cff-version: 1.2.0
+message: "If you use Zapdos, please cite it as below."
+authors:
+- family-names: "Lindsay"
+  given-names: "Alexander"
+  orcid: "https://orcid.org/0000-0002-6988-2123"
+- family-names: "Shannon"
+  given-names: "Steven"
+  orcid: "https://orcid.org/0000-0001-8317-6949"
+- family-names: "Haase"
+  given-names: "John"
+title: "Zapdos"
+version: 0.1.0
+doi: 10.5281/zenodo.801834
+date-released: 2017-06-01
+url: "https://github.com/shannon-lab/zapdos"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Lindsay"
+    given-names: "Alexander D"
+    orcid: "https://orcid.org/0000-0002-6988-2123"
+  - family-names: "Graves"
+    given-names: "David B"
+    orcid: "https://orcid.org/0000-0002-2288-6768"
+  - family-names: "Shannon"
+    given-names: "Steven C"
+    orcid: "https://orcid.org/0000-0001-8317-6949"
+  doi: "10.1088/0022-3727/49/23/235204"
+  journal: "J. Phys. D: Appl Phys."
+  start: 235204
+  title: "Fully coupled simulation of the plasma liquid interface and interfacial coefficient effects"
+  issue: 23
+  volume: 49
+  year: 2016


### PR DESCRIPTION
This uses the current (old) Zenodo information as well as the 2016 paper. We'll update when we perform a release. Using a CITATION.cff file produces a "Cite this repository" link on the right hand side of the repository page, making it even more obvious to a user which citation they should be using. 

See more info about CITATION.cff files here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files