### PR TITLE
Making Periodic Postprocessors more robust 

### DIFF
--- a/src/postprocessors/MultiPeriodAverager.C
+++ b/src/postprocessors/MultiPeriodAverager.C
@@ -41,8 +41,9 @@ MultiPeriodAverager::MultiPeriodAverager(const InputParameters & parameters)
 void
 MultiPeriodAverager::execute()
 {
-  // lets check if we have reached the next period
-  if (std::abs(_t - _next_period_start) <= _dt * 1e-3)
+  // lets check if we will be reaching the next period on the next
+  // time step
+  if ((_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
   {
     _period_count += 1;
     _cyclic_period_count += 1;

--- a/src/postprocessors/MultiPeriodAverager.C
+++ b/src/postprocessors/MultiPeriodAverager.C
@@ -17,11 +17,14 @@ MultiPeriodAverager::validParams()
   InputParameters params = GeneralPostprocessor::validParams();
   params.addClassDescription(
       "Calculate the average value of a post processor over multiple periods");
-  params.addParam<Real>("number_of_periods", "The number of periods over which you are averaging");
+  params.addRangeCheckedParam<Real>("number_of_periods",
+                                    "number_of_periods > 0",
+                                    "The number of periods over which you are averaging");
   params.addParam<PostprocessorName>(
       "value", "The name of the postprocessor you would like to average over multiple periods");
-  params.addParam<Real>(
+  params.addRequiredRangeCheckedParam<Real>(
       "cycle_frequency",
+      "cycle_frequency > 0",
       "The frequency of the process. Used to calculate the period over which you are integrating.");
   return params;
 }

--- a/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
+++ b/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
@@ -18,8 +18,9 @@ PeriodicTimeIntegratedPostprocessor::validParams()
   InputParameters params = MultipliedTimeIntegratedPostprocessor::validParams();
   params.addClassDescription(
       "Integrate a Postprocessor value over a period in time using trapezoidal rule.");
-  params.addParam<Real>(
+  params.addRangeCheckedParam<Real>(
       "cycle_frequency",
+      "cycle_frequency > 0",
       "The frequency of the process. Used to calculate the period over which you are integrating.");
   return params;
 }

--- a/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
+++ b/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
@@ -38,8 +38,9 @@ PeriodicTimeIntegratedPostprocessor::execute()
 {
   // performing the integral
   MultipliedTimeIntegratedPostprocessor::execute();
-  // checking if we are on the next period or not if so reset the integral
-  if (std::abs(_t - _next_period_start) <= _dt * 1e-3)
+  // lets check if we will be reaching the next period on the next
+  // time step
+  if ((_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
   {
     _period_count++;
     _next_period_start = (_period_count + 1) * _period;

--- a/test/tests/postprocessors/multi_period_averaging/multi_period_averager.i
+++ b/test/tests/postprocessors/multi_period_averaging/multi_period_averager.i
@@ -67,7 +67,6 @@
   []
 []
 
-
 [Executioner]
   type = Transient
   end_time = 41

--- a/test/tests/postprocessors/multi_period_averaging/multi_period_averager.i
+++ b/test/tests/postprocessors/multi_period_averaging/multi_period_averager.i
@@ -46,6 +46,7 @@
 [GlobalParams]
   cycle_frequency = 0.1
 []
+
 [Postprocessors]
   [a]
     type = ElementIntegralVariablePostprocessor

--- a/test/tests/postprocessors/multi_period_averaging/tests
+++ b/test/tests/postprocessors/multi_period_averaging/tests
@@ -1,10 +1,27 @@
 [Tests]
-  [receiver]
+  design = 'MultiPeriodAverager.md'
+  issues = '#222 #253'
+  [averaging]
     type = CSVDiff
     input = multi_period_averager.i
     csvdiff = multi_period_averager_out.csv
-    requirement = "Take the average value of a postprocesser over multiple periods"
-    design = 'MultiPeriodAverager.md'
-    issues = '#222'
+    requirement = "Take the average value of a postprocesser over multiple periods."
+  []
+  [errors]
+    requirement = "The system shall report a reasonable error when the user provides an invalid"
+    [invalid_number_of_periods]
+      type = RunException
+      input = multi_period_averager.i
+      cli_args = 'Postprocessors/multi_period/number_of_periods=0'
+      expect_err = 'Range check failed for parameter Postprocessors/multi_period/number_of_period'
+      detail = 'number of periods.'
+    []
+    [invalid_cycle_frequency]
+      type = RunException
+      input = multi_period_averager.i
+      cli_args = 'Postprocessors/multi_period/cycle_frequency=0'
+      expect_err = 'Range check failed for parameter Postprocessors/multi_period/cycle_frequency'
+      detail = 'cycle frequency.'
+    []
   []
 []

--- a/test/tests/postprocessors/multiplied_time_integration/tests
+++ b/test/tests/postprocessors/multiplied_time_integration/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [receiver]
+  [test]
     type = CSVDiff
     input = multiplied_integral.i
     csvdiff = multiplied_integral_out.csv

--- a/test/tests/postprocessors/periodic_amplitude_regulator/tests
+++ b/test/tests/postprocessors/periodic_amplitude_regulator/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [receiver]
+  [test]
     type = CSVDiff
     input = periodic_modifier.i
     csvdiff = periodic_modifier_out.csv

--- a/test/tests/postprocessors/periodic_integration/tests
+++ b/test/tests/postprocessors/periodic_integration/tests
@@ -1,10 +1,20 @@
 [Tests]
-  [receiver]
+  design = 'PeriodicTimeIntegratedPostprocessor.md'
+  issues = '#222 #253'
+  [test]
     type = CSVDiff
     input = periodic_integral.i
     csvdiff = periodic_integral_out.csv
-    requirement = "Integrate a postprocesssor over a period of time specified by a frequency"
-    design = 'PeriodicTimeIntegratedPostprocessor.md'
-    issues = '#222'
+    requirement = "Integrate a postprocesssor over a period of time specified by a frequency."
+  []
+  [errors]
+    requirement = "The system shall report a reasonable error when the user provides an invalid"
+    [invalid_cycle_frequency]
+      type = RunException
+      input = periodic_integral.i
+      cli_args = 'Postprocessors/periodic/cycle_frequency=0'
+      expect_err = 'Range check failed for parameter Postprocessors/periodic/cycle_frequency'
+      detail = 'cycle frequency.'
+    []
   []
 []


### PR DESCRIPTION
# Periodic Objects Fix 

As noted in #253 the periodic post processor objects initial implementation were fragile. While unable to replicate the results of these tests failing I have identified what I believe to be a potential issue in the initial design. In the initial design of these the value of the post processor was reset based on the difference between the the simulation time and the starting point of the next period being within the following criteria 

```c++
std::abs(_t - _next_period_start) <= _dt * 1e-3 
```

I think this criteria was the cause of the periodic test failures since it is not a very robust check. I have updated the criteria to have what I believe to be a more robust check in the form 

```c++ 
   (_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
```

This criteria maintains the same behavior as the initial implementation but has a tighter tolerance on the check and also uses a relative difference to help alleviate potential precision issues that the initial implementation likely suffered from. 

# Additional clean up 

I also took this opportunity to cleanup the tests of the post processors since all of the tests were named `receiver` for some reason, probably left over copy pasta, they were renamed to make more sense. Additionally, some of the parameters in the periodic objects were updated to be range checked to prevent misuse. 

