### PR TITLE
Updating Interface Kernels Documentation

### DIFF
--- a/doc/content/source/bcs/DielectricBCWithEffEfield.md
+++ b/doc/content/source/bcs/DielectricBCWithEffEfield.md
@@ -9,7 +9,7 @@
 The potential at the boundary of a grounded ideal dielectric is defined as
 
 \begin{equation}
-\epsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} - \frac{\epsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} = - e \left( \Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n} \right) \\[10pt]
+\varepsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} - \frac{\varepsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} = - e \left( \Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n} \right) \\[10pt]
 \Gamma_{e} \cdot \textbf{n}  = \frac{1}{4}\sqrt{\frac{8 k T_{e}}{\pi m_{e}}} \ n_e - \gamma \Gamma_{+} \cdot \textbf{n} \\[10pt]
 \Gamma_{+} \cdot \textbf{n}  = a \ \mu_{+} \ \vec{E}_{\text{Eff.}} \cdot \textbf{n} \ n_{+} \\[10pt]
 a =
@@ -19,16 +19,16 @@ a =
 \end{cases}
 \end{equation}
 
-where 
+where
 
-- $\epsilon_{i}$ is the permittivity of the dielectric,
+- $\varepsilon_{i}$ is the permittivity of the dielectric,
 - $d_{i}$ is the thickness of the dielectric,
 - $V_{i}$ is the voltage on the dielectric,
-- $\textbf{n}$ is the normal to the boundary, 
-- $e$ is the elemental charge, 
-- $\epsilon_{0}$ is the permittivity of free space,
-- $\vec{E} \cdot \textbf{n}$ is the electric field normal to the dielectric, 
-- $\Gamma_{e}$ is the electron outflow flux, and 
+- $\textbf{n}$ is the normal to the boundary,
+- $e$ is the elemental charge,
+- $\varepsilon_{0}$ is the permittivity of free space,
+- $\vec{E} \cdot \textbf{n}$ is the electric field normal to the dielectric,
+- $\Gamma_{e}$ is the electron outflow flux, and
 - $\Gamma_{+}$ is the ion outflow flux.
 
 !alert note title=Flux Information
@@ -37,13 +37,13 @@ $\Gamma_{e}$ and $\Gamma_{+}$ are defined with the [`SakiyamaElectronDiffusionBC
 To convert the above equation into the form of a NeumannBC, the time integral is taken such that:
 
 \begin{equation}
-\int{ \epsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} } dt - \int{ \frac{\epsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} } dt = \int{ - e \left( \Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n} \right) } dt
+\int{ \varepsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} } dt - \int{ \frac{\varepsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} } dt = \int{ - e \left( \Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n} \right) } dt
 \end{equation}
 
 Using the trapezoidal rule for the definite integral and rearranging the equation such that the electric field term is on one side results in:
 
 \begin{equation}
-\epsilon_{0} \left( E \cdot \textbf{n} \right) = \epsilon_{0} \left( E_{\text{old}} \cdot \textbf{n} \right) + \frac{\epsilon_{i}}{d_{i}} \left( V - V_
+\varepsilon_{0} \left( E \cdot \textbf{n} \right) = \varepsilon_{0} \left( E_{\text{old}} \cdot \textbf{n} \right) + \frac{\varepsilon_{i}}{d_{i}} \left( V - V_
 {old} \right) - 0.5 \left( e \left( \Gamma_{+} \cdot \textbf{n} - \Gamma_{e} \cdot \textbf{n} \right) + e \left( \Gamma_{+} \cdot \textbf{n} - \Gamma_{e} \cdot \textbf{n} \right)_{old} \right) dt
 \end{equation}
 
@@ -55,7 +55,7 @@ where
 Lastly, the electrostatic approximation is applied to the electric field normal to the dielectric, which results in a NeumannBC for the potential defined as:
 
 \begin{equation}
-\epsilon_{0} \left( -\nabla V \cdot \textbf{n} \right) = \epsilon_{0} \left( -\nabla V_{\text{old}} \cdot \textbf{n} \right) + \frac{\epsilon_{i}}{d_{i}} \left( V - V_
+\varepsilon_{0} \left( -\nabla V \cdot \textbf{n} \right) = \varepsilon_{0} \left( -\nabla V_{\text{old}} \cdot \textbf{n} \right) + \frac{\varepsilon_{i}}{d_{i}} \left( V - V_
 {old} \right) - 0.5 \left( e \left( \Gamma_{+} \cdot \textbf{n} - \Gamma_{e} \cdot \textbf{n} \right) + e \left( \Gamma_{+} \cdot \textbf{n} - \Gamma_{e} \cdot \textbf{n} \right)_{old} \right) dt
 \end{equation}
 

--- a/doc/content/source/bcs/EconomouDielectricBC.md
+++ b/doc/content/source/bcs/EconomouDielectricBC.md
@@ -9,7 +9,7 @@
 The potential at the boundary of a grounded ideal dielectric is defined as
 
 \begin{equation}
-\frac{\epsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} = e(\Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n})+\epsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} \\[10pt]
+\frac{\varepsilon_{i}}{d_{i}}\frac{\partial V_{i}}{\partial t} = e(\Gamma_{+} \cdot \textbf{n} -\Gamma_{e} \cdot \textbf{n})+\varepsilon_{0}\frac{\partial (E \cdot \textbf{n}) }{\partial t} \\[10pt]
 E = \text{-} \nabla (V)\\[10pt]
 \Gamma_{e} \cdot \textbf{n}  = \frac{1}{4}\sqrt{\frac{8 k T_{e}}{\pi m_{e}}} \ n_e - \gamma \Gamma_{+} \cdot \textbf{n} \\[10pt]
 \Gamma_{+} \cdot \textbf{n}  = a \ \mu_{+} \ \text{-} \nabla (V) \cdot \textbf{n} \ n_{+} \\[10pt]
@@ -20,7 +20,7 @@ a =
 \end{cases}
 \end{equation}
 
-Where $\epsilon_{i}$ is the permittivity of the dielectric, $d_{i}$ is the thickness of the dielectric, $V_{i}$ is the voltage on the dielectric, $\textbf{n}$ is the normal to the boundary, $e$ is the elemental charge, $\epsilon_{0}$ is the permittivity of free space, and $E$ is the E-field normal to the dielectric. $\Gamma_{e}$ and $\Gamma_{+}$ are the electron and ion outflow flux and are defined with the [`SakiyamaElectronDiffusionBC`](/bcs/SakiyamaElectronDiffusionBC.md), [`SakiyamaSecondaryElectronBC`](/bcs/SakiyamaSecondaryElectronBC.md) and [`SakiyamaIonAdvectionBC`](/bcs/SakiyamaIonAdvectionBC.md) (please refer to those BC's for more information on the fluxes).
+Where $\varepsilon_{i}$ is the permittivity of the dielectric, $d_{i}$ is the thickness of the dielectric, $V_{i}$ is the voltage on the dielectric, $\textbf{n}$ is the normal to the boundary, $e$ is the elemental charge, $\varepsilon_{0}$ is the permittivity of free space, and $E$ is the E-field normal to the dielectric. $\Gamma_{e}$ and $\Gamma_{+}$ are the electron and ion outflow flux and are defined with the [`SakiyamaElectronDiffusionBC`](/bcs/SakiyamaElectronDiffusionBC.md), [`SakiyamaSecondaryElectronBC`](/bcs/SakiyamaSecondaryElectronBC.md) and [`SakiyamaIonAdvectionBC`](/bcs/SakiyamaIonAdvectionBC.md) (please refer to those BC's for more information on the fluxes).
 
 ## Example Input File Syntax
 

--- a/doc/content/source/bcs/SchottkyEmissionBC.md
+++ b/doc/content/source/bcs/SchottkyEmissionBC.md
@@ -16,7 +16,7 @@ a_{e} =
 \end{cases} \\[10pt]
 \textbf{J}_{\textbf{e}} \cdot \textbf{n} = A_{G} T^{2} \exp\left( \frac{\text{-} \left( \phi - \Delta \phi \right) }{ k_{B} T} \right) \\[10pt]
 F =  \left( 1-a_{e} \right) \gamma \left( \text{-} \nabla V \right) \cdot \textbf{n} \\[10pt]
-\Delta \phi = \sqrt{\frac{e^{3} F}{4 \pi \epsilon_{0}}} 
+\Delta \phi = \sqrt{\frac{e^{3} F}{4 \pi \varepsilon_{0}}}
 \end{equation}
 
 Where $\textbf{J}_{\textbf{e}}$ is the electron current density, $A_{G}$ is the Richardson coefficient, $T$ is the temperature of the cathode, $k_{B}$ is Boltzmann constant in units of eV/K, $\phi$ is the local work function, $\Delta \phi$ is the difference in the work funtion due to the electric field, $F$ is the local field, $\textbf{n}$ is the normal vector of the boundary, $\gamma$ is the field enhancement factor, and $V$ is the potential. $a_{e}$ is defined such that the outflow is only defined when the drift velocity is directed towards the wall and zero otherwise. With the electron current density, the outward electron flux is defined as

--- a/doc/content/source/bcs/TM0AntennaVertBC.md
+++ b/doc/content/source/bcs/TM0AntennaVertBC.md
@@ -9,13 +9,13 @@
 The boundary condition of the azimuthal component of the magnetizing field normal to the antenna surface is
 
 \begin{equation}
-  \textbf{n} \times \left( \nabla \times \textbf{H} \right) = j \omega \epsilon \textbf{E}
+  \textbf{n} \times \left( \nabla \times \textbf{H} \right) = j \omega \varepsilon \textbf{E}
 \end{equation}
 
-Where $\textbf{H}$ is the magnetizing field, $\textbf{n}$ is the normal vector of the boundary, $\epsilon$ is the material permittivity, $\omega$ is the drive frequency of the system, $\textbf{E}$ is the electric field, and $j = \sqrt{-1}$. By assuming the normal of azimuthal component of the magnetizing field to the surface is purely in the axial direction and an incoming electric field of unity (such that $\textbf{E} = (1 - j)$), the integrated boundary condition simplifies to
+Where $\textbf{H}$ is the magnetizing field, $\textbf{n}$ is the normal vector of the boundary, $\varepsilon$ is the material permittivity, $\omega$ is the drive frequency of the system, $\textbf{E}$ is the electric field, and $j = \sqrt{-1}$. By assuming the normal of azimuthal component of the magnetizing field to the surface is purely in the axial direction and an incoming electric field of unity (such that $\textbf{E} = (1 - j)$), the integrated boundary condition simplifies to
 
 \begin{equation}
-  \nabla \text{H}_{\theta} \cdot \textbf{n} = \frac{\text{-} \text{H}_{\theta}}{r} + \omega \epsilon
+  \nabla \text{H}_{\theta} \cdot \textbf{n} = \frac{\text{-} \text{H}_{\theta}}{r} + \omega \varepsilon
 \end{equation}
 
 Where $H_{\phi}$ is the azimuthal component of the magnetizing field and $r$ is the radial distance from the axial centerline.

--- a/doc/content/source/interfacekernels/HphiRadialInterface.md
+++ b/doc/content/source/interfacekernels/HphiRadialInterface.md
@@ -1,20 +1,59 @@
 # HphiRadialInterface
 
-!alert construction title=Undocumented Class
-The HphiRadialInterface has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /InterfaceKernels/HphiRadialInterface
 
 ## Overview
 
-!! Replace these lines with information regarding the HphiRadialInterface object.
+`HphiRadialInterface` enforces the axial electric field at an interface to be continuous, assuming an axisymmetric geometry. This is done by using Ampère–Maxwell law to relate the azmithal magnetic flux to the axial electric field.
+
+Assuming negligible current density when compared to the displacement current, Ampère–Maxwell law in the frequency domain is defined as:
+
+\begin{equation}
+  \nabla \times \textbf{H} = \epsilon \omega \textbf{E}
+\end{equation}
+
+Where:
+
+- $\textbf{H}$ is the magnetizing field,
+- $\epsilon$ is the material permittivity,
+- $\omega$ is the frequency, and
+- $\textbf{E}$ is the electric field.
+
+By assuming an axisymmetric cylindrical geometry, this equation simplifies to:
+
+\begin{equation}
+  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \epsilon \omega \text{E}_{z}
+\end{equation}
+
+Where:
+
+- $H_{\phi}$ is the azimuthal component of the magnetizing field,
+- $\text{E}_{z}$ is the axial component of the electric field, and
+- $r$ is the radial distance from the axial centerline.
+
+To enforces that $\text{E}_{z}$ is continuous at an interface, where $\omega$ is the same on both side of the boundary, the following expression can be derived:
+
+\begin{equation}
+  \text{E} _{z1} = \text{E} _{z2}
+\end{equation}
+\begin{equation}
+  \frac{1}{\epsilon_{1}} \left( \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 1}}{r} \right) = \frac{1}{\epsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right)
+\end{equation}
+\begin{equation}
+  \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} = \frac{\epsilon_{1}}{\epsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right) - \frac{H_{\phi 1}}{r}
+\end{equation}
+
+Where:
+
+- Subscript $1$ is the the primary side of the interface,
+- Subscript $2$ is the the neighboring side of the interface, and
+- $\textbf{n}$ is the normal vector of the interface.
+
+The expression is equated to the gradient of $H_{\phi 1}$ because MOOSE's interface kernels provide general flux condition at an interface. For more information, please see the [InterfaceKernels System page](syntax/InterfaceKernels/index.md).
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the HphiRadialInterface object.
+!listing test/tests/TM10_circular_wg/TM_steady_dieletric.i block=InterfaceKernels/Ez_continuous
 
 !syntax parameters /InterfaceKernels/HphiRadialInterface
 

--- a/doc/content/source/interfacekernels/HphiRadialInterface.md
+++ b/doc/content/source/interfacekernels/HphiRadialInterface.md
@@ -4,25 +4,25 @@
 
 ## Overview
 
-`HphiRadialInterface` enforces the axial electric field at an interface to be continuous, assuming an axisymmetric geometry. This is done by using Ampère–Maxwell law to relate the azmithal magnetic flux to the axial electric field.
+`HphiRadialInterface` enforces the axial electric field at an interface to be continuous, assuming an axisymmetric geometry. This is done by using Ampère–Maxwell law to relate the azimuthal magnetic flux to the axial electric field.
 
 Assuming negligible current density when compared to the displacement current, Ampère–Maxwell law in the frequency domain is defined as:
 
 \begin{equation}
-  \nabla \times \textbf{H} = \epsilon \omega \textbf{E}
+  \nabla \times \textbf{H} = \varepsilon \omega \textbf{E}
 \end{equation}
 
 Where:
 
 - $\textbf{H}$ is the magnetizing field,
-- $\epsilon$ is the material permittivity,
+- $\varepsilon$ is the material permittivity,
 - $\omega$ is the frequency, and
 - $\textbf{E}$ is the electric field.
 
 By assuming an axisymmetric cylindrical geometry, this equation simplifies to:
 
 \begin{equation}
-  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \epsilon \omega \text{E}_{z}
+  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \varepsilon \omega \text{E}_{z}
 \end{equation}
 
 Where:
@@ -31,16 +31,16 @@ Where:
 - $\text{E}_{z}$ is the axial component of the electric field, and
 - $r$ is the radial distance from the axial centerline.
 
-To enforces that $\text{E}_{z}$ is continuous at an interface, where $\omega$ is the same on both side of the boundary, the following expression can be derived:
+To enforce that $\text{E}_{z}$ is continuous at an interface, where $\omega$ is the same on both side of the boundary, the following expression can be derived:
 
 \begin{equation}
   \text{E} _{z1} = \text{E} _{z2}
 \end{equation}
 \begin{equation}
-  \frac{1}{\epsilon_{1}} \left( \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 1}}{r} \right) = \frac{1}{\epsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right)
+  \frac{1}{\varepsilon_{1}} \left( \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 1}}{r} \right) = \frac{1}{\varepsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right)
 \end{equation}
 \begin{equation}
-  \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} = \frac{\epsilon_{1}}{\epsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right) - \frac{H_{\phi 1}}{r}
+  \frac{\partial H_{\phi 1}}{\partial r} \cdot \textbf{n} = \frac{\varepsilon_{1}}{\varepsilon_{2}} \left( \frac{\partial H_{\phi 2}}{\partial r} \cdot \textbf{n} + \frac{H_{\phi 2}}{r} \right) - \frac{H_{\phi 1}}{r}
 \end{equation}
 
 Where:

--- a/doc/content/source/interfacekernels/InterfaceAdvection.md
+++ b/doc/content/source/interfacekernels/InterfaceAdvection.md
@@ -9,7 +9,7 @@
 This advection term at the interface is defined as
 
 \begin{equation}
-\Gamma_{\text{adv}1} \cdot \textbf{n} = \text{sign}_{j2} \mu_{j2} n_{j2} \ \vec{E}_{2} \cdot \textbf{n}
+\Gamma_{\text{adv},1} \cdot \textbf{n} = \text{sign}_{j,2} \mu_{j,2} n_{j,2} \ \vec{E}_{2} \cdot \textbf{n}
 \end{equation}
 
 Where:
@@ -27,7 +27,7 @@ When converting the density to logarithmic form and applying a scaling
 factor of the mesh, `InterfaceAdvection` is defined as
 
 \begin{equation}
-\Gamma_{\text{adv1}} \cdot \textbf{n} = \text{sign}_{j2} \mu_{j2} \exp(N_{j2}) \ (\vec{E}_{2} / l_{c}) \cdot \textbf{n}
+\Gamma_{\text{adv}, 1} \cdot \textbf{n} = \text{sign}_{j,2} \mu_{j,2} \exp \left( N_{j,2} \right) \ \left( \vec{E}_{2} / l_{c} \right) \cdot \textbf{n}
 \end{equation}
 
 Where:

--- a/doc/content/source/interfacekernels/InterfaceAdvection.md
+++ b/doc/content/source/interfacekernels/InterfaceAdvection.md
@@ -1,20 +1,44 @@
 # InterfaceAdvection
 
-!alert construction title=Undocumented Class
-The InterfaceAdvection has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /InterfaceKernels/InterfaceAdvection
 
 ## Overview
 
-!! Replace these lines with information regarding the InterfaceAdvection object.
+`InterfaceAdvection` is used to defined the advection flux on one side of an interface to a species' electric field driven advective flux on the other side of the interface.
+
+This advection term at the interface is defined as
+
+\begin{equation}
+\Gamma_{\text{adv}1} \cdot \textbf{n} = \text{sign}_{j2} \mu_{j2} n_{j2} \ \vec{E}_{2} \cdot \textbf{n}
+\end{equation}
+
+Where:
+
+- Subscript $1$ is the the primary side of the interface,
+- Subscript $2$ is the the neighboring side of the interface,
+- $\textbf{n}$ is the normal vector of the interface,
+- $\Gamma_{\text{adv}}$ is the advection component of a species' flux,
+- $\text{sign}_{j}$ indicates the advection behavior ($\text{+}1$ for positively charged species and $\text{-}1$ for negatively charged species),
+- $\mu_{j}$ is the mobility coefficient,
+- $n_{j}$ is the density, and
+- $\vec{E}$ is the electric field.
+
+When converting the density to logarithmic form and applying a scaling
+factor of the mesh, `InterfaceAdvection` is defined as
+
+\begin{equation}
+\Gamma_{\text{adv1}} \cdot \textbf{n} = \text{sign}_{j2} \mu_{j2} \exp(N_{j2}) \ (\vec{E}_{2} / l_{c}) \cdot \textbf{n}
+\end{equation}
+
+Where:
+
+- $N_{j}$ is the molar density of the species in logarithmic form and
+- $l_{c}$ is the scaling factor of the mesh.
+
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the InterfaceAdvection object.
+!listing test/tests/1d_dc/mean_en.i block=InterfaceKernels/em_advection
 
 !syntax parameters /InterfaceKernels/InterfaceAdvection
 

--- a/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
+++ b/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
@@ -1,20 +1,40 @@
 # InterfaceLogDiffusionElectrons
 
-!alert construction title=Undocumented Class
-The InterfaceLogDiffusionElectrons has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /InterfaceKernels/InterfaceLogDiffusionElectrons
 
 ## Overview
 
-!! Replace these lines with information regarding the InterfaceLogDiffusionElectrons object.
+`InterfaceLogDiffusionElectrons` is used to defined the diffusion flux on one side of an interface to the electron diffusion flux on the other side of the interface.
+
+This diffusion term at the interface is defined as
+
+\begin{equation}
+\Gamma_{\text{\text{diff}}1} \cdot \textbf{n} = -D_{e2} \nabla (n_{e2}) \cdot \textbf{n}
+\end{equation}
+
+Where:
+
+- Subscript $1$ is the the primary side of the interface,
+- Subscript $2$ is the the neighboring side of the interface,
+- $\textbf{n}$ is the normal vector of the interface,
+- $\Gamma_{\text{\text{diff}}}$ is the diffusion component of a species' flux,
+- $D_{e}$ is the electron diffusion coefficient, and
+- $n_{e}$ is the electron density.
+
+When converting the density to logarithmic form and applying a scaling factor of the mesh, the strong form for `InterfaceLogDiffusionElectrons` is defined as
+
+\begin{equation}
+\Gamma_{\text{\text{diff}}1} \cdot \textbf{n} = -D_{e2} \exp(N_{e2}) \nabla (N_{e2} / l_{c}) \cdot \textbf{n}
+\end{equation}
+
+Where:
+
+- $N_{e}$ is the molar density of the electrons in logarithmic form, and
+- $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the InterfaceLogDiffusionElectrons object.
+!listing test/tests/1d_dc/mean_en.i block=InterfaceKernels/em_diffusion
 
 !syntax parameters /InterfaceKernels/InterfaceLogDiffusionElectrons
 

--- a/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
+++ b/doc/content/source/interfacekernels/InterfaceLogDiffusionElectrons.md
@@ -9,7 +9,7 @@
 This diffusion term at the interface is defined as
 
 \begin{equation}
-\Gamma_{\text{\text{diff}}1} \cdot \textbf{n} = -D_{e2} \nabla (n_{e2}) \cdot \textbf{n}
+\Gamma_{\text{diff}, 1} \cdot \textbf{n} = -D_{e,2} \nabla \left( n_{e,2} \right) \cdot \textbf{n}
 \end{equation}
 
 Where:
@@ -17,14 +17,14 @@ Where:
 - Subscript $1$ is the the primary side of the interface,
 - Subscript $2$ is the the neighboring side of the interface,
 - $\textbf{n}$ is the normal vector of the interface,
-- $\Gamma_{\text{\text{diff}}}$ is the diffusion component of a species' flux,
+- $\Gamma_{\text{diff}}$ is the diffusion component of a species' flux,
 - $D_{e}$ is the electron diffusion coefficient, and
 - $n_{e}$ is the electron density.
 
 When converting the density to logarithmic form and applying a scaling factor of the mesh, the strong form for `InterfaceLogDiffusionElectrons` is defined as
 
 \begin{equation}
-\Gamma_{\text{\text{diff}}1} \cdot \textbf{n} = -D_{e2} \exp(N_{e2}) \nabla (N_{e2} / l_{c}) \cdot \textbf{n}
+\Gamma_{\text{diff}, 1} \cdot \textbf{n} = -D_{e2} \exp(N_{e,2}) \nabla (N_{e,2} / l_{c}) \cdot \textbf{n}
 \end{equation}
 
 Where:

--- a/doc/content/source/interfacekernels/PotentialSurfaceCharge.md
+++ b/doc/content/source/interfacekernels/PotentialSurfaceCharge.md
@@ -1,20 +1,39 @@
 # PotentialSurfaceCharge
 
-!alert construction title=Undocumented Class
-The PotentialSurfaceCharge has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /InterfaceKernels/PotentialSurfaceCharge
 
 ## Overview
 
-!! Replace these lines with information regarding the PotentialSurfaceCharge object.
+`PotentialSurfaceCharge` enforces the dielectric boundary condition at an interface by equating the difference in the electric field at an interface to a surface charge. To supply the surface charge, the [ADSurfaceCharge.md] object is often used.
+
+The dielectric boundary condition is defined as
+
+\begin{equation}
+\left( \epsilon_{1} \vec{E}_{1} - \epsilon_{2} \vec{E}_{2} \right) \cdot \textbf{n} = \sigma
+\end{equation}
+
+Where:
+
+- Subscript $1$ is the the primary side of the interface,
+- Subscript $2$ is the the neighboring side of the interface,
+- $\textbf{n}$ is the normal vector of the interface,
+- $\vec{E}$ is the electric field, and
+- $\sigma$ is the surface charge.
+
+`PotentialSurfaceCharge` assumes the electrostatic approximation (i.e., $\vec{E} = -\nabla V$). When converting to the electrostatic potential and applying a scaling factor of the mesh, `PotentialSurfaceCharge` is defined as
+
+\begin{equation}
+\left( \epsilon_{2} \left( \nabla V_{2} / l_{c2} \right) -  \epsilon_{1} \nabla \left( V_{1} / l_{c1} \right) \right) \cdot \textbf{n} = \sigma
+\end{equation}
+
+Where:
+
+- $V$ is the electrostatic potential, and
+- $l_{c}$ is the scaling factor of the mesh.
 
 ## Example Input File Syntax
 
-!! Describe and include an example of how to use the PotentialSurfaceCharge object.
+!listing test/tests/surface_charge/dbd_test.i block=InterfaceKernels/potential_right
 
 !syntax parameters /InterfaceKernels/PotentialSurfaceCharge
 

--- a/doc/content/source/interfacekernels/PotentialSurfaceCharge.md
+++ b/doc/content/source/interfacekernels/PotentialSurfaceCharge.md
@@ -9,7 +9,7 @@
 The dielectric boundary condition is defined as
 
 \begin{equation}
-\left( \epsilon_{1} \vec{E}_{1} - \epsilon_{2} \vec{E}_{2} \right) \cdot \textbf{n} = \sigma
+\left( \varepsilon_{1} \vec{E}_{1} - \varepsilon_{2} \vec{E}_{2} \right) \cdot \textbf{n} = \sigma
 \end{equation}
 
 Where:
@@ -23,7 +23,7 @@ Where:
 `PotentialSurfaceCharge` assumes the electrostatic approximation (i.e., $\vec{E} = -\nabla V$). When converting to the electrostatic potential and applying a scaling factor of the mesh, `PotentialSurfaceCharge` is defined as
 
 \begin{equation}
-\left( \epsilon_{2} \left( \nabla V_{2} / l_{c2} \right) -  \epsilon_{1} \nabla \left( V_{1} / l_{c1} \right) \right) \cdot \textbf{n} = \sigma
+\left( \varepsilon_{2} \left( \nabla V_{2} / l_{c,2} \right) -  \varepsilon_{1} \nabla \left( V_{1} / l_{c,1} \right) \right) \cdot \textbf{n} = \sigma
 \end{equation}
 
 Where:

--- a/doc/content/source/kernels/TM0Cylindrical.md
+++ b/doc/content/source/kernels/TM0Cylindrical.md
@@ -9,13 +9,13 @@
 The wave equation for the H-field is defined as
 
 \begin{equation}
-  \nabla \times \nabla \times \textbf{H} = \text{-} \epsilon \mu_{0} \omega^{2} \textbf{H}
+  \nabla \times \nabla \times \textbf{H} = \text{-} \varepsilon \mu_{0} \omega^{2} \textbf{H}
 \end{equation}
 
-Where $\textbf{H}$ is the magnetizing field, $\epsilon$ is the material permittivity, $\mu_{0}$ is the permeability of free space, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
+Where $\textbf{H}$ is the magnetizing field, $\varepsilon$ is the material permittivity, $\mu_{0}$ is the permeability of free space, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
 
 \begin{equation}
-  \nabla^2 \text{H}_{\theta} - \frac{\text{H}_{\theta}}{r^2} = \text{-} \epsilon \mu_{0} \omega^{2} \text{H}_{\theta}
+  \nabla^2 \text{H}_{\theta} - \frac{\text{H}_{\theta}}{r^2} = \text{-} \varepsilon \mu_{0} \omega^{2} \text{H}_{\theta}
 \end{equation}
 
 Where $H_{\phi}$ is the azimuthal component of the magnetizing field and $r$ is the radial distance from the axial centerline.

--- a/doc/content/source/kernels/TM0CylindricalEr.md
+++ b/doc/content/source/kernels/TM0CylindricalEr.md
@@ -9,13 +9,13 @@
 The wave equation for the electric field is defined as
 
 \begin{equation}
-  \nabla \times \textbf{H} = \epsilon \omega \textbf{E}
+  \nabla \times \textbf{H} = \varepsilon \omega \textbf{E}
 \end{equation}
 
-Where $\textbf{H}$ is the magnetizing field, $\epsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
+Where $\textbf{H}$ is the magnetizing field, $\varepsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
 
 \begin{equation}
-  \text{-} \frac{\partial H_{\phi}}{\partial z} = \epsilon \omega \text{E}_{r}
+  \text{-} \frac{\partial H_{\phi}}{\partial z} = \varepsilon \omega \text{E}_{r}
 \end{equation}
 
 Where $H_{\phi}$ is the azimuthal component of the magnetizing field and $\text{E}_{r}$ is the radial component of the electric field.

--- a/doc/content/source/kernels/TM0CylindricalEz.md
+++ b/doc/content/source/kernels/TM0CylindricalEz.md
@@ -15,7 +15,7 @@ The wave equation for the electric field is defined as
 Where $\textbf{H}$ is the magnetizing field, $\epsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
 
 \begin{equation}
-  \frac{\partial H_{\phi}}{\partial r} -\frac{H_{\phi}}{r}  = \epsilon \omega \text{E}_{z}
+  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \epsilon \omega \text{E}_{z}
 \end{equation}
 
 Where $H_{\phi}$ is the azimuthal component of the magnetizing field, $\text{E}_{z}$ is the axial component of the electric field, and $r$ is the radial distance from the axial centerline.

--- a/doc/content/source/kernels/TM0CylindricalEz.md
+++ b/doc/content/source/kernels/TM0CylindricalEz.md
@@ -15,7 +15,7 @@ The wave equation for the electric field is defined as
 Where $\textbf{H}$ is the magnetizing field, $\epsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
 
 \begin{equation}
-  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \epsilon \omega \text{E}_{z}
+  \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \varepsilon \omega \text{E}_{z}
 \end{equation}
 
 Where $H_{\phi}$ is the azimuthal component of the magnetizing field, $\text{E}_{z}$ is the axial component of the electric field, and $r$ is the radial distance from the axial centerline.

--- a/doc/content/source/kernels/TM0CylindricalEz.md
+++ b/doc/content/source/kernels/TM0CylindricalEz.md
@@ -9,10 +9,10 @@
 The wave equation for the electric field is defined as
 
 \begin{equation}
-  \nabla \times \textbf{H} = \epsilon \omega \textbf{E}
+  \nabla \times \textbf{H} = \varepsilon \omega \textbf{E}
 \end{equation}
 
-Where $\textbf{H}$ is the magnetizing field, $\epsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
+Where $\textbf{H}$ is the magnetizing field, $\varepsilon$ is the material permittivity, $\textbf{E}$ is the electric field, and $\omega$ is the frequency. By assuming an axisymmetric cylindrical geometry, the wave equation simplifies to
 
 \begin{equation}
   \frac{\partial H_{\phi}}{\partial r} + \frac{H_{\phi}}{r}  = \varepsilon \omega \text{E}_{z}

--- a/src/interfacekernels/PotentialSurfaceCharge.C
+++ b/src/interfacekernels/PotentialSurfaceCharge.C
@@ -18,6 +18,9 @@ PotentialSurfaceCharge::validParams()
   InputParameters params = ADInterfaceKernel::validParams();
   params.addParam<Real>("position_units", 1.0, "The units of position.");
   params.addParam<Real>("neighbor_position_units", 1.0, "The units of position.");
+  params.addClassDescription(
+      "Enforces the dielectric boundary condition on a potential variable at an interface, "
+      "where the surface charge is provided as an ADMaterialProperty.");
   return params;
 }
 


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
Updating Zapdos's interface kernel objects documentation. This PR contributes to the goal of Zapdos following MOOSE's software quality assurance (SQA), refs #260 

## Design
Include missing information from Zapdos's interface kernels objects documentation.

This PR also fixes a minor sign error in the `TM0CylindricalEz` documentation.

## Impact
This is necessary for Zapdos to be SQA compliant.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
