### PR TITLE
Editing Deprecated Parameters in 2D_DielectricBCWithEffEfield Testing

### DIFF
--- a/test/tests/mms/bcs/2D_DielectricBCWithEffEfield.i
+++ b/test/tests/mms/bcs/2D_DielectricBCWithEffEfield.i
@@ -104,7 +104,7 @@
   []
   [EffEfield_X_diffusion]
     type = MatDiffusion
-    D_name = diffEx
+    diffusivity = diffEx
     variable = Ex
   []
   [EffEfield_X_source]
@@ -118,7 +118,7 @@
   []
   [EffEfield_Y_diffusion]
     type = MatDiffusion
-    D_name = diffEy
+    diffusivity = diffEy
     variable = Ey
   []
   [EffEfield_Y_source]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
As mentioned in Issue #312, the current MOOSE submodule of Zapdos cases the test `2D_DielectricBCWithEffEfield` to fail.  This is due to a deprecated parameter for the `MatDiffusion` Kernel object.

## Design
<!--A concise description (design) of the enhancement.-->
Update input file to use the current parameters for the `MatDiffusion` Kernel object.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Fixes Zapdos testing and closes #312


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
