### PR TITLE
Editing Deprecated Output Parameter 'interval' to 'time_step_interval'.

### DIFF
--- a/test/tests/mms/bcs/1D_LymberopoulosElectronBC.i
+++ b/test/tests/mms/bcs/1D_LymberopoulosElectronBC.i
@@ -25,7 +25,7 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []
 

--- a/test/tests/mms/bcs/1D_LymberopoulosIonBC.i
+++ b/test/tests/mms/bcs/1D_LymberopoulosIonBC.i
@@ -25,7 +25,7 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []
 

--- a/test/tests/mms/bcs/2D_DielectricBCWithEffEfield.i
+++ b/test/tests/mms/bcs/2D_DielectricBCWithEffEfield.i
@@ -567,6 +567,6 @@
 [Outputs]
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_ElectronBC.i
+++ b/test/tests/mms/bcs/2D_ElectronBC.i
@@ -630,6 +630,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_ElectronBC_NegivateOutWardFacingEfield.i
+++ b/test/tests/mms/bcs/2D_ElectronBC_NegivateOutWardFacingEfield.i
@@ -641,6 +641,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_EnergyBC.i
+++ b/test/tests/mms/bcs/2D_EnergyBC.i
@@ -627,6 +627,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_EnergyBC_NegivateOutWardFacingEfield.i
+++ b/test/tests/mms/bcs/2D_EnergyBC_NegivateOutWardFacingEfield.i
@@ -632,6 +632,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_IonBC.i
+++ b/test/tests/mms/bcs/2D_IonBC.i
@@ -350,6 +350,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/bcs/2D_IonBC_NegivateOutWardFacingEfield.i
+++ b/test/tests/mms/bcs/2D_IonBC_NegivateOutWardFacingEfield.i
@@ -346,6 +346,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions.i
+++ b/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions.i
@@ -335,6 +335,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy.i
+++ b/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy.i
@@ -514,6 +514,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy_Einstein_Relation.i
+++ b/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy_Einstein_Relation.i
@@ -524,6 +524,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy_Einstein_Relation_EffEfield.i
+++ b/test/tests/mms/continuity_equations/2D_Coupling_Electons_Potential_Ions_MeanEnergy_Einstein_Relation_EffEfield.i
@@ -608,6 +608,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Single_Fluid_Diffusion.i
+++ b/test/tests/mms/continuity_equations/2D_Single_Fluid_Diffusion.i
@@ -179,6 +179,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/continuity_equations/2D_Single_Fluid_Diffusion_Advection.i
+++ b/test/tests/mms/continuity_equations/2D_Single_Fluid_Diffusion_Advection.i
@@ -209,6 +209,6 @@
   perf_graph = true
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []

--- a/test/tests/mms/materials/2D_PlasmaDielectricConstant.i
+++ b/test/tests/mms/materials/2D_PlasmaDielectricConstant.i
@@ -390,6 +390,6 @@
 [Outputs]
   [out]
     type = Exodus
-    interval = 10
+    time_step_interval = 10
   []
 []


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

Due to a recent MOOSE PR merger, [PR #31426](https://github.com/idaholab/moose/pull/31426), the Output object parameter `interval` is no longer available. This PR edits the parameter in Zapdos input file to current parameter of `time_step_interval` This closes Issue #306 

## Design
<!--A concise description (design) of the enhancement.-->

Edit input files that used `Output/interval` to `Output/time_step_interval`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
This will allow Zapdos to pass current CIVET testing.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
