### PR TITLE
Improving Consistency of Input Nomenclature for Postprocessers Objects.

### DIFF
--- a/src/postprocessors/SideCurrent.C
+++ b/src/postprocessors/SideCurrent.C
@@ -27,8 +27,6 @@ SideCurrent::validParams()
       "The name of the mobility material property that will be used in the flux computation.");
   params.addRequiredParam<Real>("r", "The reflection coefficient");
   params.addRequiredParam<Real>("position_units", "Units of position.");
-  params.addRequiredCoupledVar("mean_en", "Electron energy.");
-  params.deprecateParam("mean_en", "electron_energy", "04/01/2026");
   params.addRequiredCoupledVar("electron_energy", "The mean electron energy density in log form.");
   params.addRequiredCoupledVar("ions", "A list of ion densities in log form.");
   params.addClassDescription("Computes a side integral of current density");


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

This PR focuses on unifying the wording of the input parameters for the Postprocesser objects in Zapdos.

This is in a series of PRs that address the inconsistency of Zapdos input parameter nomenclature, as outline in Issues #223 and #214.

## Design
<!--A concise description (design) of the enhancement.-->

Changes of several input parameter names and descriptions were made to the Postprocesser objects. A deprecation plan was put in place that will permanently remove the previous nomenclature after `04/01/2026`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

This changes will improve the language of Zapdos objects to be more consistent.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
