### PR TITLE
Updating Dependabot to Add Refs to GitHub Actions Commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
     schedule:
       interval: "monthly"
     directory: "/"
+    commit-message:
+      # Prefix all commit messages with "[refs #0] " to satisfy CIVET ticket requirement
+      prefix: "[refs #0] "


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Actions updates by dependabot currently fail CIVET pre-checks. This PR addresses that by editing dependabot to add reference messages to Github Actions commits and closes Issue #322 

## Design
<!--A concise description (design) of the enhancement.-->
Dependabot will add the message `[refs #0] ` to actions updates, the same as it already does for submodule updates.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Actions updates by dependabot will pass CIVET ticket requirement.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
