### PR TITLE
Modifying tolerance for 1d_dc test

### DIFF
--- a/test/tests/1d_dc/mean_en_out.cmp
+++ b/test/tests/1d_dc/mean_en_out.cmp
@@ -49,10 +49,10 @@ ELEMENT VARIABLES relative 7.9e-5 floor 0.0
 	Current_em           # min:       45.060467 @ t1,b0,e1	max:       1355.7795 @ t1,b0,e211
 	Current_emliq        # min:       77.590584 @ t1,b1,e274	max:       1355.8411 @ t1,b1,e212
 	Current_Arp          # min:   0.00029148585 @ t1,b0,e201	max:       1310.0395 @ t1,b0,e1
-	Current_OHm          # min:    0.0069512219 @ t1,b1,e212	max:       1278.2575 @ t1,b1,e274
+	Current_OHm relative 9.6e-5 floor 0.0
 	tot_gas_current      # min:          1355.1 @ t1,b0,e1	max:       1355.8114 @ t1,b0,e105
 	tot_liq_current      # min:        1355.848 @ t1,b1,e215	max:        1355.848 @ t1,b1,e274
-	tot_flux_OHm         # min:   7.2168002e-15 @ t1,b1,e212	max:   1.3270945e-09 @ t1,b1,e274
+	tot_flux_OHm relative 9.6e-5 floor 0.0
 	EFieldAdvAux_em      # min:    3.455381e+20 @ t1,b0,e43	max:   7.5835982e+22 @ t1,b0,e211
 	DiffusiveFlux_em     # min:   1.3602054e+18 @ t1,b0,e104	max:    6.736236e+22 @ t1,b0,e211
 	EFieldAdvAux_emliq relative 9.6e-5 floor 0.0


### PR DESCRIPTION
Updates the relative tolerance for a few more variables for this test. This update makes this tolerance consistent with a few other variables which also needed their comparison tolerance changed.

closes #248

