### PR TITLE
Changing types to help with comparison of counters

### DIFF
--- a/include/postprocessors/MultiPeriodAverager.h
+++ b/include/postprocessors/MultiPeriodAverager.h
@@ -36,9 +36,9 @@ protected:
   /// The previous post process value of the post processor we are averaging over several periods
   const PostprocessorValue & _pps_value_old;
   /// The number of periods that have passed
-  uint _period_count;
+  unsigned int _period_count;
   /// The counter for how many periods have passed since we last updated
-  uint _cyclic_period_count;
+  unsigned int _cyclic_period_count;
   /// the number of periods over which we are averaging
-  uint _num_periods;
+  unsigned int _num_periods;
 };

--- a/include/postprocessors/MultiPeriodAverager.h
+++ b/include/postprocessors/MultiPeriodAverager.h
@@ -29,16 +29,16 @@ protected:
   Real _value;
   /// Where we are going to be storing the next average while we calculate it
   Real _temp_value;
-  /// The number of periods that have passed
-  Real _period_count;
   /// The time when the next period starts
   Real _next_period_start;
-  /// The counter for how many periods have passed since we last updated
-  Real _cyclic_period_count;
   /// inverse of the frequency
   const Real _period;
-  /// the number of periods over which we are averaging
-  Real _num_periods;
   /// The previous post process value of the post processor we are averaging over several periods
   const PostprocessorValue & _pps_value_old;
+  /// The number of periods that have passed
+  uint _period_count;
+  /// The counter for how many periods have passed since we last updated
+  uint _cyclic_period_count;
+  /// the number of periods over which we are averaging
+  uint _num_periods;
 };

--- a/include/postprocessors/PeriodicTimeIntegratedPostprocessor.h
+++ b/include/postprocessors/PeriodicTimeIntegratedPostprocessor.h
@@ -25,7 +25,7 @@ protected:
   /// the period of time over which to integrate
   const Real _period;
   /// the total number of periods that have occured
-  uint _period_count;
+  unsigned int _period_count;
   /// the point in the time when the next period begins
   Real _next_period_start;
 };

--- a/include/postprocessors/PeriodicTimeIntegratedPostprocessor.h
+++ b/include/postprocessors/PeriodicTimeIntegratedPostprocessor.h
@@ -22,7 +22,10 @@ public:
   virtual void execute() override;
 
 protected:
+  /// the period of time over which to integrate
   const Real _period;
-  Real _period_count;
+  /// the total number of periods that have occured
+  uint _period_count;
+  /// the point in the time when the next period begins
   Real _next_period_start;
 };

--- a/src/postprocessors/MultiPeriodAverager.C
+++ b/src/postprocessors/MultiPeriodAverager.C
@@ -17,7 +17,7 @@ MultiPeriodAverager::validParams()
   InputParameters params = GeneralPostprocessor::validParams();
   params.addClassDescription(
       "Calculate the average value of a post processor over multiple periods");
-  params.addRangeCheckedParam<Real>("number_of_periods",
+  params.addRangeCheckedParam<uint>("number_of_periods",
                                     "number_of_periods > 0",
                                     "The number of periods over which you are averaging");
   params.addParam<PostprocessorName>(
@@ -33,10 +33,11 @@ MultiPeriodAverager::MultiPeriodAverager(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
     _value(0),
     _temp_value(0),
-    _period_count(0),
     _period(1.0 / getParam<Real>("cycle_frequency")),
-    _num_periods(getParam<Real>("number_of_periods")),
-    _pps_value_old(getPostprocessorValueOld("value"))
+    _pps_value_old(getPostprocessorValueOld("value")),
+    _period_count(0),
+    _cyclic_period_count(0),
+    _num_periods(getParam<uint>("number_of_periods"))
 {
   _next_period_start = _period;
 }
@@ -46,21 +47,21 @@ MultiPeriodAverager::execute()
 {
   // lets check if we will be reaching the next period on the next
   // time step
-  if ((_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
-  {
-    _period_count += 1;
-    _cyclic_period_count += 1;
-    _next_period_start = (_period_count + 1) * _period;
-    _temp_value += _pps_value_old / _num_periods;
+  if ((_t + _dt - _next_period_start) / _next_period_start < 1e-6)
+    return;
 
-    /// if its time to update the average reset the temporary values
-    if (_cyclic_period_count == _num_periods)
-    {
-      _value = _temp_value;
-      _cyclic_period_count = 0;
-      _temp_value = 0;
-    }
-  }
+  _period_count += 1;
+  _cyclic_period_count += 1;
+  _next_period_start = (_period_count + 1) * _period;
+  _temp_value += _pps_value_old / _num_periods;
+
+  /// if its time to update the average reset the temporary values
+  if (_cyclic_period_count != _num_periods)
+    return;
+
+  _value = _temp_value;
+  _cyclic_period_count = 0;
+  _temp_value = 0;
 }
 
 Real

--- a/src/postprocessors/MultiPeriodAverager.C
+++ b/src/postprocessors/MultiPeriodAverager.C
@@ -17,9 +17,9 @@ MultiPeriodAverager::validParams()
   InputParameters params = GeneralPostprocessor::validParams();
   params.addClassDescription(
       "Calculate the average value of a post processor over multiple periods");
-  params.addRangeCheckedParam<uint>("number_of_periods",
-                                    "number_of_periods > 0",
-                                    "The number of periods over which you are averaging");
+  params.addRangeCheckedParam<unsigned int>("number_of_periods",
+                                            "number_of_periods > 0",
+                                            "The number of periods over which you are averaging");
   params.addParam<PostprocessorName>(
       "value", "The name of the postprocessor you would like to average over multiple periods");
   params.addRequiredRangeCheckedParam<Real>(

--- a/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
+++ b/src/postprocessors/PeriodicTimeIntegratedPostprocessor.C
@@ -41,10 +41,10 @@ PeriodicTimeIntegratedPostprocessor::execute()
   MultipliedTimeIntegratedPostprocessor::execute();
   // lets check if we will be reaching the next period on the next
   // time step
-  if ((_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
-  {
-    _period_count++;
-    _next_period_start = (_period_count + 1) * _period;
-    this->_value = 0;
-  }
+  if ((_t + _dt - _next_period_start) / _next_period_start < 1e-6)
+    return;
+
+  _period_count++;
+  _next_period_start = (_period_count + 1) * _period;
+  this->_value = 0;
 }


### PR DESCRIPTION
Addresses #253

And I ran the test close to 1000 times on rod without a filature and a few hundred times on my Intel Desktop with no failure
However, after looking at the most recent  [failure for this test](https://civet.inl.gov/job/2369942/), for a while, I believe I have found a potential source for the intermittent failure.

In this failure we have the following result
```
Postprocessor Values:
test:postprocessors/multi_period_averaging.averaging: +----------------+----------------+----------------+----------------+
test:postprocessors/multi_period_averaging.averaging: | time           | a              | multi_period   | periodic       |
test:postprocessors/multi_period_averaging.averaging: +----------------+----------------+----------------+----------------+
test:postprocessors/multi_period_averaging.averaging: :                :                :                :                :
test:postprocessors/multi_period_averaging.averaging: |   1.400000e+01 |   9.332400e+00 |   0.000000e+00 |   3.199680e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.450000e+01 |   9.665700e+00 |   0.000000e+00 |   3.674632e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.500000e+01 |   9.999000e+00 |   0.000000e+00 |   4.166250e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.550000e+01 |   1.033230e+01 |   0.000000e+00 |   4.674532e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.600000e+01 |   1.066560e+01 |   0.000000e+00 |   5.199480e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.650000e+01 |   1.099890e+01 |   0.000000e+00 |   5.741092e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.700000e+01 |   1.133220e+01 |   0.000000e+00 |   6.299370e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.750000e+01 |   1.166550e+01 |   0.000000e+00 |   6.874312e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.800000e+01 |   1.199880e+01 |   0.000000e+00 |   7.465920e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.850000e+01 |   1.233210e+01 |   0.000000e+00 |   8.074192e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.900000e+01 |   1.266540e+01 |   0.000000e+00 |   8.699130e+01 |
test:postprocessors/multi_period_averaging.averaging: |   1.950000e+01 |   1.299870e+01 |   0.000000e+00 |   9.340733e+01 |
test:postprocessors/multi_period_averaging.averaging: |   2.000000e+01 |   1.333200e+01 |   0.000000e+00 |   0.000000e+00 |
test:postprocessors/multi_period_averaging.averaging: |   2.050000e+01 |   1.366530e+01 |   0.000000e+00 |   6.749325e+00 |
test:postprocessors/multi_period_averaging.averaging: |   2.100000e+01 |   1.399860e+01 |   0.000000e+00 |   1.366530e+01 |
test:postprocessors/multi_period_averaging.averaging: +----------------+----------------+----------------+----------------+
```

In this failure we can see that  `PeriodicTimeIntegratedPostprocessor`  is working properly but `MultiPeriodAverager`  is not, it never has a value other than 0 in the test. The previous PR to try to fix this addressed the check for if the next time step is when the next period starts

```c++
if ((_t + _dt - _next_period_start) / _next_period_start >= 1e-6)
```
However, `PeriodicTimeIntegratedPostprocessor` is fine and `MultiPeriodAverager` is not so this is likely not the source of the failure. But `MultiPeriodAverager` has another check that `PeriodicTimeIntegratedPostprocessor`  does not.
```c++
if (_cyclic_period_count == _num_periods)
{
   _value = _temp_value;
   _cyclic_period_count = 0;
   _temp_value = 0;
}
```
I believe that this could be the cause of this error. I wrote this object a while ago and was very sloppy in the type selection for the variables `_cyclic_period_count` and `_num_periods`. The counters in this object are `Real`s when really they should be `unsigned int`s. I believe that failure could be coming from the floating point comparison for equality here and that this second check is never satisfied on some machines while it is satisfied on most machines which is why I have not been able to replicate this error.